### PR TITLE
fix re-open failure issue when using gluster ioengine

### DIFF
--- a/engines/glusterfs.c
+++ b/engines/glusterfs.c
@@ -260,7 +260,7 @@ int fio_gf_open_file(struct thread_data *td, struct fio_file *f)
 	dprint(FD_FILE, "fio %p created %s\n", g->fs, f->file_name);
 	f->fd = -1;
 	f->shadow_fd = -1;
-
+	td->o.open_files ++;
 	return ret;
 }
 

--- a/examples/gfapi.fio
+++ b/examples/gfapi.fio
@@ -1,0 +1,16 @@
+# Test opening a file from multiple jobs.
+# Originally authored by Castor Fu
+[global]
+ioengine=gfapi
+volume=vol
+brick=localhost
+create_on_open=1
+rw=write
+
+[reopen_file_test]
+nrfiles=4
+filesize=16k
+size=64k
+openfiles=2
+rw=write
+filename_format=reopen_test.$filenum


### PR DESCRIPTION
Signed-off-by: rootfs hchen@redhat.com
