### PR TITLE
Fix segmentation fault and memory leak issue in rbd engine

### DIFF
--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -134,15 +134,22 @@ static int _fio_rbd_connect(struct thread_data *td)
 		 * as a full type.id namestr
 		 */
 		if (o->client_name) {
+			char *client_name = NULL;
+
 			if (!index(o->client_name, '.')) {
-				char *client_name = calloc(1, strlen("client.") +
-							strlen(o->client_name) + 1);
+				client_name = calloc(1, strlen("client.") +
+						    strlen(o->client_name) + 1);
 				strcat(client_name, "client.");
-				o->client_name = strcat(client_name, o->client_name);
+				strcat(client_name, o->client_name);
+			} else {
+				client_name = o->client_name;
 			}
 
 			r = rados_create2(&rbd->cluster, o->cluster_name,
-					o->client_name, 0);
+					client_name, 0);
+
+			if (!index(o->client_name, '.'))
+				free(client_name);
 		} else {
 			log_err("clientname is missing.\n");
 			goto failed_early;

--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -128,21 +128,25 @@ static int _fio_rbd_connect(struct thread_data *td)
 	int r;
 
 	if (o->cluster_name) {
-		char *client_name = NULL; 
-
 		/*
 		 * If we specify cluser name, the rados_creat2
 		 * will not assume 'client.'. name is considered
 		 * as a full type.id namestr
 		 */
-		if (!index(o->client_name, '.')) {
-			client_name = calloc(1, strlen("client.") +
-						strlen(o->client_name) + 1);
-			strcat(client_name, "client.");
-			o->client_name = strcat(client_name, o->client_name);
-		}
-		r = rados_create2(&rbd->cluster, o->cluster_name,
+		if (o->client_name) {
+			if (!index(o->client_name, '.')) {
+				char *client_name = calloc(1, strlen("client.") +
+							strlen(o->client_name) + 1);
+				strcat(client_name, "client.");
+				o->client_name = strcat(client_name, o->client_name);
+			}
+
+			r = rados_create2(&rbd->cluster, o->cluster_name,
 					o->client_name, 0);
+		} else {
+			log_err("clientname is missing.\n");
+			goto failed_early;
+		}
 	} else
 		r = rados_create(&rbd->cluster, o->client_name);
 	


### PR DESCRIPTION
For the segmentation fault issue:
Fio with rbd engine will panic if clustername option is specified but
clientname is not. In that case, o->client_name will be a NULL pointer,
strlen(o->client_name) in _fio_rbd_connect() will lead to a segmentation
fault.

For the memory leak issue:
When running fio with rbd engine and specifying clustername, a piece of
memory will be allocated in _fio_rbd_connect(), but it never gets freed.