### PR TITLE
Add device_is_mounted() support for BSDs

### DIFF
--- a/configure
+++ b/configure
@@ -1472,6 +1472,24 @@ if compile_prog "" "" "getmntent"; then
 fi
 echo "getmntent                     $getmntent"
 
+##########################################
+# Check whether we have getmntinfo
+getmntinfo="no"
+cat > $TMPC << EOF
+#include <stdio.h>
+#include <sys/param.h>
+#include <sys/mount.h>
+int main(int argc, char **argv)
+{
+  struct statfs st;
+  return getmntinfo(&st, MNT_NOWAIT);
+}
+EOF
+if compile_prog "" "" "getmntinfo"; then
+  getmntinfo="yes"
+fi
+echo "getmntinfo                    $getmntinfo"
+
 #############################################################################
 
 if test "$wordsize" = "64" ; then
@@ -1647,6 +1665,9 @@ if test "$arith" = "yes" ; then
 fi
 if test "$getmntent" = "yes" ; then
   output_sym "CONFIG_GETMNTENT"
+fi
+if test "$getmntinfo" = "yes" ; then
+  output_sym "CONFIG_GETMNTINFO"
 fi
 
 if test "$zlib" = "no" ; then

--- a/lib/mountcheck.c
+++ b/lib/mountcheck.c
@@ -29,10 +29,25 @@ int device_is_mounted(const char *dev)
 	return ret;
 }
 
-#else
+#elif defined(CONFIG_GETMNTINFO)
+/* for BSDs */
+#include <sys/param.h>
+#include <sys/mount.h>
 
 int device_is_mounted(const char *dev)
 {
+	struct statfs *st;
+	int i, ret;
+
+	ret = getmntinfo(&st, MNT_NOWAIT);
+	if (ret <= 0)
+		return 0;
+
+	for (i = 0; i < ret; i++) {
+		if (!strcmp(st[i].f_mntfromname, dev))
+			return 1;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Implement '#elif' part of lib/mountcheck.c using getmntinfo(3).

This should implement device_is_mounted() on most BSDs, and has been
tested on FreeBSD/DragonFlyBSD. NetBSD/OpenBSD do have getmntinfo(3)
but may need to include different headers according to their online
manpages.

--
 # cat ./test1.c
 #include <stdio.h>
 #include "./lib/mountcheck.h"
 int main(int argc, char *argv[]) {
 	printf("%s %d\n", argv[1], device_is_mounted(argv[1]));
 	return 0;
 }

--
 # uname
 FreeBSD
 # clang -Wall -g ./test1.c ./lib/mountcheck.o -o ./test1
 # ./test1 /dev/ada0p2  /\* UFS \*/
 /dev/ada0p2 1
 # ./test1 zfs  /\* ZFS \*/
 zfs 1
 # ./test1 zfs/test  /\* ZFS \*/
 zfs/test 1
 # ./test1 /dev/da0  /\* not mounted device \*/
 /dev/da0 0
 # ./test1 random  /\* irrelevant string \*/
 random 0

--
 # uname
 DragonFly
 # gcc -Wall -g ./test1.c ./lib/mountcheck.o -o ./test1
 # ./test1 /pfs/@@-1:00005  /\* HAMMER \*/
 /pfs/@@-1:00005 1
 # ./test1 procfs  /\* procfs \*/
 procfs 1
 # ./test1 /dev/da8  /\* not mounted device \*/
 /dev/da8 0
 # ./test1 random  /\* irrelevant string \*/
 random 0