### PR TITLE
Improve informativeness about directIO support or rather lackthereof on Solaris when errno is set to ENOTTY

### DIFF
--- a/ioengines.c
+++ b/ioengines.c
@@ -483,7 +483,12 @@ int td_io_open_file(struct thread_data *td, struct fio_file *f)
 
 		if (ret) {
 			td_verror(td, ret, "fio_set_odirect");
-			log_err("fio: the file system does not seem to support direct IO\n");
+			if (ret == ENOTTY) { /* ENOTTY suggests RAW device or ZFS */
+				log_err("fio: doing directIO to RAW devices or ZFS not supported\n");
+			} else {
+				log_err("fio: the file system does not seem to support direct IO\n");
+			}
+
 			goto err;
 		}
 	}


### PR DESCRIPTION
I don't know if this is something that really will be beneficial to all, but I felt for my own uses and that of my peers at RackTop this is a better reminder than the more generic message. Hopefully you will see it as generally useful.