### PR TITLE
Fix fio perfomance on windows to match IOMETER.

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2010,6 +2010,7 @@ before it can be used with this format. The offset and length are given in
 bytes. The action can be one of these:
 
 wait       Wait for 'offset' microseconds. Everything below 100 is discarded.
+	   The time is relative to the previous wait statement.
 read       Read 'length' bytes beginning from 'offset'
 write      Write 'length' bytes beginning from 'offset'
 sync       fsync() the file

--- a/backend.c
+++ b/backend.c
@@ -428,7 +428,7 @@ static int wait_for_completions(struct thread_data *td, struct timeval *time)
 	 * if the queue is full, we MUST reap at least 1 event
 	 */
 	min_evts = min(td->o.iodepth_batch_complete, td->cur_depth);
-	if (full && !min_evts)
+    if ((full && !min_evts) || !td->o.iodepth_batch_complete)
 		min_evts = 1;
 
 	if (time && (__should_check_rate(td, DDIR_READ) ||


### PR DESCRIPTION
On google cloud compute machines with local flash, we see fio do around 60k iops while IoMeter does 100k.
This change brings fio on par with iometer.