### PR TITLE
Cleanup DragonFlyBSD support

### DIFF
--- a/os/os-dragonfly.h
+++ b/os/os-dragonfly.h
@@ -5,12 +5,7 @@
 
 #include <errno.h>
 #include <sys/param.h>
-/* XXX hack to avoid confilcts between rbtree.h and <sys/rb.h> */
-#define	rb_node	_rb_node
 #include <sys/sysctl.h>
-#undef rb_node
-#undef rb_left
-#undef rb_right
 
 #include "../file.h"
 


### PR DESCRIPTION
Remove these define/undef since fio compiles on DragonFlyBSD
without them.

\<sys/rb.h> seems to have never existed in DragonFlyBSD history,
and it compiles without these define/undef. It seems this hack
was necessary on some older versions of NetBSD.