### PR TITLE
Fix build error on non-GNU environment

### DIFF
--- a/lib/mountcheck.c
+++ b/lib/mountcheck.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <string.h>
-#include <mntent.h>
 
 #ifdef CONFIG_GETMNTENT
+#include <mntent.h>
 
 #define MTAB	"/etc/mtab"
 


### PR DESCRIPTION
'#include \<mntent.h\>' needs to be inside '#ifdef CONFIG_GETMNTENT'
and that was probably the intention of the commit aae599ba.
e.g. BSDs are likely to hit following compile error.

--
lib/mountcheck.c:3:20: fatal error: mntent.h: No such file or directory
compilation terminated.
Makefile:275: recipe for target 'lib/mountcheck.o' failed
gmake: *** [lib/mountcheck.o] Error 1