### PR TITLE
Fix warning from gmake on BSD

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -511,6 +511,7 @@ static int block_state_category(int block_state)
 		return 2;
 	default:
 		assert(0);
+		return -1;
 	}
 }
 


### PR DESCRIPTION
This pull request fixes -Wreturn-type compiler warning that i see on BSD.

stat.c: In function 'block_state_category':
stat.c:514:1: warning: control reaches end of non-void function
[-Wreturn-type]
 }