### PR TITLE
Fix overflow caused by signed long division by unsigned long.

### DIFF
--- a/gettime.c
+++ b/gettime.c
@@ -424,8 +424,8 @@ uint64_t mtime_since(const struct timeval *s, const struct timeval *e)
 	if (sec < 0 || (sec == 0 && usec < 0))
 		return 0;
 
-	sec *= 1000UL;
-	usec /= 1000UL;
+	sec *= 1000;
+	usec /= 1000;
 	ret = sec + usec;
 
 	return ret;


### PR DESCRIPTION
I have been following issue ( #183 ), and found the root cause.
If the value of 'log_avg_msec' is relatively large (maybe greater than 1000), the computed interval time in _mtime_since_ overflows.Then the values of bw and IOPS are set to zero by the overflow. 
I confirmed this fix have resoloved the issue ( #183 ). 