### PR TITLE
doc: fix man page headings

### DIFF
--- a/doc/fio_man.rst
+++ b/doc/fio_man.rst
@@ -1,9 +1,7 @@
 :orphan:
 
-
-
-(rev. |release|)
-
+fio - Flexible I/O tester
+=========================
 
 .. include:: ../README
 


### PR DESCRIPTION
Sphinx skips over the top level heading when generating man page output
so add a top level heading for it to skip over and skip showing version
information.