### PR TITLE
Verify: Tighten header length check in verify_header()

### DIFF
--- a/verify.c
+++ b/verify.c
@@ -720,7 +720,7 @@ static int verify_header(struct io_u *io_u, struct verify_header *hdr,
 			hdr->magic, FIO_HDR_MAGIC);
 		goto err;
 	}
-	if (hdr->len > io_u->buflen) {
+	if (hdr->len != hdr_len) {
 		log_err("verify: bad header length %u, wanted %u",
 			hdr->len, hdr_len);
 		goto err;


### PR DESCRIPTION
Fix-up to commit 5964842c: Tighten the header length check as well, don't only
change the message.
