### PR TITLE
Add mmapshared option to use mmaped files with the MAP_SHARED flag.

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -146,12 +146,14 @@ static int alloc_mem_mmap(struct thread_data *td, size_t total_mem)
 			return 1;
 		}
 		if (td->o.mem_type != MEM_MMAPHUGE &&
+		    td->o.mem_type != MEM_MMAPSHARED &&
 		    ftruncate(td->mmapfd, total_mem) < 0) {
 			td_verror(td, errno, "truncate mmap file");
 			td->orig_buffer = NULL;
 			return 1;
 		}
-		if (td->o.mem_type == MEM_MMAPHUGE)
+		if (td->o.mem_type == MEM_MMAPHUGE ||
+		    td->o.mem_type == MEM_MMAPSHARED)
 			flags |= MAP_SHARED;
 		else
 			flags |= MAP_PRIVATE;
@@ -231,7 +233,8 @@ int allocate_io_mem(struct thread_data *td)
 		ret = alloc_mem_malloc(td, total_mem);
 	else if (td->o.mem_type == MEM_SHM || td->o.mem_type == MEM_SHMHUGE)
 		ret = alloc_mem_shm(td, total_mem);
-	else if (td->o.mem_type == MEM_MMAP || td->o.mem_type == MEM_MMAPHUGE)
+	else if (td->o.mem_type == MEM_MMAP || td->o.mem_type == MEM_MMAPHUGE ||
+		 td->o.mem_type == MEM_MMAPSHARED)
 		ret = alloc_mem_mmap(td, total_mem);
 	else {
 		log_err("fio: bad mem type: %d\n", td->o.mem_type);
@@ -256,7 +259,8 @@ void free_io_mem(struct thread_data *td)
 		free_mem_malloc(td);
 	else if (td->o.mem_type == MEM_SHM || td->o.mem_type == MEM_SHMHUGE)
 		free_mem_shm(td);
-	else if (td->o.mem_type == MEM_MMAP || td->o.mem_type == MEM_MMAPHUGE)
+	else if (td->o.mem_type == MEM_MMAP || td->o.mem_type == MEM_MMAPHUGE ||
+		 td->o.mem_type == MEM_MMAPSHARED)
 		free_mem_mmap(td, total_mem);
 	else
 		log_err("Bad memory type %u\n", td->o.mem_type);

--- a/options.c
+++ b/options.c
@@ -351,7 +351,8 @@ static int str_mem_cb(void *data, const char *mem)
 {
 	struct thread_data *td = data;
 
-	if (td->o.mem_type == MEM_MMAPHUGE || td->o.mem_type == MEM_MMAP)
+	if (td->o.mem_type == MEM_MMAPHUGE || td->o.mem_type == MEM_MMAP ||
+	    td->o.mem_type == MEM_MMAPSHARED)
 		td->o.mmapfile = get_opt_postfix(mem);
 
 	return 0;
@@ -2227,6 +2228,10 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 			  { .ival = "mmap",
 			    .oval = MEM_MMAP,
 			    .help = "Use mmap(2) (file or anon) for IO buffers",
+			  },
+			  { .ival = "mmapshared",
+			    .oval = MEM_MMAPSHARED,
+			    .help = "Like mmap, but use the shared flag",
 			  },
 #ifdef FIO_HAVE_HUGETLB
 			  { .ival = "mmaphuge",

--- a/thread_options.h
+++ b/thread_options.h
@@ -19,6 +19,7 @@ enum fio_memtype {
 	MEM_SHMHUGE,	/* use shared memory segments with huge pages */
 	MEM_MMAP,	/* use anonynomous mmap */
 	MEM_MMAPHUGE,	/* memory mapped huge file */
+	MEM_MMAPSHARED, /* use mmap with shared flag */
 };
 
 #define ERROR_STR_MAX	128


### PR DESCRIPTION
This is primarily useful for benchmarking DAX files. If they are mmaped
with the MAP_PRIVATE flag they will still have copy on write semantics
and the test will not actually run against the memory that backs the
DAX file. This memory option allows tests to be constructed that use the
MAP_SHARED flag which allows running directly with the memory backing
a DAX file.