### PR TITLE
fio: allow for build in separate build directory

### DIFF
--- a/configure
+++ b/configure
@@ -1717,3 +1717,10 @@ echo "LDFLAGS+=$LDFLAGS" >> $config_host_mak
 echo "CC=$cc" >> $config_host_mak
 echo "BUILD_CFLAGS=$BUILD_CFLAGS $CFLAGS" >> $config_host_mak
 echo "INSTALL_PREFIX=$prefix" >> $config_host_mak
+
+if [ `dirname $0` != "." ]; then
+    cat > Makefile <<EOF
+SRCDIR:=`dirname $0`
+include \$(SRCDIR)/Makefile
+EOF
+fi


### PR DESCRIPTION
Change configure so that it will use its current directory for building,
and the path to the script itself as the source directory.

Change the Makefile to use VPATH to find the source files. Only a few other
things needed to be touched:
 - use the full path to the source in wildcard, then strip it off again
 - search both build and source for header files
 - FIO-VERSION-GEN is in source
 - make directories in build as needed
 - use $< to refer to input files
 - install non-executables from source

Signed-off-by: Jeremy Fitzhardinge <jeremy@exablox.com>