### PR TITLE
make the bs info output clearer.

### DIFF
--- a/init.c
+++ b/init.c
@@ -1534,10 +1534,10 @@ static int add_job(struct thread_data *td, const char *jobname, int job_add_num,
 							ddir_str(o->td_ddir));
 
 				if (o->bs_is_seq_rand)
-					log_info("bs=%s-%s,%s-%s, bs_is_seq_rand, ",
+					log_info("bs=(R) %s-%s, (W) %s-%s, bs_is_seq_rand, ",
 							c1, c2, c3, c4);
 				else
-					log_info("bs=%s-%s,%s-%s,%s-%s, ",
+					log_info("bs=(R) %s-%s, (W) %s-%s, (T) %s-%s, ",
 							c1, c2, c3, c4, c5, c6);
 
 				log_info("ioengine=%s, iodepth=%u\n",


### PR DESCRIPTION
The current log is:
file1: (g=0): rw=randread, bs=128KiB-128KiB,128KiB-128KiB,128KiB-128KiB, ioengine=libaio, iodepth=4
the value after bs may makes the user confused.

My changes:
file1: (g=0): rw=randread, bs=(r)128KiB-128KiB, (w)128KiB-128KiB, (t)128KiB-128KiB, ioengine=libaio, iodepth=4