### PR TITLE
flist.h: replace offsetof macros by stddef.h include

### DIFF
--- a/configure
+++ b/configure
@@ -1930,16 +1930,7 @@ fi
 cat > $TMPC << EOF
 #include <assert.h>
 #include <stdlib.h>
-#undef offsetof
-#ifdef __compiler_offsetof
-#define offsetof(TYPE,MEMBER) __compiler_offsetof(TYPE,MEMBER)
-#else
-#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
-#endif
-
-#define container_of(ptr, type, member) ({			\
-	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
-	(type *)( (char *)__mptr - offsetof(type,member) );})
+#include <stddef.h>
 
 struct foo {
   int a, b;

--- a/flist.h
+++ b/flist.h
@@ -2,13 +2,7 @@
 #define _LINUX_FLIST_H
 
 #include <stdlib.h>
-
-#undef offsetof
-#ifdef __compiler_offsetof
-#define offsetof(TYPE,MEMBER) __compiler_offsetof(TYPE,MEMBER)
-#else
-#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
-#endif
+#include <stddef.h>
 
 #define container_of(ptr, type, member) ({			\
 	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\


### PR DESCRIPTION
`stddef.h` is provided by the compiler and has a builtin `offsetof` implementation if it is available. For instance, both GCC and Clang have the following (or very similar):
```C
#define offsetof(t, d) __builtin_offsetof(t, d)
```