### PR TITLE
Clear sysfs path before reading current ioscheduler from sysfs

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1172,13 +1172,17 @@ static int switch_ioscheduler(struct thread_data *td)
 	/*
 	 * Read back and check that the selected scheduler is now the default.
 	 */
+	memset(tmp, 0, sizeof(tmp));
 	ret = fread(tmp, sizeof(tmp), 1, f);
 	if (ferror(f) || ret < 0) {
 		td_verror(td, errno, "fread");
 		fclose(f);
 		return 1;
 	}
-	tmp[sizeof(tmp) - 1] = '\0';
+	/*
+	 * either a list of io schedulers or "none\n" is expected.
+	 */
+	tmp[strlen(tmp) - 1] = '\0';
 
 
 	sprintf(tmp2, "[%s]", td->o.ioscheduler);


### PR DESCRIPTION
switch_ioscheduler() function has a local buffer tmp[] to store
both sysfs path (e.g. /sys/block/`device`/queue/scheduler) and
content of that sysfs path.

In order to properly test strstr() after writing a ioscheduler
string (e.g. "deadline") to sysfs, it needs to memset(0) first.
Otherwise if the content of sysfs path (below (b)) is shorter
than the existing sysfs path in tmp[] (below (a)), then tmp[]
after storing the content of sysfs (below (c) and *haystack of
strstr()) contains remaining part of the sysfs path.

(a) "/sys/block/sdb/queue/scheduler"
(b) "noop [deadline] cfq \n"
(c) "noop [deadline] cfq \nscheduler"

strstr() will result the same given that the remaining part of
the sysfs path is unlikely to contain ioscheduler string, but
the remaining part should still be cleared first.