### PR TITLE
gaps in IOPS logs because of time drift

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -2142,7 +2142,7 @@ static void add_log_sample(struct thread_data *td, struct io_log *iolog,
 
 	_add_stat_to_log(iolog, elapsed, td->o.log_max != 0);
 
-	iolog->avg_last = elapsed;
+	iolog->avg_last = elapsed - (this_window - iolog->avg_msec);
 }
 
 void finalize_logs(struct thread_data *td, bool unit_logs)


### PR DESCRIPTION
Every time we set iolog->avg_last, we get a slight time drift. Namely we are taking samples *at least* every log_avg_msec milliseconds. This PR adjusts for the drift by subtracting the amount we drift by when updating avg_last.