### PR TITLE
Fix memory leak on tmp_buf

### DIFF
--- a/oslib/libmtd.c
+++ b/oslib/libmtd.c
@@ -1116,6 +1116,7 @@ static int legacy_auto_oob_layout(const struct mtd_dev_info *mtd, int fd,
 		len = mtd->oob_size - start;
 		memcpy(oob + start, tmp_buf + start, len);
 	}
+	free(tmp_buf);
 
 	return 0;
 }


### PR DESCRIPTION
tmp_buf is allocated but not free'd, causing a minor memory leak

Signed-off-by: Colin Ian King <colin.king@canonical.com>