### PR TITLE
Fix compile error on non Linux-or-BSDs

### DIFF
--- a/lib/mountcheck.c
+++ b/lib/mountcheck.c
@@ -51,4 +51,12 @@ int device_is_mounted(const char *dev)
 	return 0;
 }
 
+#else
+/* others */
+
+int device_is_mounted(const char *dev)
+{
+	return 0;
+}
+
 #endif


### PR DESCRIPTION
Sorry, my previous pull request (e7e136da) needed to add a blank device_is_mounted() for #else case. It breaks non Linux-or-BSDs.

--
e7e136da needed to add #else part with another device_is_mounted()
that returns 0 for non Linux-or-BSDs environment. Any environment
without getmntent(3) or getmntinfo(3) needs a blank function.
