### PR TITLE
iolog: fix use after free when two in-flight writes overlap

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -364,6 +364,7 @@ struct thread_data {
 	 */
 	struct rb_root io_hist_tree;
 	struct flist_head io_hist_list;
+	struct flist_head io_orphan_list;
 	unsigned long io_hist_len;
 
 	/*

--- a/iolog.h
+++ b/iolog.h
@@ -187,6 +187,7 @@ enum {
 	IP_F_ONLIST	= 2,
 	IP_F_TRIMMED	= 4,
 	IP_F_IN_FLIGHT	= 8,
+	IP_F_UNLOGGED   = 16,
 };
 
 /*

--- a/rate-submit.c
+++ b/rate-submit.c
@@ -116,6 +116,7 @@ static int io_workqueue_init_worker_fn(struct submit_worker *sw)
 	INIT_FLIST_HEAD(&td->verify_list);
 	INIT_FLIST_HEAD(&td->trim_list);
 	INIT_FLIST_HEAD(&td->next_rand_list);
+	INIT_FLIST_HEAD(&td->io_orphan_list);
 	td->io_hist_tree = RB_ROOT;
 
 	td->o.iodepth = 1;


### PR DESCRIPTION
(From the comment in https://github.com/axboe/fio/issues/336 )

This is an attempt to try and fix a use after free when an overlap is detected on an in-flight I/O in a way that doesn't just leak memory. It would be simpler to just have completion do the free but in the `io_submit_mode=offload` case completion can happen asynchronously in a different thread to the one that is running `log_io_piece()` and would be racy...

Even with this updated patch I think we actually need locking in `log_io_piece()` and other functions such as `unlog_io_piece()` in the  `io_submit_mode=offload` case to prevent an existing `__ipo` (and any structures it is in) being fiddled with while you're using them (`unlog_io_piece()` can change the rb tree and free an ipo when it is called due to I/O failure).