### PR TITLE
Add make test and add OSX builds to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: c
+os:
+  - linux
 compiler:
   - clang
   - gcc
@@ -6,5 +8,5 @@ env:
   global:
     - MAKEFLAGS="-j 2"
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -qq -y libaio-dev libnuma-dev libz-dev
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq -y libaio-dev libnuma-dev libz-dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: c
 compiler:
   - clang
   - gcc
+env:
+  global:
+    - MAKEFLAGS="-j 2"
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -qq -y libaio-dev libnuma-dev libz-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,22 @@ compiler:
 env:
   global:
     - MAKEFLAGS="-j 2"
+matrix:
+  include:
+    - os: osx
+      compiler: clang # Workaround travis setting CC=["clang", "gcc"]
+    # Build using the 10.12 SDK but target and run on OSX 10.11
+#   - os: osx
+#     compiler: clang
+#     osx_image: xcode8
+#     env: SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk MACOSX_DEPLOYMENT_TARGET=10.11
+    # Build on the latest OSX version (will eventually become obsolete)
+    - os: osx
+      compiler: clang
+      osx_image: xcode8.2
+  exclude:
+    - os: osx
+      compiler: gcc
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq -y libaio-dev libnuma-dev libz-dev; fi

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ endif
 
 all: $(PROGS) $(T_TEST_PROGS) $(SCRIPTS) FORCE
 
-.PHONY: all install clean
+.PHONY: all install clean test
 .PHONY: FORCE cscope
 
 FIO-VERSION-FILE: FORCE
@@ -448,7 +448,8 @@ doc: tools/plot/fio2gnuplot.1
 	@man -t tools/plot/fio2gnuplot.1 | ps2pdf - fio2gnuplot.pdf
 	@man -t tools/hist/fiologparser_hist.py.1 | ps2pdf - fiologparser_hist.pdf
 
-test:
+test: fio
+	./fio --minimal --ioengine=null --runtime=1s --name=nulltest --rw=randrw --iodepth=2 --norandommap --random_generator=tausworthe64 --size=16T --name=verifynulltest --rw=write --verify=crc32c --verify_state_save=0 --size=100M
 
 install: $(PROGS) $(SCRIPTS) tools/plot/fio2gnuplot.1 FORCE
 	$(INSTALL) -m 755 -d $(DESTDIR)$(bindir)


### PR DESCRIPTION
- Add a "test" target to the Makefile which runs two simultaneous null ioengine jobs for a short time.
- Make travis run two parallel make jobs letting it finish faster.
- Add two OSX builds to travis (with a third build commented out). This is slightly controversial because at peak time travis is heavily backed up with OSX builds from other projects. This can mean the travis results don't return in the usual less than 4 minutes but can instead take up to 2 hours(!) because while the Linux jobs were scheduled quickly the OSX ones weren't. If this sounds problematic, perhaps I can rework this commit to just comment out the travis OSX builds...