### PR TITLE
allow fio --client to run multiple hosts on a shared filesystem

### DIFF
--- a/options.c
+++ b/options.c
@@ -825,6 +825,7 @@ int set_name_idx(char *target, char *input, int index)
 	unsigned int cur_idx;
 	int len;
 	char *fname, *str, *p;
+	extern char my_addr[INET6_ADDRSTRLEN];
 
 	p = str = strdup(input);
 
@@ -832,7 +833,12 @@ int set_name_idx(char *target, char *input, int index)
 	for (cur_idx = 0; cur_idx <= index; cur_idx++)
 		fname = get_next_name(&str);
 
-	len = sprintf(target, "%s/", fname);
+	if (my_addr[0]) {
+		len = sprintf(target, "%s/%s.", fname, my_addr);
+	} else {
+		len = sprintf(target, "%s/", fname);
+	}
+
 	free(p);
 
 	return len;

--- a/options.c
+++ b/options.c
@@ -17,6 +17,8 @@
 
 #include "crc/crc32c.h"
 
+char client_sockaddr_str[INET6_ADDRSTRLEN] = {0};
+
 /*
  * Check if mmap/mmaphuge has a :/foo/bar/file at the end. If so, return that.
  */
@@ -825,7 +827,6 @@ int set_name_idx(char *target, char *input, int index)
 	unsigned int cur_idx;
 	int len;
 	char *fname, *str, *p;
-	extern char my_addr[INET6_ADDRSTRLEN];
 
 	p = str = strdup(input);
 
@@ -833,8 +834,8 @@ int set_name_idx(char *target, char *input, int index)
 	for (cur_idx = 0; cur_idx <= index; cur_idx++)
 		fname = get_next_name(&str);
 
-	if (my_addr[0]) {
-		len = sprintf(target, "%s/%s.", fname, my_addr);
+	if (client_sockaddr_str[0]) {
+		len = sprintf(target, "%s/%s.", fname, client_sockaddr_str);
 	} else {
 		len = sprintf(target, "%s/", fname);
 	}

--- a/server.c
+++ b/server.c
@@ -44,6 +44,8 @@ static unsigned int has_zlib = 0;
 #endif
 static unsigned int use_zlib;
 static char me[128];
+char my_addr[INET6_ADDRSTRLEN] = {0};
+
 
 struct fio_fork_item {
 	struct flist_head list;
@@ -1007,6 +1009,7 @@ static int accept_loop(int listen_sk)
 		}
 
 		/* exits */
+		strncpy(my_addr, from, INET6_ADDRSTRLEN);
 		handle_connection(sk);
 	}
 

--- a/server.c
+++ b/server.c
@@ -44,7 +44,6 @@ static unsigned int has_zlib = 0;
 #endif
 static unsigned int use_zlib;
 static char me[128];
-char my_addr[INET6_ADDRSTRLEN] = {0};
 
 
 struct fio_fork_item {
@@ -945,6 +944,7 @@ static int accept_loop(int listen_sk)
 	socklen_t len = use_ipv6 ? sizeof(addr6) : sizeof(addr);
 	struct pollfd pfd;
 	int ret = 0, sk, exitval = 0;
+	extern char client_sockaddr_str[INET6_ADDRSTRLEN];
 	FLIST_HEAD(conn_list);
 
 	dprint(FD_NET, "server enter accept loop\n");
@@ -1009,7 +1009,7 @@ static int accept_loop(int listen_sk)
 		}
 
 		/* exits */
-		strncpy(my_addr, from, INET6_ADDRSTRLEN);
+		strncpy(client_sockaddr_str, from, INET6_ADDRSTRLEN);
 		handle_connection(sk);
 	}
 


### PR DESCRIPTION
This change is intended to allow fio --client to invoke multiple fio instances on different hosts accessing a shared filesystem, such as cephfs, glusterfs, or nfs.  The problem is that fio file pathnames are not unique across hosts.  So this change captures the IP addr of the fio workload generator process.  It assumes there is only one such process per host and it does not create a subdirectory for the host.  Consequently there will be more files per directory, depending on how many fio instances are accessing the shared directory.  All comments appreciated.