### PR TITLE
fio.h: zero old flag bits when setting new ioengine flags

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -596,7 +596,8 @@ static inline enum fio_ioengine_flags td_ioengine_flags(struct thread_data *td)
 
 static inline void td_set_ioengine_flags(struct thread_data *td)
 {
-	td->flags |= (td->io_ops->flags << TD_ENG_FLAG_SHIFT);
+	td->flags = (~(TD_ENG_FLAG_MASK << TD_ENG_FLAG_SHIFT) & td->flags) |
+		    (td->io_ops->flags << TD_ENG_FLAG_SHIFT);
 }
 
 static inline bool td_ioengine_flagged(struct thread_data *td,


### PR DESCRIPTION
Fix a small bug in td_set_ioengine_flags() where it wouldn't zero old
bits in td->flags before setting new flag bits.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>