### PR TITLE
fix manpage heading issue

### DIFF
--- a/doc/fio_man.rst
+++ b/doc/fio_man.rst
@@ -1,6 +1,7 @@
 :orphan:
 
-
+Fio Manpage
+===========
 
 (rev. |release|)
 


### PR DESCRIPTION
Sphinx skips zero level headins when generating manpages.
Increasing sections depth solves missing headers problem.