### PR TITLE
Return non-negtive error in order to print right error msg

### DIFF
--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -290,7 +290,7 @@ static void _fio_rbd_finish_aiocb(rbd_completion_t comp, void *data)
 	 */
 	ret = rbd_aio_get_return_value(fri->completion);
 	if (ret < 0) {
-		io_u->error = ret;
+		io_u->error = -ret;
 		io_u->resid = io_u->xfer_buflen;
 	} else
 		io_u->error = 0;
@@ -524,7 +524,7 @@ static int fio_rbd_queue(struct thread_data *td, struct io_u *io_u)
 failed_comp:
 	rbd_aio_release(fri->completion);
 failed:
-	io_u->error = r;
+	io_u->error = -r;
 	td_verror(td, io_u->error, "xfer");
 	return FIO_Q_COMPLETED;
 }


### PR DESCRIPTION
When an op from librbd returns ETIMEOUT(110), fio reports "Unknown error":
```
fio: io_u error on file rbd_iodepth32.0.0: Unknown error -110: write offset=31948800, buflen=4096
fio: pid=1859, err=-110/file:io_u.c:1711, func=io_u error, error=Unknown error -110
```

It is caused by strerror, which cannot handle a negtive input.  After my modification, the output is:
```
fio: io_u error on file rbd_iodepth32.0.0: Connection timed out: write offset=24109056, buflen=4096
fio: pid=15397, err=110/file:io_u.c:1711, func=io_u error, error=Connection timed out
```

Signed-off-by: Pan Liu <liupan1111@gmail.com>