### PR TITLE
remove redundant _fio_rbd_disconnect, which is already called in fio_rbd_cleanup

### DIFF
--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -597,11 +597,11 @@ static int fio_rbd_setup(struct thread_data *td)
 	r = rbd_stat(rbd->image, &info, sizeof(info));
 	if (r < 0) {
 		log_err("rbd_status failed.\n");
-		goto disconnect;
+		goto cleanup;
 	} else if (info.size == 0) {
 		log_err("image size should be larger than zero.\n");
 		r = -EINVAL;
-		goto disconnect;
+		goto cleanup;
 	}
 
 	dprint(FD_IO, "rbd-engine: image size: %lu\n", info.size);
@@ -620,8 +620,6 @@ static int fio_rbd_setup(struct thread_data *td)
 
 	return 0;
 
-disconnect:
-	_fio_rbd_disconnect(rbd);
 cleanup:
 	fio_rbd_cleanup(td);
 	return r;

--- a/engines/rbd.c
+++ b/engines/rbd.c
@@ -618,9 +618,6 @@ static int fio_rbd_setup(struct thread_data *td)
 	f = td->files[0];
 	f->real_file_size = info.size;
 
-	/* disconnect, then we were only connected to determine
-	 * the size of the RBD.
-	 */
 	return 0;
 
 disconnect:


### PR DESCRIPTION
Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>