### PR TITLE
iolog replay_align fix

### DIFF
--- a/iolog.h
+++ b/iolog.h
@@ -271,7 +271,7 @@ static inline bool inline_log(struct io_log *log)
 
 static inline void ipo_bytes_align(unsigned int replay_align, struct io_piece *ipo)
 {
-	if (replay_align)
+	if (!replay_align)
 		return;
 
 	ipo->offset &= ~(replay_align - (uint64_t)1);


### PR DESCRIPTION
The previous code was immediately returning on a positive alignment value, and accepting only alignment to zero.

I believe this should be doing the opposite.
