### PR TITLE
generate unique pathname for each fio --client log file

### DIFF
--- a/client.c
+++ b/client.c
@@ -1294,7 +1294,7 @@ static int fio_client_handle_iolog(struct fio_client *client,
 {
 	struct cmd_iolog_pdu *pdu;
 	bool store_direct;
-	char * log_pathname;
+	char *log_pathname;
 
 	pdu = convert_iolog(cmd, &store_direct);
 	if (!pdu) {

--- a/client.c
+++ b/client.c
@@ -1302,12 +1302,15 @@ static int fio_client_handle_iolog(struct fio_client *client,
 		return 1;
 	}
 
-	/* generate a unique pathname for the log file using hostname */
-	log_pathname = malloc(PATH_MAX+10);
+        /* allocate buffer big enough for next sprintf() call */
+	log_pathname = malloc( 10 + 
+			strlen((char * )pdu->name) + 
+			strlen(client->hostname));
 	if (!log_pathname) {
 		log_err("fio: memory allocation of unique pathname failed");
 		return -1;
 	}
+	/* generate a unique pathname for the log file using hostname */
 	sprintf(log_pathname, "%s.%s", pdu->name, client->hostname);
 
 	if (store_direct) {


### PR DESCRIPTION
fio --client implementation in client.c is not yet generating log filenames that are unique across hosts.  This fix simply appends .hostname to the pathname.  It also logs the filename if there is an error opening the logfile.  It does not affect filename at all unless --client is used.