### PR TITLE
Add get_fs_size() support for BSDs

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -732,7 +732,7 @@ static unsigned long long get_fs_free_counts(struct thread_data *td)
 		fm = flist_entry(n, struct fio_mount, list);
 		flist_del(&fm->list);
 
-		sz = get_fs_size(fm->base);
+		sz = get_fs_free_size(fm->base);
 		if (sz && sz != -1ULL)
 			ret += sz;
 

--- a/os/os-android.h
+++ b/os/os-android.h
@@ -238,7 +238,7 @@ static inline int arch_cache_line_size(void)
 		return atoi(size);
 }
 
-static inline unsigned long long get_fs_size(const char *path)
+static inline unsigned long long get_fs_free_size(const char *path)
 {
 	unsigned long long ret;
 	struct statfs s;

--- a/os/os-dragonfly.h
+++ b/os/os-dragonfly.h
@@ -52,7 +52,7 @@ static inline int gettid(void)
 	return (int) lwp_gettid();
 }
 
-static inline unsigned long long get_fs_size(const char *path)
+static inline unsigned long long get_fs_free_size(const char *path)
 {
 	unsigned long long ret;
 	struct statvfs s;

--- a/os/os-dragonfly.h
+++ b/os/os-dragonfly.h
@@ -4,6 +4,7 @@
 #define	FIO_OS	os_dragonfly
 
 #include <errno.h>
+#include <unistd.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
 

--- a/os/os-dragonfly.h
+++ b/os/os-dragonfly.h
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
+#include <sys/statvfs.h>
 
 #include "../file.h"
 
@@ -14,6 +15,7 @@
 #define FIO_USE_GENERIC_BDEV_SIZE
 #define FIO_USE_GENERIC_RAND
 #define FIO_USE_GENERIC_INIT_RANDOM_STATE
+#define FIO_HAVE_FS_STAT
 #define FIO_HAVE_GETTID
 
 #undef	FIO_HAVE_CPU_AFFINITY	/* XXX notyet */
@@ -48,6 +50,19 @@ static inline unsigned long long os_phys_mem(void)
 static inline int gettid(void)
 {
 	return (int) lwp_gettid();
+}
+
+static inline unsigned long long get_fs_size(const char *path)
+{
+	unsigned long long ret;
+	struct statvfs s;
+
+	if (statvfs(path, &s) < 0)
+		return -1ULL;
+
+	ret = s.f_frsize;
+	ret *= (unsigned long long) s.f_bfree;
+	return ret;
 }
 
 #ifdef MADV_FREE

--- a/os/os-freebsd.h
+++ b/os/os-freebsd.h
@@ -101,7 +101,7 @@ static inline int gettid(void)
 	return (int) lwpid;
 }
 
-static inline unsigned long long get_fs_size(const char *path)
+static inline unsigned long long get_fs_free_size(const char *path)
 {
 	unsigned long long ret;
 	struct statvfs s;

--- a/os/os-freebsd.h
+++ b/os/os-freebsd.h
@@ -10,6 +10,7 @@
 #include <sys/socket.h>
 #include <sys/param.h>
 #include <sys/cpuset.h>
+#include <sys/statvfs.h>
 
 #include "../file.h"
 
@@ -17,6 +18,7 @@
 #define FIO_USE_GENERIC_RAND
 #define FIO_USE_GENERIC_INIT_RANDOM_STATE
 #define FIO_HAVE_CHARDEV_SIZE
+#define FIO_HAVE_FS_STAT
 #define FIO_HAVE_GETTID
 #define FIO_HAVE_CPU_AFFINITY
 
@@ -97,6 +99,19 @@ static inline int gettid(void)
 
 	thr_self(&lwpid);
 	return (int) lwpid;
+}
+
+static inline unsigned long long get_fs_size(const char *path)
+{
+	unsigned long long ret;
+	struct statvfs s;
+
+	if (statvfs(path, &s) < 0)
+		return -1ULL;
+
+	ret = s.f_frsize;
+	ret *= (unsigned long long) s.f_bfree;
+	return ret;
 }
 
 #ifdef MADV_FREE

--- a/os/os-linux.h
+++ b/os/os-linux.h
@@ -247,7 +247,7 @@ static inline int arch_cache_line_size(void)
 		return atoi(size);
 }
 
-static inline unsigned long long get_fs_size(const char *path)
+static inline unsigned long long get_fs_free_size(const char *path)
 {
 	unsigned long long ret;
 	struct statfs s;

--- a/os/os.h
+++ b/os/os.h
@@ -332,7 +332,7 @@ static inline int init_random_state(struct thread_data *td, unsigned long *rand_
 #endif
 
 #ifndef FIO_HAVE_FS_STAT
-static inline unsigned long long get_fs_size(const char *path)
+static inline unsigned long long get_fs_free_size(const char *path)
 {
 	return 0;
 }


### PR DESCRIPTION
This pull request submits 3 related commits on get_fs_size().

I've used POSIX statvfs(2) instead of statfs(2), but if there is a reason to use statfs(2) I'll resubmit it using statfs(2) (just like Linux version does).
