### PR TITLE
Warn when we know an iodepth > 1 can never be reached

### DIFF
--- a/engines/null.c
+++ b/engines/null.c
@@ -149,7 +149,7 @@ void get_ioengine(struct ioengine_ops **ioengine_ptr)
 	ioengine.init           = fio_null_init;
 	ioengine.cleanup        = fio_null_cleanup;
 	ioengine.open_file      = fio_null_open;
-	ioengine.flags          = FIO_DISKLESSIO | FIO_FAKEIO;
+	ioengine.flags          = FIO_DISKLESSIO | FIO_FAKEIO | FIO_SUBMITMANY;
 }
 }
 #endif /* FIO_EXTERNAL_ENGINE */

--- a/engines/sg.c
+++ b/engines/sg.c
@@ -821,7 +821,7 @@ static struct ioengine_ops ioengine = {
 	.open_file	= fio_sgio_open,
 	.close_file	= generic_close_file,
 	.get_file_size	= fio_sgio_get_file_size,
-	.flags		= FIO_SYNCIO | FIO_RAWIO,
+	.flags		= FIO_SYNCIO | FIO_RAWIO | FIO_SUBMITMANY,
 };
 
 #else /* FIO_HAVE_SGIO */

--- a/engines/sync.c
+++ b/engines/sync.c
@@ -412,7 +412,7 @@ static struct ioengine_ops ioengine_vrw = {
 	.open_file	= generic_open_file,
 	.close_file	= generic_close_file,
 	.get_file_size	= generic_get_file_size,
-	.flags		= FIO_SYNCIO,
+	.flags		= FIO_SYNCIO | FIO_SUBMITMANY,
 };
 
 #ifdef CONFIG_PWRITEV

--- a/fio.h
+++ b/fio.h
@@ -596,7 +596,8 @@ static inline enum fio_ioengine_flags td_ioengine_flags(struct thread_data *td)
 
 static inline void td_set_ioengine_flags(struct thread_data *td)
 {
-	td->flags |= (td->io_ops->flags << TD_ENG_FLAG_SHIFT);
+	td->flags = (~(TD_ENG_FLAG_MASK << TD_ENG_FLAG_SHIFT) & td->flags) |
+		    (td->io_ops->flags << TD_ENG_FLAG_SHIFT);
 }
 
 static inline bool td_ioengine_flagged(struct thread_data *td,

--- a/ioengines.h
+++ b/ioengines.h
@@ -59,6 +59,7 @@ enum fio_ioengine_flags {
 	FIO_MEMALIGN	= 1 << 9,	/* engine wants aligned memory */
 	FIO_BIT_BASED	= 1 << 10,	/* engine uses a bit base (e.g. uses Kbit as opposed to KB) */
 	FIO_FAKEIO	= 1 << 11,	/* engine pretends to do IO */
+	FIO_SUBMITMANY	= 1 << 12,	/* engine can submit multiple I/Os (auto set on async engines) */
 };
 
 /*


### PR DESCRIPTION
This pull request fixes up a small bug where bits weren't cleared in td_set_ioengine_flags and adds a warning that the requested iodepth can't be reached by the specified I/O engine e.g.:

```
fio: iodepth=32 but psync IO engine can't submit more than one I/O at a time
```