### PR TITLE
Fix segmentation fault and memory leak issue in rbd engine

### DIFF
--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -131,15 +131,18 @@ static int _fio_rbd_connect(struct thread_data *td)
 		char *client_name = NULL; 
 
 		/*
-		 * If we specify cluser name, the rados_creat2
+		 * If we specify cluser name, the rados_create2
 		 * will not assume 'client.'. name is considered
 		 * as a full type.id namestr
 		 */
-		if (!index(o->client_name, '.')) {
-			client_name = calloc(1, strlen("client.") +
-						strlen(o->client_name) + 1);
-			strcat(client_name, "client.");
-			o->client_name = strcat(client_name, o->client_name);
+		if (o->client_name) {
+			if (!index(o->client_name, '.')) {
+				client_name = calloc(1, strlen("client.") +
+						    strlen(o->client_name) + 1);
+				strcat(client_name, "client.");
+				o->client_name = strcat(client_name,
+							o->client_name);
+			}
 		}
 		r = rados_create2(&rbd->cluster, o->cluster_name,
 					o->client_name, 0);

--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -140,12 +140,17 @@ static int _fio_rbd_connect(struct thread_data *td)
 				client_name = calloc(1, strlen("client.") +
 						    strlen(o->client_name) + 1);
 				strcat(client_name, "client.");
-				o->client_name = strcat(client_name,
-							o->client_name);
+				strcat(client_name, o->client_name);
+			} else {
+				client_name = o->client_name;
 			}
 		}
+
 		r = rados_create2(&rbd->cluster, o->cluster_name,
-					o->client_name, 0);
+				 client_name, 0);
+
+		if (client_name && !index(o->client_name, '.'))
+			free(client_name);
 	} else
 		r = rados_create(&rbd->cluster, o->client_name);
 	


### PR DESCRIPTION
For segmentation fault issue:
Fio with rbd engine will panic if clustername option is specified but clientname
is not. In that case, o->client_name will be a NULL pointer, strlen(o->client_name) in _fio_rbd_connect() will lead to the segmentation fault.

For memory leak issue:
When running fio with rbd engine and specifying clustername, a piece of
memory will be allocated in _fio_rbd_connect(), but it never gets freed.