### PR TITLE
re-seed based on rand_repeatable

### DIFF
--- a/libfio.c
+++ b/libfio.c
@@ -116,9 +116,11 @@ void clear_io_state(struct thread_data *td)
 	}
 
 	/*
-	 * Set the same seed to get repeatable runs
+	 * Re-Seed random number generator if rand_repeatable is true
 	 */
-	td_fill_rand_seeds(td);
+	 if (td->o.rand_repeatable){
+	 	td_fill_rand_seeds(td);	
+	 }
 }
 
 void reset_all_stats(struct thread_data *td)


### PR DESCRIPTION
Re-seeding the random generator will repeat "random" IO sequences, which in some cases may produce unexpected IO patterns.

if rand_repeatable is true (default), then the random generator will be re-seeded every iteration per normal. Otherwise the random generator will not be-reseeded and will continue to produce random IO offsets.
