### PR TITLE
iolog: add support for 'replay_scale'

### DIFF
--- a/blktrace.c
+++ b/blktrace.c
@@ -221,7 +221,7 @@ static void ipo_bytes_align(struct thread_options *o, struct io_piece *ipo)
 	if (!o->replay_align)
 		return;
 
-	ipo->offset &= ~(o->replay_align - 1);
+	ipo->offset &= ~(o->replay_align - (uint64_t)1);
 }
 
 

--- a/blktrace.c
+++ b/blktrace.c
@@ -216,15 +216,6 @@ static void t_bytes_align(struct thread_options *o, struct blk_io_trace *t)
 	t->bytes = (t->bytes + o->replay_align - 1) & ~(o->replay_align - 1);
 }
 
-static void ipo_bytes_align(struct thread_options *o, struct io_piece *ipo)
-{
-	if (!o->replay_align)
-		return;
-
-	ipo->offset &= ~(o->replay_align - (uint64_t)1);
-}
-
-
 /*
  * Store blk_io_trace data in an ipo for later retrieval.
  */
@@ -239,7 +230,7 @@ static void store_ipo(struct thread_data *td, unsigned long long offset,
 	ipo->offset = offset * bs;
 	if (td->o.replay_scale)
 		ipo->offset = ipo->offset / td->o.replay_scale;
-	ipo_bytes_align(&td->o, ipo);
+	ipo_bytes_align(td->o.replay_align, ipo);
 	ipo->len = bytes;
 	ipo->delay = ttime / 1000;
 	if (rw)
@@ -297,7 +288,7 @@ static void handle_trace_discard(struct thread_data *td,
 	ipo->offset = t->sector * bs;
 	if (td->o.replay_scale)
 		ipo->offset = ipo->offset / td->o.replay_scale;
-	ipo_bytes_align(&td->o, ipo);
+	ipo_bytes_align(td->o.replay_align, ipo);
 	ipo->len = t->bytes;
 	ipo->delay = ttime / 1000;
 	ipo->ddir = DDIR_TRIM;

--- a/iolog.c
+++ b/iolog.c
@@ -454,7 +454,12 @@ static int read_iolog2(struct thread_data *td, FILE *f)
 		if (rw == DDIR_WAIT) {
 			ipo->delay = offset;
 		} else {
-			ipo->offset = offset;
+			if (td->o.replay_scale)
+				ipo->offset = offset / td->o.replay_scale;
+			else
+				ipo->offset = offset;
+			ipo_bytes_align(td->o.replay_align, ipo);
+
 			ipo->len = bytes;
 			if (rw != DDIR_INVAL && bytes > td->o.max_bs[rw])
 				td->o.max_bs[rw] = bytes;

--- a/iolog.h
+++ b/iolog.h
@@ -269,6 +269,14 @@ static inline bool inline_log(struct io_log *log)
 		log->log_type == IO_LOG_TYPE_SLAT;
 }
 
+static inline void ipo_bytes_align(unsigned int replay_align, struct io_piece *ipo)
+{
+	if (replay_align)
+		return;
+
+	ipo->offset &= ~(replay_align - (uint64_t)1);
+}
+
 extern void finalize_logs(struct thread_data *td, bool);
 extern void setup_log(struct io_log **, struct log_params *, const char *);
 extern void flush_log(struct io_log *, bool);


### PR DESCRIPTION
Example patch for adding replay scaling to iolog replay and also fixes up a 64 bit number truncation issue in `iolog.c` too.

Not really a final version but more to get comment/ideas on how to add this in such a way that  `ipo_bytes_align()` can also be shared between `blktrace.c` and `iolog.c`.
