### PR TITLE
Make histogram samples non-cumulative

### DIFF
--- a/iolog.c
+++ b/iolog.c
@@ -576,6 +576,9 @@ void setup_log(struct io_log **log, struct log_params *p,
 	       const char *filename)
 {
 	struct io_log *l;
+	int i;
+	struct io_u_plat_entry *entry;
+	struct flist_head *list;
 
 	l = scalloc(1, sizeof(*l));
 	INIT_FLIST_HEAD(&l->io_logs);
@@ -588,6 +591,16 @@ void setup_log(struct io_log **log, struct log_params *p,
 	l->hist_coarseness = p->hist_coarseness;
 	l->filename = strdup(filename);
 	l->td = p->td;
+
+	/* Initialize histogram lists for each r/w direction,
+	 * with initial io_u_plat of all zeros:
+	 */
+	for (i = 0; i < DDIR_RWDIR_CNT; i++) {
+		list = &l->hist_window[i].list.list;
+		INIT_FLIST_HEAD(list);
+		entry = calloc(1, sizeof(struct io_u_plat_entry));
+		flist_add(&entry->list, list);
+	}
 
 	if (l->td && l->td->o.io_submit_mode != IO_MODE_OFFLOAD) {
 		struct io_logs *p;
@@ -661,13 +674,14 @@ void free_log(struct io_log *log)
 	sfree(log);
 }
 
-static inline unsigned long hist_sum(int j, int stride, unsigned int *io_u_plat)
+static inline unsigned long hist_sum(int j, int stride, unsigned int *io_u_plat,
+		unsigned int *io_u_plat_last)
 {
 	unsigned long sum;
 	int k;
 
 	for (k = sum = 0; k < stride; k++)
-		sum += io_u_plat[j + k];
+		sum += io_u_plat[j + k] - io_u_plat_last[j + k];
 
 	return sum;
 }
@@ -678,7 +692,9 @@ void flush_hist_samples(FILE *f, int hist_coarseness, void *samples,
 	struct io_sample *s;
 	int log_offset;
 	uint64_t i, j, nr_samples;
+	struct io_u_plat_entry *entry, *entry_before;
 	unsigned int *io_u_plat;
+	unsigned int *io_u_plat_before;
 
 	int stride = 1 << hist_coarseness;
 	
@@ -692,15 +708,24 @@ void flush_hist_samples(FILE *f, int hist_coarseness, void *samples,
 
 	for (i = 0; i < nr_samples; i++) {
 		s = __get_sample(samples, log_offset, i);
-		io_u_plat = (unsigned int *) (uintptr_t) s->val;
+		
+		entry = (struct io_u_plat_entry *) s->val;
+		io_u_plat = entry->io_u_plat;
+		
+		entry_before = flist_first_entry(&entry->list, struct io_u_plat_entry, list);
+		io_u_plat_before = entry_before->io_u_plat;
+		
 		fprintf(f, "%lu, %u, %u, ", (unsigned long)s->time,
 		        io_sample_ddir(s), s->bs);
 		for (j = 0; j < FIO_IO_U_PLAT_NR - stride; j += stride) {
-			fprintf(f, "%lu, ", hist_sum(j, stride, io_u_plat));
+			fprintf(f, "%lu, ", hist_sum(j, stride, io_u_plat, io_u_plat_before));
 		}
 		fprintf(f, "%lu\n", (unsigned long) 
-		        hist_sum(FIO_IO_U_PLAT_NR - stride, stride, io_u_plat));
-		free(io_u_plat);
+		        hist_sum(FIO_IO_U_PLAT_NR - stride, stride, io_u_plat,
+		                 io_u_plat_before));
+		
+		flist_del(&entry_before->list);
+		free(entry_before);
 	}
 }
 

--- a/iolog.h
+++ b/iolog.h
@@ -18,9 +18,14 @@ struct io_stat {
 	fio_fp64_t S;
 };
 
+struct io_u_plat_list {
+	struct flist_head list;
+};
+
 struct io_hist {
 	uint64_t samples;
 	unsigned long hist_last;
+	struct io_u_plat_list list;
 };
 
 /*

--- a/stat.c
+++ b/stat.c
@@ -2221,7 +2221,7 @@ void add_clat_sample(struct thread_data *td, enum fio_ddir ddir,
 		
 		if (this_window >= iolog->hist_msec) {
 			unsigned int *io_u_plat;
-			unsigned int *dst;
+			struct io_u_plat_entry *dst;
 
 			/*
 			 * Make a byte-for-byte copy of the latency histogram
@@ -2231,10 +2231,11 @@ void add_clat_sample(struct thread_data *td, enum fio_ddir ddir,
 			 * log file.
 			 */
 			io_u_plat = (unsigned int *) td->ts.io_u_plat[ddir];
-			dst = malloc(FIO_IO_U_PLAT_NR * sizeof(unsigned int));
-			memcpy(dst, io_u_plat,
+			dst = malloc(sizeof(struct io_u_plat_entry));
+			memcpy(&(dst->io_u_plat), io_u_plat,
 				FIO_IO_U_PLAT_NR * sizeof(unsigned int));
-			__add_log_sample(iolog, (unsigned long )dst, ddir, bs,
+			flist_add(&dst->list, &hw->list.list);
+			__add_log_sample(iolog, (unsigned long)dst, ddir, bs,
 						elapsed, offset);
 
 			/*

--- a/stat.h
+++ b/stat.h
@@ -240,6 +240,11 @@ struct jobs_eta {
 	uint8_t run_str[];
 } __attribute__((packed));
 
+struct io_u_plat_entry {
+	struct flist_head list;
+	unsigned int io_u_plat[FIO_IO_U_PLAT_NR];
+};
+
 extern struct fio_mutex *stat_mutex;
 
 extern struct jobs_eta *get_jobs_eta(bool force, size_t *size);


### PR DESCRIPTION
by tracking a linked-list of the most recent histogram and differencing it when we print to the log file(s). Linked list of pointers used to minimize runtime impact on recording side, instead choosing to do subtraction on the logging (when logs get printed to file) side.

This helps cleanup `fiologparser_hist.py`, makes the log files easier to understand at a glance (the frequencies correspond to just that interval), reduces file size(s), and averts the possibility of integer overflow in the logs (for a long enough fio job).

I couldn't get the existing linked list implementation to work for me (`flist.h`), but I can try again / rework this to use that if that's preferred. All I needed was a write-once, read-once singly-linked list.