### PR TITLE
Minor cleanups on cleanup()

### DIFF
--- a/engines/null.c
+++ b/engines/null.c
@@ -86,8 +86,7 @@ static void fio_null_cleanup(struct thread_data *td)
 	struct null_data *nd = (struct null_data *) td->io_ops->data;
 
 	if (nd) {
-		if (nd->io_us)
-			free(nd->io_us);
+		free(nd->io_us);
 		free(nd);
 	}
 }

--- a/engines/sync.c
+++ b/engines/sync.c
@@ -317,9 +317,11 @@ static void fio_vsyncio_cleanup(struct thread_data *td)
 {
 	struct syncio_data *sd = td->io_ops->data;
 
-	free(sd->iovecs);
-	free(sd->io_us);
-	free(sd);
+	if (sd) {
+		free(sd->iovecs);
+		free(sd->io_us);
+		free(sd);
+	}
 }
 
 static struct ioengine_ops ioengine_rw = {


### PR DESCRIPTION
Sync with the way other engines implement cleanup() that is regarded
as a better practice. td->io_ops->data should have null check before
dereference and its members can be freed without null check.