### PR TITLE
Fix "exitall_on_error" option

### DIFF
--- a/options.c
+++ b/options.c
@@ -3444,8 +3444,8 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 	{
 		.name	= "exitall_on_error",
 		.lname	= "Exit-all on terminate in error",
-		.type	= FIO_OPT_BOOL,
-		.off1	= td_var_offset(unlink),
+		.type	= FIO_OPT_STR_SET,
+		.off1	= td_var_offset(exitall_error),
 		.help	= "Terminate all jobs when one exits in error",
 		.category = FIO_OPT_C_GENERAL,
 		.group	= FIO_OPT_G_PROCESS,


### PR DESCRIPTION
I found that the rest of the jobs did not stop after a job terminated with an error while _exit_on_all_ was enabled.
So I fixed _options.c_ so that _exitall_on_error_ could work as specified.