### PR TITLE
iolog: fix error when compiled as c++

### DIFF
--- a/iolog.h
+++ b/iolog.h
@@ -122,7 +122,8 @@ static inline size_t log_entry_sz(struct io_log *log)
 static inline struct io_sample *__get_sample(void *samples, int log_offset,
 					     uint64_t sample)
 {
-	return samples + sample * __log_entry_sz(log_offset);
+	uint64_t sample_offset = sample * __log_entry_sz(log_offset);
+	return (struct io_sample *) ((char *) samples + sample_offset);
 }
 
 static inline struct io_sample *get_sample(struct io_log *iolog,


### PR DESCRIPTION
Given the main.cc source file:
```
#include <fio.h>
int main() { return 0; }
```

And the gcc command line:
```
$ gcc main.cc -Ifio
In file included from fio/stat.h:4:0,
                 from fio/thread_options.h:7,
                 from fio/fio.h:18,
                 from main.cc:1:
fio/iolog.h: In function 'io_sample* __get_sample(void*, int, uint64_t)':
fio/iolog.h:125:53: warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
  return samples + sample * __log_entry_sz(log_offset);
                                                     ^
fio/iolog.h:125:17: error: invalid conversion from 'void*' to 'io_sample*' [-fpermissive]
  return samples + sample * __log_entry_sz(log_offset);
```
Building as c++ is useful for external engines, such as the ceph objectstore engine (https://github.com/ceph/ceph/pull/5943).