### PR TITLE
ARM: Use generic assembly nop and barrier code for armv8-a

### DIFF
--- a/arch/arch-arm.h
+++ b/arch/arch-arm.h
@@ -25,7 +25,7 @@
 #define nop             __asm__ __volatile__("mov\tr0,r0\t@ nop\n\t")
 #define read_barrier()	__asm__ __volatile__ ("" : : : "memory")
 #define write_barrier()	__asm__ __volatile__ ("" : : : "memory")
-#elif defined(__ARM_ARCH_7A__)
+#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A__)
 #define	nop		__asm__ __volatile__ ("nop")
 #define read_barrier()	__sync_synchronize()
 #define write_barrier()	__sync_synchronize()


### PR DESCRIPTION
Signed-off-by: Milton Chiang <milton.chiang@mediatek.com>