### PR TITLE
Change (blank)cpu affinity macros to inline functions

### DIFF
--- a/gettime-thread.c
+++ b/gettime-thread.c
@@ -9,9 +9,7 @@
 struct timeval *fio_tv = NULL;
 int fio_gtod_offload = 0;
 static pthread_t gtod_thread;
-#ifdef FIO_HAVE_CPU_AFFINITY
 static os_cpu_mask_t fio_gtod_cpumask;
-#endif
 
 void fio_gtod_init(void)
 {

--- a/os/os.h
+++ b/os/os.h
@@ -79,12 +79,24 @@ typedef struct aiocb os_aiocb_t;
 #endif
 
 #ifndef FIO_HAVE_CPU_AFFINITY
-#define fio_setaffinity(pid, mask)	(0)
 #define fio_getaffinity(pid, mask)	do { } while (0)
 #define fio_cpu_clear(mask, cpu)	do { } while (0)
-#define fio_cpuset_exit(mask)		(-1)
-#define fio_cpus_split(mask, cpu)	(0)
 typedef unsigned long os_cpu_mask_t;
+
+static inline int fio_setaffinity(int pid, os_cpu_mask_t cpumask)
+{
+	return 0;
+}
+
+static inline int fio_cpuset_exit(os_cpu_mask_t *mask)
+{
+	return -1;
+}
+
+static inline int fio_cpus_split(os_cpu_mask_t *mask, unsigned int cpu_index)
+{
+	return 0;
+}
 #else
 extern int fio_cpus_split(os_cpu_mask_t *mask, unsigned int cpu);
 #endif


### PR DESCRIPTION
Not sure if you would want to take this one, but I think it's better with inline functions for these cases where macros are used in either conditional or non-conditional so as to avoid compiler warnings.

---
gcc warns -Wunused-value on some environments (e.g. BSD) when
the following cpu affinity macros are used in non conditional code.

Also removed #ifdef FIO_HAVE_CPU_AFFINITY in gettime-thread.c
since this variable needs to be visible when calling the function.

gettime-thread.c: In function 'gtod_thread_main':
os/os.h:82:36: warning: statement with no effect [-Wunused-value]
 #define fio_setaffinity(pid, mask) (0)
                                    ^
gettime-thread.c:48:2: note: in expansion of macro 'fio_setaffinity'
  fio_setaffinity(gettid(), fio_gtod_cpumask);