### PR TITLE
appveyor: add CI building of the Windows version of fio

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+clone_depth: 50
+environment:
+  MAKEFLAGS: -j 2
+  matrix:
+    - platform: x86_64
+      BUILD_ARCH: x64
+      CYG_ROOT: C:\cygwin64
+      CONFIGURE_OPTIONS:
+    - platform: x86
+      BUILD_ARCH: x86
+      CYG_ROOT: C:\cygwin
+      CONFIGURE_OPTIONS: --build-32bit-win
+
+build_script:
+  - SET PATH=%CYG_ROOT%\bin;%PATH%
+  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && ./configure ${CONFIGURE_OPTIONS} && make.exe'
+
+after_build:
+  - cd os\windows && dobuild.cmd %BUILD_ARCH%
+
+test_script:
+  - SET PATH=%CYG_ROOT%\bin;%PATH%
+  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && file.exe fio.exe && make.exe test'
+
+artifacts:
+  - path: os\windows\*.msi
+    name: msi


### PR DESCRIPTION
Add AppVeyor (https://www.appveyor.com/ )  continuous integration build of the Windows port (you'll need an AppVeyor account to get going) . The 64 bit and 32 bit versions of the Window's binary are currently built. This also builds the Windows installer and the resulting MSI can be downloaded. Example output can be seen on https://github.com/sitsofe/fio/commits/appveyor and https://ci.appveyor.com/project/sitsofe/fio/build/1.0.37/job/c3i3jw3ug8bdt5pq . At the moment builds seem to be scheduled in under a minute.

Note that AppVeyor limits you to one build at a time but each build seems to finish after about one minute so the total time to get a result is about 3 minutes.