### PR TITLE
Disable libaio for ESXi build - bug#80

### DIFF
--- a/configure
+++ b/configure
@@ -471,8 +471,10 @@ int main(void)
 }
 EOF
 if compile_prog "" "-laio" "libaio" ; then
-  libaio=yes
-  LIBS="-laio $LIBS"
+  if test "$esx" != "yes" ; then
+    libaio=yes
+    LIBS="-laio $LIBS"
+  fi
 else
   if test "$libaio" = "yes" ; then
     feature_not_found "linux AIO" "libaio-dev or libaio-devel"


### PR DESCRIPTION
Suggested fix for bug#80 (libaio library not found on ESXi)