### PR TITLE
Disable usleep in fio_rbd_getevents to reduce the latency

### DIFF
--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -245,7 +245,7 @@ static int fio_rbd_getevents(struct thread_data *td, unsigned int min,
 
 		}
 		if (events < min)
-			usleep(100);
+			;
 		else
 			break;
 


### PR DESCRIPTION
The fio rbd engine use usleep(100) in function fio_rbd_getevents. This cause about 160us latency on fio rbd test.In our practice (Jobs=1,iodepth=1) if we apply this patch, we could get avg 86us result random write test to rbd. But without this patch, the latency is avg 248us. So the usleep(100) and the usleep's thread context switch increased the latency of the result.

Signed-off-by: Ketor Meng d.ketor@gmail.com
