### PR TITLE
Add missing fio_mutex_up() on return

### DIFF
--- a/flow.c
+++ b/flow.c
@@ -59,6 +59,7 @@ static struct fio_flow *flow_get(unsigned int id)
 		flow = smalloc(sizeof(*flow));
 		if (!flow) {
 			log_err("fio: smalloc pool exhausted\n");
+			fio_mutex_up(flow_lock);
 			return NULL;
 		}
 		flow->refs = 0;


### PR DESCRIPTION
Call fio_mutex_up() before returning from this function.