### PR TITLE
Potential Improvement in Rate Implimentation

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -238,9 +238,10 @@ struct thread_data {
 	 * Rate state
 	 */
 	uint64_t rate_bps[DDIR_RWDIR_CNT];
-	long rate_pending_usleep[DDIR_RWDIR_CNT];
+	unsigned long rate_next_io_time[DDIR_RWDIR_CNT];
 	unsigned long rate_bytes[DDIR_RWDIR_CNT];
 	unsigned long rate_blocks[DDIR_RWDIR_CNT];
+	unsigned long rate_io_issue_bytes[DDIR_RWDIR_CNT];
 	struct timeval lastrate[DDIR_RWDIR_CNT];
 
 	/*

--- a/init.c
+++ b/init.c
@@ -466,6 +466,7 @@ static int __setup_rate(struct thread_data *td, enum fio_ddir ddir)
 	}
 
 	td->rate_next_io_time[ddir] = 0;
+	td->rate_io_issue_bytes[ddir] = 0;
 	return 0;
 }
 

--- a/init.c
+++ b/init.c
@@ -465,7 +465,7 @@ static int __setup_rate(struct thread_data *td, enum fio_ddir ddir)
 		return -1;
 	}
 
-	td->rate_pending_usleep[ddir] = 0;
+	td->rate_next_io_time[ddir] = 0;
 	return 0;
 }
 

--- a/io_u.c
+++ b/io_u.c
@@ -568,48 +568,46 @@ void io_u_quiesce(struct thread_data *td)
 static enum fio_ddir rate_ddir(struct thread_data *td, enum fio_ddir ddir)
 {
 	enum fio_ddir odir = ddir ^ 1;
-	long usec;
+	long usec, now;
 
 	assert(ddir_rw(ddir));
+	now = utime_since_now(&td->start);
 
-	if (td->rate_pending_usleep[ddir] <= 0)
+	/*
+	 * if rate_next_io_time is in the past, need to catch up to rate
+	 */
+	if (td->rate_next_io_time[ddir] <= now)
 		return ddir;
 
 	/*
-	 * We have too much pending sleep in this direction. See if we
+	 * We are ahead of rate in this direction. See if we
 	 * should switch.
 	 */
 	if (td_rw(td) && td->o.rwmix[odir]) {
 		/*
-		 * Other direction does not have too much pending, switch
+		 * Other direction is behind rate, switch
 		 */
-		if (td->rate_pending_usleep[odir] < 100000)
+		if (td->rate_next_io_time[odir] <= now)
 			return odir;
 
 		/*
-		 * Both directions have pending sleep. Sleep the minimum time
-		 * and deduct from both.
+		 * Both directions are ahead of rate. sleep the min
+		 * switch if necissary
 		 */
-		if (td->rate_pending_usleep[ddir] <=
-			td->rate_pending_usleep[odir]) {
-			usec = td->rate_pending_usleep[ddir];
+		if (td->rate_next_io_time[ddir] <=
+			td->rate_next_io_time[odir]) {
+			usec = td->rate_next_io_time[ddir] - now;
 		} else {
-			usec = td->rate_pending_usleep[odir];
+			usec = td->rate_next_io_time[odir] - now;
 			ddir = odir;
 		}
 	} else
-		usec = td->rate_pending_usleep[ddir];
+		usec = td->rate_next_io_time[ddir] - now;
 
 	if (td->o.io_submit_mode == IO_MODE_INLINE)
 		io_u_quiesce(td);
 
 	usec = usec_sleep(td, usec);
-
-	td->rate_pending_usleep[ddir] -= usec;
-
-	odir = ddir ^ 1;
-	if (td_rw(td) && __should_check_rate(td, odir))
-		td->rate_pending_usleep[odir] -= usec;
 
 	return ddir;
 }
@@ -1656,18 +1654,6 @@ static void account_io_completion(struct thread_data *td, struct io_u *io_u,
 	}
 }
 
-static long long usec_for_io(struct thread_data *td, enum fio_ddir ddir)
-{
-	uint64_t secs, remainder, bps, bytes;
-
-	assert(!(td->flags & TD_F_CHILD));
-	bytes = td->this_io_bytes[ddir];
-	bps = td->rate_bps[ddir];
-	secs = bytes / bps;
-	remainder = bytes % bps;
-	return remainder * 1000000 / bps + secs * 1000000;
-}
-
 static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 			 struct io_completion_data *icd)
 {
@@ -1709,7 +1695,6 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 
 	if (!io_u->error && ddir_rw(ddir)) {
 		unsigned int bytes = io_u->buflen - io_u->resid;
-		const enum fio_ddir oddir = ddir ^ 1;
 		int ret;
 
 		td->io_blocks[ddir]++;
@@ -1738,26 +1723,8 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 		}
 
 		if (ramp_time_over(td) && (td->runstate == TD_RUNNING ||
-					   td->runstate == TD_VERIFYING)) {
-			struct thread_data *__td = td;
-
+					   td->runstate == TD_VERIFYING))
 			account_io_completion(td, io_u, icd, ddir, bytes);
