### PR TITLE
Log to parent instead of twice to child td

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -1667,7 +1667,7 @@ void io_u_log_error(struct thread_data *td, struct io_u *io_u)
 {
 	__io_u_log_error(td, io_u);
 	if (td->parent)
-		__io_u_log_error(td, io_u);
+		__io_u_log_error(td->parent, io_u);
 }
 
 static inline bool gtod_reduce(struct thread_data *td)


### PR DESCRIPTION
In io_u_log_error, the duplicated log call looked strange, this patch is a guess at original intent.