### PR TITLE
add clustername for rbd engine

### DIFF
--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -27,6 +27,7 @@ struct rbd_data {
 
 struct rbd_options {
 	void *pad;
+	char *cluster_name;
 	char *rbd_name;
 	char *pool_name;
 	char *client_name;
@@ -34,6 +35,15 @@ struct rbd_options {
 };
 
 static struct fio_option options[] = {
+        {
+		.name		= "clustername",
+		.lname		= "ceph cluster name",
+		.type		= FIO_OPT_STR_STORE,
+		.help		= "Cluster name for ceph",
+		.off1		= offsetof(struct rbd_options, cluster_name),
+		.category	= FIO_OPT_C_ENGINE,
+		.group		= FIO_OPT_G_RBD,
+	},
 	{
 		.name		= "rbdname",
 		.lname		= "rbd engine rbdname",
@@ -112,7 +122,24 @@ static int _fio_rbd_connect(struct thread_data *td)
 	struct rbd_options *o = td->eo;
 	int r;
 
-	r = rados_create(&rbd->cluster, o->client_name);
+	if(o->cluster_name){
+	/*
+	 * If we specific cluser name, the rados_creat2
+	 * will not assume 'client.'. name is considered
+	 * as a full type.id namestr
+	 */
+	char * client_name = NULL; 
+	if(!index(o->client_name, '.')){
+		client_name = calloc(1, strlen("client.") + strlen(o->client_name) + 1);
+		strcat(client_name, "client.");
+		o->client_name = strcat(client_name, o->client_name);
+	}
+
+ 	r = rados_create2(&rbd->cluster, o->cluster_name,o->client_name, 0);
+	} else {
+		r = rados_create(&rbd->cluster, o->client_name);
+	}
+	
 	if (r < 0) {
 		log_err("rados_create failed.\n");
 		goto failed_early;

--- a/fio.1
+++ b/fio.1
@@ -1772,6 +1772,9 @@ Preallocate donor's file on init
 .BI 1:
 allocate space immediately inside defragment event, and free right after event
 .RE
+.TP 
+.BI (rbd)clustername \fR=\fPstr
+Specifies the name of the ceph cluster.
 .TP
 .BI (rbd)rbdname \fR=\fPstr
 Specifies the name of the RBD.
@@ -1781,6 +1784,8 @@ Specifies the name of the Ceph pool containing the RBD.
 .TP
 .BI (rbd)clientname \fR=\fPstr
 Specifies the username (without the 'client.' prefix) used to access the Ceph cluster.
+If the clustername is specified, the clientname should be full type.id string. If no
+type. prefix, fio will add 'client.' by default for you.
 .TP
 .BI (mtd)skipbad \fR=\fPbool
 Skip operations against known bad blocks.


### PR DESCRIPTION
As the Ceph Jewel is released, ceph cluster name
may not be the default "ceph". So we should add
the clustername for rbd engine to support that.

Signed-off-by: Tianqing <tianqing@unitedstack.com>