### PR TITLE
fix rbd_option parse error

### DIFF
--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -23,6 +23,7 @@ struct rbd_data {
 };
 
 struct rbd_options {
+	struct thread_data *td;
 	char *rbd_name;
 	char *pool_name;
 	char *client_name;
@@ -62,7 +63,7 @@ static struct fio_option options[] = {
 		.lname		= "Busy poll",
 		.type		= FIO_OPT_BOOL,
 		.help		= "Busy poll for completions instead of sleeping",
-		.off1		= offsetof(struct rbd_options, client_name),
+		.off1		= offsetof(struct rbd_options, busy_poll),
 		.def		= "0",
 		.category	= FIO_OPT_C_ENGINE,
 		.group		= FIO_OPT_G_RBD,


### PR DESCRIPTION
There is two bug in the rbd_options parse:
1. The memeber struct thread_data *td of struct rbd_options is filled in the cmdline parse process.So it is usable and cannot be deleted.

2.The busy_poll offset of struct rbd_options is not the "busy_poll" but "client_name"

After fix these two bugs, the fio test then can run.

Signed-off-by: Ketor Meng d.ketor@gmail.com