-
-			if (td->parent)
-				__td = td->parent;
-
-			if (__should_check_rate(__td, ddir)) {
-				__td->rate_pending_usleep[ddir] =
-					(usec_for_io(__td, ddir) -
-					 utime_since_now(&__td->start));
-			}
-			if (ddir != DDIR_TRIM &&
-			    __should_check_rate(__td, oddir)) {
-				__td->rate_pending_usleep[oddir] =
-					(usec_for_io(__td, oddir) -
-					 utime_since_now(&__td->start));
-			}
-		}
 
 		icd->bytes_done[ddir] += bytes;
 

--- a/ioengines.c
+++ b/ioengines.c
@@ -299,6 +299,7 @@ int td_io_queue(struct thread_data *td, struct io_u *io_u)
 	if (ddir_rw(ddir)) {
 		td->io_issues[ddir]++;
 		td->io_issue_bytes[ddir] += buflen;
+		td->rate_io_issue_bytes[ddir] += buflen;
 	}
 
 	ret = td->io_ops->queue(td, io_u);
@@ -308,6 +309,7 @@ int td_io_queue(struct thread_data *td, struct io_u *io_u)
 	if (ret == FIO_Q_BUSY && ddir_rw(ddir)) {
 		td->io_issues[ddir]--;
 		td->io_issue_bytes[ddir] -= buflen;
+		td->rate_io_issue_bytes[ddir] -= buflen;
 	}
 
 	/*

--- a/libfio.c
+++ b/libfio.c
@@ -89,6 +89,8 @@ static void reset_io_counters(struct thread_data *td)
 		td->rate_bytes[ddir] = 0;
 		td->rate_blocks[ddir] = 0;
 		td->bytes_done[ddir] = 0;
+		td->rate_io_issue_bytes[ddir] = 0;
+		td->rate_next_io_time[ddir] = 0;
 	}
 	td->zone_bytes = 0;
 

--- a/workqueue.c
+++ b/workqueue.c
@@ -124,6 +124,7 @@ int workqueue_enqueue(struct workqueue *wq, struct io_u *io_u)
 		if (ddir_rw(ddir)) {
 			parent->io_issues[ddir]++;
 			parent->io_issue_bytes[ddir] += io_u->xfer_buflen;
+			parent->rate_io_issue_bytes[ddir] += io_u->xfer_buflen;
 		}
 
 		pthread_mutex_lock(&sw->lock);


### PR DESCRIPTION
The current implementation of rate is direction control inside of rate_ddir, using td->rate_pending_usleep[ddir] as feedback.  This feedback occurs during io-completion, which introduces a delay while IO is pending.  When IO-depth > 1, the result is that rate control may saturate the iodepth with a given ddir until IO completions occur and provide feedback, regardless of if the given iodepth is necessary to maintain rate. A simplified flow chart of the feedback delay can be found here:
https://docs.google.com/drawings/d/1EG-9eGlNvw-m9m0wMSb_C_lyJcaPlhEFbkHRsVpt4wo/edit?usp=sharing

The proposed change alters rate control to contain feedback on io issues rather than completions, in order to remove the feedback delay. A flow diagram shoeing the idea can be found here:
https://docs.google.com/drawings/d/1NphdZGjYGuOLWJzvXHv44zuy0nnSunvFrROCVfA67Y8/edit?usp=sharing

Here are the list of changes:
1.Replace td->rate_pending_usleep[ddir] with td->rate_next_io_time[ddir] to track rate control
2.Add td->rate_io_issue_bytes[ddir] to track submissions and update it whenever td->io_issue_bytes[ddir] is updated.
3.Modify usec_for_io() to use td->rate_io_issue_bytes and move it into backend.c
4.Update td->rate_next_io_time[ddir] using usec_for_io() after io enqueues and before “reap:” in do_io()
5.Check td->rate_next_io_time[ddir] compared to now in rate_ddir(). If it is in the past, we are behind rate and need to submit IO. if it is in the future, we are ahead of rate and can switch ddir or sleep. 
6.Remove rate control from io_completed and cleanup unused variables
7.Change _setup_rate in init.c for new thread variables
8.reset td->rate_next_io_time[ddir] and td->rate_io_issue_bytes[ddir] in reset_io_counters

I have performed some testing where a single randrw job that has rate control on writes, but not on reads.  The result is a 4x implement in 99.99% clat  read percentiles, and a 1.6x improvement in the same for writes.

Although the results appear promising, At this point It might be best to keep it on a separate branch pursuing possible performance improvements.


