### PR TITLE
Verify warn

### DIFF
--- a/init.c
+++ b/init.c
@@ -731,9 +731,14 @@ static int fixup_options(struct thread_data *td)
 		o->size = -1ULL;
 
 	if (o->verify != VERIFY_NONE) {
-		if (td_write(td) && o->do_verify && o->numjobs > 1) {
-			log_info("Multiple writers may overwrite blocks that "
-				"belong to other jobs. This can cause "
+		if (td_write(td) && o->do_verify && o->numjobs > 1 &&
+		    (o->filename ||
+		     !(o->unique_filename &&
+		       strstr(o->filename_format, "$jobname") &&
+		       strstr(o->filename_format, "$jobnum") &&
+		       strstr(o->filename_format, "$filenum")))) {
+			log_info("fio: multiple writers may overwrite blocks "
+				"that belong to other jobs. This can cause "
 				"verification failures.\n");
 			ret = warnings_fatal;
 		}

--- a/init.c
+++ b/init.c
@@ -743,6 +743,18 @@ static int fixup_options(struct thread_data *td)
 			ret = warnings_fatal;
 		}
 
+		/*
+		 * Warn if verification is requested but no verification of any
+		 * kind can be started due to time constraints
+		 */
+		if (td_write(td) && o->do_verify && o->timeout &&
+		    o->time_based && !td_read(td) && !o->verify_backlog) {
+			log_info("fio: verification read phase will never "
+				 "start because write phase uses all of "
+				 "runtime\n");
+			ret = warnings_fatal;
+		}
+
 		if (!fio_option_is_set(o, refill_buffers))
 			o->refill_buffers = 1;
 


### PR DESCRIPTION
Try to make the "multiple jobs overwriting same file" warning more specific to address https://github.com/axboe/fio/issues/303 and add a new warning about the verify phase not running when using runtime + time_based (see https://github.com/axboe/fio/issues/187#issuecomment-223633831 and https://www.spinics.net/lists/fio/msg04990.html ).

These commits are kind of for review: for example if the user is using rw=rw / rw=randrw with their verify they may also get inline verifies because if at the point an area is read if it matches an area previously written by the same job it is verified. I wasn't sure if the skipping the warning in this situation when the user has asked for do_verify was worth it...
