### PR TITLE
Nanosecond timing for fio

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -3189,7 +3189,7 @@ Split up, the format is as follows:
 
         Total IO (KiB), bandwidth (KiB/sec), IOPS, runtime (msec)
         Submission latency: min, max, mean, stdev (usec)
-        Completion latency: min, max, mean, stdev(usec)
+        Completion latency: min, max, mean, stdev (usec)
         Completion latency percentiles: 20 fields (see below)
         Total latency: min, max, mean, stdev (usec)
         Bw (KiB/s): min, max, aggregate percentage of total, mean, stdev

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,9 @@ T_PIPE_ASYNC_PROGS = t/read-to-pipe-async
 T_MEMLOCK_OBJS = t/memlock.o
 T_MEMLOCK_PROGS = t/memlock
 
+T_TT_OBJS = t/time-test.o
+T_TT_PROGS = t/time-test
+
 T_OBJS = $(T_SMALLOC_OBJS)
 T_OBJS += $(T_IEEE_OBJS)
 T_OBJS += $(T_ZIPF_OBJS)
@@ -261,6 +264,7 @@ T_OBJS += $(T_DEDUPE_OBJS)
 T_OBJS += $(T_VS_OBJS)
 T_OBJS += $(T_PIPE_ASYNC_OBJS)
 T_OBJS += $(T_MEMLOCK_OBJS)
+T_OBJS += $(T_TT_OBJS)
 
 ifneq (,$(findstring CYGWIN,$(CONFIG_TARGET_OS)))
     T_DEDUPE_OBJS += os/windows/posix.o lib/hweight.o
@@ -433,6 +437,9 @@ t/fio-dedupe: $(T_DEDUPE_OBJS)
 
 t/fio-verify-state: $(T_VS_OBJS)
 	$(QUIET_LINK)$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $(T_VS_OBJS) $(LIBS)
+
+t/time-test: $(T_TT_OBJS)
+	$(QUIET_LINK)$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $(T_TT_OBJS) $(LIBS)
 
 clean: FORCE
 	@rm -f .depend $(FIO_OBJS) $(GFIO_OBJS) $(OBJS) $(T_OBJS) $(PROGS) $(T_PROGS) $(T_TEST_PROGS) core.* core gfio FIO-VERSION-FILE *.d lib/*.d oslib/*.d crc/*.d engines/*.d profiles/*.d t/*.d config-host.mak config-host.h y.tab.[ch] lex.yy.c exp/*.[do] lexer.h

--- a/client.c
+++ b/client.c
@@ -908,6 +908,8 @@ static void convert_ts(struct thread_stat *dst, struct thread_stat *src)
 		dst->io_u_complete[i]	= le32_to_cpu(src->io_u_complete[i]);
 	}
 
+	for (i = 0; i < FIO_IO_U_LAT_N_NR; i++)
+		dst->io_u_lat_n[i]	= le32_to_cpu(src->io_u_lat_n[i]);
 	for (i = 0; i < FIO_IO_U_LAT_U_NR; i++)
 		dst->io_u_lat_u[i]	= le32_to_cpu(src->io_u_lat_u[i]);
 	for (i = 0; i < FIO_IO_U_LAT_M_NR; i++)

--- a/crc/test.c
+++ b/crc/test.c
@@ -392,7 +392,7 @@ int fio_crctest(const char *type)
 	fill_random_buf(&state, buf, CHUNK);
 
 	for (i = 0; t[i].name; i++) {
-		struct timeval tv;
+		struct timespec ts;
 		double mb_sec;
 		uint64_t usec;
 		char pre[3];
@@ -409,9 +409,9 @@ int fio_crctest(const char *type)
 			t[i].fn(&t[i], buf, CHUNK);
 		}
 
-		fio_gettime(&tv, NULL);
+		fio_gettime(&ts, NULL);
 		t[i].fn(&t[i], buf, CHUNK);
-		usec = utime_since_now(&tv);
+		usec = utime_since_now(&ts);
 
 		if (usec) {
 			mb_sec = (double) mb / (double) usec;

--- a/diskutil.c
+++ b/diskutil.c
@@ -84,7 +84,7 @@ static int get_io_ticks(struct disk_util *du, struct disk_util_stat *dus)
 static void update_io_tick_disk(struct disk_util *du)
 {
 	struct disk_util_stat __dus, *dus, *ldus;
-	struct timeval t;
+	struct timespec t;
 
 	if (!du->users)
 		return;

--- a/diskutil.h
+++ b/diskutil.h
@@ -64,7 +64,7 @@ struct disk_util {
 	 */
 	struct flist_head slaves;
 
-	struct timeval time;
+	struct timespec time;
 
 	struct fio_mutex *lock;
 	unsigned long users;

--- a/engines/guasi.c
+++ b/engines/guasi.c
@@ -132,7 +132,7 @@ static void fio_guasi_queued(struct thread_data *td, struct io_u **io_us, int nr
 {
 	int i;
 	struct io_u *io_u;
-	struct timeval now;
+	struct timespec now;
 
 	if (!fio_fill_issue_time(td))
 		return;

--- a/engines/libaio.c
+++ b/engines/libaio.c
@@ -220,7 +220,7 @@ static int fio_libaio_queue(struct thread_data *td, struct io_u *io_u)
 static void fio_libaio_queued(struct thread_data *td, struct io_u **io_us,
 			      unsigned int nr)
 {
-	struct timeval now;
+	struct timespec now;
 	unsigned int i;
 
 	if (!fio_fill_issue_time(td))
@@ -241,7 +241,7 @@ static int fio_libaio_commit(struct thread_data *td)
 	struct libaio_data *ld = td->io_ops_data;
 	struct iocb **iocbs;
 	struct io_u **io_us;
-	struct timeval tv;
+	struct timespec ts;
 	int ret, wait_start = 0;
 
 	if (!ld->queued)
@@ -282,9 +282,9 @@ static int fio_libaio_commit(struct thread_data *td)
 				break;
 			}
 			if (!wait_start) {
-				fio_gettime(&tv, NULL);
+				fio_gettime(&ts, NULL);
 				wait_start = 1;
-			} else if (mtime_since_now(&tv) > 30000) {
+			} else if (mtime_since_now(&ts) > 30000) {
 				log_err("fio: aio appears to be stalled, giving up\n");
 				break;
 			}

--- a/engines/rdma.c
+++ b/engines/rdma.c
@@ -802,7 +802,7 @@ static void fio_rdmaio_queued(struct thread_data *td, struct io_u **io_us,
 			      unsigned int nr)
 {
 	struct rdmaio_data *rd = td->io_ops_data;
-	struct timeval now;
+	struct timespec now;
 	unsigned int i;
 
 	if (!fio_fill_issue_time(td))

--- a/eta.c
+++ b/eta.c
@@ -358,12 +358,12 @@ bool calc_thread_status(struct jobs_eta *je, int force)
 	uint64_t rate_time, disp_time, bw_avg_time, *eta_secs;
 	unsigned long long io_bytes[DDIR_RWDIR_CNT];
 	unsigned long long io_iops[DDIR_RWDIR_CNT];
-	struct timeval now;
+	struct timespec now;
 
 	static unsigned long long rate_io_bytes[DDIR_RWDIR_CNT];
 	static unsigned long long disp_io_bytes[DDIR_RWDIR_CNT];
 	static unsigned long long disp_io_iops[DDIR_RWDIR_CNT];
-	static struct timeval rate_prev_time, disp_prev_time;
+	static struct timespec rate_prev_time, disp_prev_time;
 
 	if (!force) {
 		if (!(output_format & FIO_OUTPUT_NORMAL) &&
@@ -511,7 +511,7 @@ bool calc_thread_status(struct jobs_eta *je, int force)
 
 void display_thread_status(struct jobs_eta *je)
 {
-	static struct timeval disp_eta_new_line;
+	static struct timespec disp_eta_new_line;
 	static int eta_new_line_init, eta_new_line_pending;
 	static int linelen_last;
 	static int eta_good;

--- a/fio.h
+++ b/fio.h
@@ -165,10 +165,10 @@ struct thread_data {
 	struct thread_data *parent;
 
 	uint64_t stat_io_bytes[DDIR_RWDIR_CNT];
-	struct timeval bw_sample_time;
+	struct timespec bw_sample_time;
 
 	uint64_t stat_io_blocks[DDIR_RWDIR_CNT];
-	struct timeval iops_sample_time;
+	struct timespec iops_sample_time;
 
 	volatile int update_rusage;
 	struct fio_mutex *rusage_sem;
@@ -287,7 +287,7 @@ struct thread_data {
 	unsigned long rate_bytes[DDIR_RWDIR_CNT];
 	unsigned long rate_blocks[DDIR_RWDIR_CNT];
 	unsigned long long rate_io_issue_bytes[DDIR_RWDIR_CNT];
-	struct timeval lastrate[DDIR_RWDIR_CNT];
+	struct timespec lastrate[DDIR_RWDIR_CNT];
 	int64_t last_usec[DDIR_RWDIR_CNT];
 	struct frand_state poisson_state[DDIR_RWDIR_CNT];
 
@@ -323,21 +323,21 @@ struct thread_data {
 	 */
 	struct frand_state random_state;
 
-	struct timeval start;	/* start of this loop */
-	struct timeval epoch;	/* time job was started */
+	struct timespec start;	/* start of this loop */
+	struct timespec epoch;	/* time job was started */
 	unsigned long long unix_epoch; /* Time job was started, unix epoch based. */
-	struct timeval last_issue;
+	struct timespec last_issue;
 	long time_offset;
-	struct timeval tv_cache;
-	struct timeval terminate_time;
-	unsigned int tv_cache_nr;
-	unsigned int tv_cache_mask;
+	struct timespec ts_cache;
+	struct timespec terminate_time;
+	unsigned int ts_cache_nr;
+	unsigned int ts_cache_mask;
 	unsigned int ramp_time_over;
 
 	/*
 	 * Time since last latency_window was started
 	 */
-	struct timeval latency_ts;
+	struct timespec latency_ts;
 	unsigned int latency_qd;
 	unsigned int latency_qd_high;
 	unsigned int latency_qd_low;
@@ -642,7 +642,7 @@ extern void reset_all_stats(struct thread_data *);
 
 extern int io_queue_event(struct thread_data *td, struct io_u *io_u, int *ret,
 		   enum fio_ddir ddir, uint64_t *bytes_issued, int from_verify,
-		   struct timeval *comp_time);
+		   struct timespec *comp_time);
 
 /*
  * Latency target helpers

--- a/fio_time.h
+++ b/fio_time.h
@@ -4,7 +4,8 @@
 #include "lib/types.h"
 
 struct thread_data;
-extern uint64_t utime_since(const struct timespec *,const  struct timespec *);
+extern uint64_t ntime_since(const struct timespec *, const struct timespec *);
+extern uint64_t utime_since(const struct timespec *, const struct timespec *);
 extern uint64_t utime_since_now(const struct timespec *);
 extern uint64_t mtime_since(const struct timespec *, const struct timespec *);
 extern uint64_t mtime_since_now(const struct timespec *);

--- a/fio_time.h
+++ b/fio_time.h
@@ -4,22 +4,23 @@
 #include "lib/types.h"
 
 struct thread_data;
-extern uint64_t utime_since(const struct timeval *,const  struct timeval *);
-extern uint64_t utime_since_now(const struct timeval *);
-extern uint64_t mtime_since(const struct timeval *, const struct timeval *);
-extern uint64_t mtime_since_now(const struct timeval *);
-extern uint64_t time_since_now(const struct timeval *);
+extern uint64_t utime_since(const struct timespec *,const  struct timespec *);
+extern uint64_t utime_since_now(const struct timespec *);
+extern uint64_t mtime_since(const struct timespec *, const struct timespec *);
+extern uint64_t mtime_since_now(const struct timespec *);
+extern uint64_t mtime_since_tv(const struct timeval *, const struct timeval *);
+extern uint64_t time_since_now(const struct timespec *);
 extern uint64_t time_since_genesis(void);
 extern uint64_t mtime_since_genesis(void);
 extern uint64_t utime_since_genesis(void);
 extern uint64_t usec_spin(unsigned int);
 extern uint64_t usec_sleep(struct thread_data *, unsigned long);
-extern void fill_start_time(struct timeval *);
+extern void fill_start_time(struct timespec *);
 extern void set_genesis_time(void);
 extern bool ramp_time_over(struct thread_data *);
 extern bool in_ramp_time(struct thread_data *);
 extern void fio_time_init(void);
-extern void timeval_add_msec(struct timeval *, unsigned int);
+extern void timespec_add_msec(struct timespec *, unsigned int);
 extern void set_epoch_time(struct thread_data *, int);
 
 #endif

--- a/gettime-thread.c
+++ b/gettime-thread.c
@@ -6,30 +6,30 @@
 #include "fio.h"
 #include "smalloc.h"
 
-struct timeval *fio_tv = NULL;
+struct timespec *fio_ts = NULL;
 int fio_gtod_offload = 0;
 static pthread_t gtod_thread;
 static os_cpu_mask_t fio_gtod_cpumask;
 
 void fio_gtod_init(void)
 {
-	if (fio_tv)
+	if (fio_ts)
 		return;
 
-	fio_tv = smalloc(sizeof(struct timeval));
-	if (!fio_tv)
+	fio_ts = smalloc(sizeof(*fio_ts));
+	if (!fio_ts)
 		log_err("fio: smalloc pool exhausted\n");
 }
 
 static void fio_gtod_update(void)
 {
-	if (fio_tv) {
+	if (fio_ts) {
 		struct timeval __tv;
 
 		gettimeofday(&__tv, NULL);
-		fio_tv->tv_sec = __tv.tv_sec;
+		fio_ts->tv_sec = __tv.tv_sec;
 		write_barrier();
-		fio_tv->tv_usec = __tv.tv_usec;
+		fio_ts->tv_nsec = __tv.tv_usec * 1000;
 		write_barrier();
 	}
 }

--- a/gettime.c
+++ b/gettime.c
@@ -380,6 +380,26 @@ void fio_clock_init(void)
 		log_info("fio: clocksource=cpu may not be reliable\n");
 }
 
+uint64_t ntime_since(const struct timespec *s, const struct timespec *e)
+{
+       int64_t sec, nsec;
+
+       sec = e->tv_sec - s->tv_sec;
+       nsec = e->tv_nsec - s->tv_nsec;
+       if (sec > 0 && nsec < 0) {
+               sec--;
+               nsec += 1000000000LL;
+       }
+
+       /*
+        * time warp bug on some kernels?
+        */
+       if (sec < 0 || (sec == 0 && nsec < 0))
+               return 0;
+
+       return nsec + (sec * 1000000000LL);
+}
+
 uint64_t utime_since(const struct timespec *s, const struct timespec *e)
 {
 	int64_t sec, usec;

--- a/gettime.c
+++ b/gettime.c
@@ -31,8 +31,6 @@ static unsigned int cycles_wrap;
 int tsc_reliable = 0;
 
 struct tv_valid {
-	uint64_t last_cycles;
-	int last_tv_valid;
 	int warned;
 };
 #ifdef ARCH_HAVE_CPU_CLOCK
@@ -198,9 +196,6 @@ static void __fio_gettime(struct timespec *tp)
 		nsecs = multiples * nsecs_for_max_cycles;
 		nsecs += ((t & max_cycles_mask) * clock_mult) >> clock_shift;
 #endif
-		tv->last_cycles = t;
-		tv->last_tv_valid = 1;
-
 		tp->tv_sec = nsecs / 1000000000ULL;
 		tp->tv_nsec = nsecs % 1000000000ULL;
 		break;

--- a/gettime.h
+++ b/gettime.h
@@ -13,27 +13,27 @@ enum fio_cs {
 	CS_INVAL,
 };
 
-extern void fio_gettime(struct timeval *, void *);
+extern void fio_gettime(struct timespec *, void *);
 extern void fio_gtod_init(void);
 extern void fio_clock_init(void);
 extern int fio_start_gtod_thread(void);
 extern int fio_monotonic_clocktest(int debug);
 extern void fio_local_clock_init(int);
 
-extern struct timeval *fio_tv;
+extern struct timespec *fio_ts;
 
-static inline int fio_gettime_offload(struct timeval *tv)
+static inline int fio_gettime_offload(struct timespec *ts)
 {
 	time_t last_sec;
 
-	if (!fio_tv)
+	if (!fio_ts)
 		return 0;
 
 	do {
 		read_barrier();
-		last_sec = tv->tv_sec = fio_tv->tv_sec;
-		tv->tv_usec = fio_tv->tv_usec;
-	} while (fio_tv->tv_sec != last_sec);
+		last_sec = ts->tv_sec = fio_ts->tv_sec;
+		ts->tv_nsec = fio_ts->tv_nsec;
+	} while (fio_ts->tv_sec != last_sec);
 
 	return 1;
 }

--- a/idletime.c
+++ b/idletime.c
@@ -11,7 +11,7 @@ static volatile struct idle_prof_common ipc;
 static double calibrate_unit(unsigned char *data)
 {
 	unsigned long t, i, j, k;
-	struct timeval tps;
+	struct timespec tps;
 	double tunit = 0.0;
 
 	for (i = 0; i < CALIBRATE_RUNS; i++) {
@@ -183,7 +183,6 @@ static void calibration_stats(void)
 void fio_idle_prof_init(void)
 {
 	int i, ret;
-	struct timeval tp;
 	struct timespec ts;
 	pthread_attr_t tattr;
 	struct idle_prof_thread *ipt;
@@ -282,9 +281,8 @@ void fio_idle_prof_init(void)
 		pthread_mutex_lock(&ipt->init_lock);
 		while ((ipt->state != TD_EXITED) &&
 		       (ipt->state!=TD_INITIALIZED)) {
-			fio_gettime(&tp, NULL);
-			ts.tv_sec = tp.tv_sec + 1;
-			ts.tv_nsec = tp.tv_usec * 1000;
+			fio_gettime(&ts, NULL);
+			ts.tv_sec += 1;
 			pthread_cond_timedwait(&ipt->cond, &ipt->init_lock, &ts);
 		}
 		pthread_mutex_unlock(&ipt->init_lock);
@@ -325,7 +323,6 @@ void fio_idle_prof_stop(void)
 {
 	int i;
 	uint64_t runt;
-	struct timeval tp;
 	struct timespec ts;
 	struct idle_prof_thread *ipt;
 
@@ -343,9 +340,8 @@ void fio_idle_prof_stop(void)
 		pthread_mutex_lock(&ipt->start_lock);
 		while ((ipt->state != TD_EXITED) &&
 		       (ipt->state!=TD_NOT_CREATED)) {
-			fio_gettime(&tp, NULL);
-			ts.tv_sec = tp.tv_sec + 1;
-			ts.tv_nsec = tp.tv_usec * 1000;
+			fio_gettime(&ts, NULL);
+			ts.tv_sec += 1;
 			/* timed wait in case a signal is not received */
 			pthread_cond_timedwait(&ipt->cond, &ipt->start_lock, &ts);
 		}

--- a/idletime.h
+++ b/idletime.h
@@ -26,8 +26,8 @@ struct idle_prof_thread {
 	pthread_t thread;
 	int cpu;
 	int state;
-	struct timeval tps;
-	struct timeval tpe;
+	struct timespec tps;
+	struct timespec tpe;
 	double cali_time; /* microseconds to finish a unit work */
 	double loops;
 	double idleness;

--- a/io_u.c
+++ b/io_u.c
@@ -20,7 +20,7 @@ struct io_completion_data {
 
 	int error;			/* output */
 	uint64_t bytes_done[DDIR_RWDIR_CNT];	/* output */
-	struct timeval time;		/* output */
+	struct timespec time;		/* output */
 };
 
 /*
@@ -1572,7 +1572,7 @@ static void small_content_scramble(struct io_u *io_u)
 		 * the buffer, given by the product of the usec time
 		 * and the actual offset.
 		 */
-		offset = (io_u->start_time.tv_usec ^ boffset) & 511;
+		offset = ((io_u->start_time.tv_nsec/1000) ^ boffset) & 511;
 		offset &= ~(sizeof(uint64_t) - 1);
 		if (offset >= 512 - sizeof(uint64_t))
 			offset -= sizeof(uint64_t);

--- a/io_u.c
+++ b/io_u.c
@@ -989,11 +989,52 @@ void io_u_mark_depth(struct thread_data *td, unsigned int nr)
 	td->ts.io_u_map[idx] += nr;
 }
 
-static void io_u_mark_lat_usec(struct thread_data *td, unsigned long usec)
+static void io_u_mark_lat_nsec(struct thread_data *td, unsigned long long nsec)
 {
 	int idx = 0;
 
-	assert(usec < 1000);
+	assert(nsec < 1000);
+
+	switch (nsec) {
+	case 750 ... 999:
+		idx = 9;
+		break;
+	case 500 ... 749:
+		idx = 8;
+		break;
+	case 250 ... 499:
+		idx = 7;
+		break;
+	case 100 ... 249:
+		idx = 6;
+		break;
+	case 50 ... 99:
+		idx = 5;
+		break;
+	case 20 ... 49:
+		idx = 4;
+		break;
+	case 10 ... 19:
+		idx = 3;
+		break;
+	case 4 ... 9:
+		idx = 2;
+		break;
+	case 2 ... 3:
+		idx = 1;
+	case 0 ... 1:
+		break;
+	}
+
+	assert(idx < FIO_IO_U_LAT_N_NR);
+	td->ts.io_u_lat_n[idx]++;
+}
+
+static void io_u_mark_lat_usec(struct thread_data *td, unsigned long long usec)
+{
+	int idx = 0;
+
+	assert(usec < 1000 && usec >= 1);
 
 	switch (usec) {
 	case 750 ... 999:
@@ -1030,9 +1071,11 @@ static void io_u_mark_lat_usec(struct thread_data *td, unsigned long usec)
 	td->ts.io_u_lat_u[idx]++;
 }
 
-static void io_u_mark_lat_msec(struct thread_data *td, unsigned long msec)
+static void io_u_mark_lat_msec(struct thread_data *td, unsigned long long msec)
 {
 	int idx = 0;
+
+	assert(msec >= 1);
 
 	switch (msec) {
 	default:
@@ -1075,12 +1118,14 @@ static void io_u_mark_lat_msec(struct thread_data *td, unsigned long msec)
 	td->ts.io_u_lat_m[idx]++;
 }
 
-static void io_u_mark_latency(struct thread_data *td, unsigned long usec)
+static void io_u_mark_latency(struct thread_data *td, unsigned long long nsec)
 {
-	if (usec < 1000)
-		io_u_mark_lat_usec(td, usec);
+	if (nsec < 1000)
+		io_u_mark_lat_nsec(td, nsec);
+	else if (nsec < 1000000)
+		io_u_mark_lat_usec(td, nsec / 1000);
 	else
-		io_u_mark_lat_msec(td, usec / 1000);
+		io_u_mark_lat_msec(td, nsec / 1000000);
 }
 
 static unsigned int __get_next_fileno_rand(struct thread_data *td)
@@ -1729,7 +1774,7 @@ static void account_io_completion(struct thread_data *td, struct io_u *io_u,
 				  const enum fio_ddir idx, unsigned int bytes)
 {
 	const int no_reduce = !gtod_reduce(td);
-	unsigned long lusec = 0;
+	unsigned long long llnsec = 0;
 
 	if (td->parent)
 		td = td->parent;
@@ -1738,37 +1783,37 @@ static void account_io_completion(struct thread_data *td, struct io_u *io_u,
 		return;
 
 	if (no_reduce)
-		lusec = utime_since(&io_u->issue_time, &icd->time);
+		llnsec = ntime_since(&io_u->issue_time, &icd->time);
 
 	if (!td->o.disable_lat) {
-		unsigned long tusec;
+		unsigned long long tnsec;
 
-		tusec = utime_since(&io_u->start_time, &icd->time);
-		add_lat_sample(td, idx, tusec, bytes, io_u->offset);
+		tnsec = ntime_since(&io_u->start_time, &icd->time);
+		add_lat_sample(td, idx, tnsec, bytes, io_u->offset);
 
 		if (td->flags & TD_F_PROFILE_OPS) {
 			struct prof_io_ops *ops = &td->prof_io_ops;
 
 			if (ops->io_u_lat)
-				icd->error = ops->io_u_lat(td, tusec);
+				icd->error = ops->io_u_lat(td, tnsec/1000);
 		}
 
-		if (td->o.max_latency && tusec > td->o.max_latency)
-			lat_fatal(td, icd, tusec, td->o.max_latency);
-		if (td->o.latency_target && tusec > td->o.latency_target) {
+		if (td->o.max_latency && tnsec/1000 > td->o.max_latency)
+			lat_fatal(td, icd, tnsec/1000, td->o.max_latency);
+		if (td->o.latency_target && tnsec/1000 > td->o.latency_target) {
 			if (lat_target_failed(td))
-				lat_fatal(td, icd, tusec, td->o.latency_target);
+				lat_fatal(td, icd, tnsec/1000, td->o.latency_target);
 		}
 	}
 
 	if (ddir_rw(idx)) {
 		if (!td->o.disable_clat) {
-			add_clat_sample(td, idx, lusec, bytes, io_u->offset);
-			io_u_mark_latency(td, lusec);
+			add_clat_sample(td, idx, llnsec, bytes, io_u->offset);
+			io_u_mark_latency(td, llnsec);
 		}
 
 		if (!td->o.disable_bw && per_unit_log(td->bw_log))
-			add_bw_sample(td, io_u, bytes, lusec);
+			add_bw_sample(td, io_u, bytes, llnsec);
 
 		if (no_reduce && per_unit_log(td->iops_log))
 			add_iops_sample(td, io_u, bytes);
@@ -2000,7 +2045,7 @@ void io_u_queued(struct thread_data *td, struct io_u *io_u)
 	if (!td->o.disable_slat && ramp_time_over(td) && td->o.stats) {
 		unsigned long slat_time;
 
-		slat_time = utime_since(&io_u->start_time, &io_u->issue_time);
+		slat_time = ntime_since(&io_u->start_time, &io_u->issue_time);
 
 		if (td->parent)
 			td = td->parent;

--- a/io_u.h
+++ b/io_u.h
@@ -31,8 +31,8 @@ enum {
  * The io unit
  */
 struct io_u {
-	struct timeval start_time;
-	struct timeval issue_time;
+	struct timespec start_time;
+	struct timespec issue_time;
 
 	struct fio_file *file;
 	unsigned int flags;

--- a/ioengines.c
+++ b/ioengines.c
@@ -281,7 +281,7 @@ int td_io_queue(struct thread_data *td, struct io_u *io_u)
 		 */
 		if (td->o.read_iolog_file)
 			memcpy(&td->last_issue, &io_u->issue_time,
-					sizeof(struct timeval));
+					sizeof(io_u->issue_time));
 	}
 
 	if (ddir_rw(ddir)) {
@@ -356,7 +356,7 @@ int td_io_queue(struct thread_data *td, struct io_u *io_u)
 		 */
 		if (td->o.read_iolog_file)
 			memcpy(&td->last_issue, &io_u->issue_time,
-					sizeof(struct timeval));
+					sizeof(io_u->issue_time));
 	}
 
 	return ret;

--- a/iolog.c
+++ b/iolog.c
@@ -65,7 +65,7 @@ static void iolog_delay(struct thread_data *td, unsigned long delay)
 {
 	uint64_t usec = utime_since_now(&td->last_issue);
 	uint64_t this_delay;
-	struct timeval tv;
+	struct timespec ts;
 
 	if (delay < td->time_offset) {
 		td->time_offset = 0;
@@ -78,7 +78,7 @@ static void iolog_delay(struct thread_data *td, unsigned long delay)
 
 	delay -= usec;
 
-	fio_gettime(&tv, NULL);
+	fio_gettime(&ts, NULL);
 	while (delay && !td->terminate) {
 		this_delay = delay;
 		if (this_delay > 500000)
@@ -88,7 +88,7 @@ static void iolog_delay(struct thread_data *td, unsigned long delay)
 		delay -= this_delay;
 	}
 
-	usec = utime_since_now(&tv);
+	usec = utime_since_now(&ts);
 	if (usec > delay)
 		td->time_offset = usec - delay;
 	else

--- a/lib/seqlock.h
+++ b/lib/seqlock.h
@@ -1,6 +1,7 @@
 #ifndef FIO_SEQLOCK_H
 #define FIO_SEQLOCK_H
 
+#include "types.h"
 #include "../arch/arch.h"
 
 struct seqlock {

--- a/libfio.c
+++ b/libfio.c
@@ -144,10 +144,10 @@ void reset_all_stats(struct thread_data *td)
 	}
 
 	set_epoch_time(td, td->o.log_unix_epoch);
-	memcpy(&td->start, &td->epoch, sizeof(struct timeval));
-	memcpy(&td->iops_sample_time, &td->epoch, sizeof(struct timeval));
-	memcpy(&td->bw_sample_time, &td->epoch, sizeof(struct timeval));
-	memcpy(&td->ss.prev_time, &td->epoch, sizeof(struct timeval));
+	memcpy(&td->start, &td->epoch, sizeof(td->epoch));
+	memcpy(&td->iops_sample_time, &td->epoch, sizeof(td->epoch));
+	memcpy(&td->bw_sample_time, &td->epoch, sizeof(td->epoch));
+	memcpy(&td->ss.prev_time, &td->epoch, sizeof(td->epoch));
 
 	lat_target_reset(td);
 	clear_rusage_stat(td);

--- a/options.c
+++ b/options.c
@@ -1381,7 +1381,7 @@ static int str_gtod_reduce_cb(void *data, int *il)
 	td->o.disable_bw = !!val;
 	td->o.clat_percentiles = !val;
 	if (val)
-		td->tv_cache_mask = 63;
+		td->ts_cache_mask = 63;
 
 	return 0;
 }

--- a/os/windows/posix.c
+++ b/os/windows/posix.c
@@ -25,8 +25,8 @@
 #include "../os-windows.h"
 #include "../../lib/hweight.h"
 
-extern unsigned long mtime_since_now(struct timeval *);
-extern void fio_gettime(struct timeval *, void *);
+extern unsigned long mtime_since_now(struct timespec *);
+extern void fio_gettime(struct timespec *, void *);
 
 /* These aren't defined in the MinGW headers */
 HRESULT WINAPI StringCchCopyA(
@@ -852,7 +852,7 @@ int poll(struct pollfd fds[], nfds_t nfds, int timeout)
 
 int nanosleep(const struct timespec *rqtp, struct timespec *rmtp)
 {
-	struct timeval tv;
+	struct timespec tv;
 	DWORD ms_remaining;
 	DWORD ms_total = (rqtp->tv_sec * 1000) + (rqtp->tv_nsec / 1000000.0);
 

--- a/profiles/act.c
+++ b/profiles/act.c
@@ -47,7 +47,7 @@ struct act_run_data {
 static struct act_run_data *act_run_data;
 
 struct act_prof_data {
-	struct timeval sample_tv;
+	struct timespec sample_tv;
 	struct act_slice *slices;
 	unsigned int cur_slice;
 	unsigned int nr_slices;

--- a/server.c
+++ b/server.c
@@ -438,7 +438,7 @@ static uint64_t alloc_reply(uint64_t tag, uint16_t opcode)
 
 	reply = calloc(1, sizeof(*reply));
 	INIT_FLIST_HEAD(&reply->list);
-	fio_gettime(&reply->tv, NULL);
+	fio_gettime(&reply->ts, NULL);
 	reply->saved_tag = tag;
 	reply->opcode = opcode;
 

--- a/server.c
+++ b/server.c
@@ -1497,6 +1497,8 @@ void fio_server_send_ts(struct thread_stat *ts, struct group_run_stats *rs)
 		p.ts.io_u_complete[i]	= cpu_to_le32(ts->io_u_complete[i]);
 	}
 
+	for (i = 0; i < FIO_IO_U_LAT_N_NR; i++)
+		p.ts.io_u_lat_n[i]	= cpu_to_le32(ts->io_u_lat_n[i]);
 	for (i = 0; i < FIO_IO_U_LAT_U_NR; i++)
 		p.ts.io_u_lat_u[i]	= cpu_to_le32(ts->io_u_lat_u[i]);
 	for (i = 0; i < FIO_IO_U_LAT_M_NR; i++)

--- a/server.h
+++ b/server.h
@@ -43,7 +43,7 @@ struct fio_net_cmd {
 
 struct fio_net_cmd_reply {
 	struct flist_head list;
-	struct timeval tv;
+	struct timespec ts;
 	uint64_t saved_tag;
 	uint16_t opcode;
 };

--- a/server.h
+++ b/server.h
@@ -49,7 +49,7 @@ struct fio_net_cmd_reply {
 };
 
 enum {
-	FIO_SERVER_VER			= 63,
+	FIO_SERVER_VER			= 64,
 
 	FIO_SERVER_MAX_FRAGMENT_PDU	= 1024,
 	FIO_SERVER_MAX_CMD_MB		= 2048,

--- a/stat.h
+++ b/stat.h
@@ -290,6 +290,7 @@ extern void init_group_run_stat(struct group_run_stats *gs);
 extern void eta_to_str(char *str, unsigned long eta_sec);
 extern bool calc_lat(struct io_stat *is, unsigned long long *min, unsigned long long *max, double *mean, double *dev);
 extern unsigned int calc_clat_percentiles(unsigned int *io_u_plat, unsigned long nr, fio_fp64_t *plist, unsigned long long **output, unsigned long long *maxv, unsigned long long *minv);
+extern void stat_calc_lat_n(struct thread_stat *ts, double *io_u_lat);
 extern void stat_calc_lat_m(struct thread_stat *ts, double *io_u_lat);
 extern void stat_calc_lat_u(struct thread_stat *ts, double *io_u_lat);
 extern void stat_calc_dist(unsigned int *map, unsigned long total, double *io_u_dist);

--- a/steadystate.c
+++ b/steadystate.c
@@ -196,7 +196,7 @@ void steadystate_check(void)
 	int i, j, ddir, prev_groupid, group_ramp_time_over = 0;
 	unsigned long rate_time;
 	struct thread_data *td, *td2;
-	struct timeval now;
+	struct timespec now;
 	uint64_t group_bw = 0, group_iops = 0;
 	uint64_t td_iops, td_bytes;
 	bool ret;

--- a/steadystate.h
+++ b/steadystate.h
@@ -35,7 +35,7 @@ struct steadystate_data {
 	uint64_t sum_xy;
 	uint64_t oldest_y;
 
-	struct timeval prev_time;
+	struct timespec prev_time;
 	uint64_t prev_iops;
 	uint64_t prev_bytes;
 };

--- a/t/debug.c
+++ b/t/debug.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
 FILE *f_err;
-struct timeval *fio_tv = NULL;
+struct timespec *fio_ts = NULL;
 unsigned long fio_debug = 0;
 
 void __dprint(int type, const char *str, ...)

--- a/t/dedupe.c
+++ b/t/dedupe.c
@@ -334,7 +334,7 @@ static void *thread_fn(void *data)
 static void show_progress(struct worker_thread *threads, unsigned long total)
 {
 	unsigned long last_nitems = 0;
-	struct timeval last_tv;
+	struct timespec last_tv;
 
 	fio_gettime(&last_tv, NULL);
 

--- a/t/lfsr-test.c
+++ b/t/lfsr-test.c
@@ -27,7 +27,7 @@ void usage()
 int main(int argc, char *argv[])
 {
 	int r;
-	struct timeval start, end;
+	struct timespec start, end;
 	struct fio_lfsr *fl;
 	int verify = 0;
 	unsigned int spin = 0;

--- a/t/time-test.c
+++ b/t/time-test.c
@@ -37,18 +37,41 @@
  *    when ticks is at its maximum value.
  *
  *    So we have
+ *	max_ticks = MAX_CLOCK_SEC * 1000000000 * cycles_per_nsec
  *	max_ticks * clock_mult <= ULLONG_MAX
  *	max_ticks * MULTIPLIER / cycles_per_nsec <= ULLONG_MAX
- *      MULTIPLIER <= ULLONG_MAX / max_ticks * cycles_per_nsec
+ *      MULTIPLIER <= ULLONG_MAX * cycles_per_nsec / max_ticks
  *
  *    Then choose the largest clock_shift that satisfies
- *	2^clock_shift <= ULLONG_MAX / max_ticks * cycles_per_nsec
+ *	2^clock_shift <= ULLONG_MAX * cycles_per_nsec / max_ticks
  *
  *    Finally calculate the appropriate clock_mult associated with clock_shift
  *	clock_mult = 2^clock_shift / cycles_per_nsec
  *
  * 4) In the code below we have cycles_per_usec and use
  *	cycles_per_nsec = cycles_per_usec / 1000
+ *
+ *
+ * The code below implements 4 clock tick to nsec conversion strategies
+ *
+ *   i) 64-bit arithmetic for the (ticks * clock_mult) product with the
+ *	conversion valid for at most MAX_CLOCK_SEC
+ *
+ *  ii) NOT IMPLEMENTED Use 64-bit integers to emulate 128-bit multiplication
+ *	for the (ticks * clock_mult) product
+ *
+ * iii) 64-bit arithmetic with clock ticks to nsec conversion occurring in
+ *	two stages. The first stage counts the number of discrete, large chunks
+ *	of time that have elapsed. To this is added the time represented by
+ *	the remaining clock ticks. The advantage of this strategy is better
+ *	accuracy because the (ticks * clock_mult) product used for final
+ *	fractional chunk
+ *
+ *  iv) 64-bit arithmetic with the clock ticks to nsec conversion occuring in
+ *	two stages. This is carried out using locks to update the number of
+ *	large time chunks (MAX_CLOCK_SEC_2STAGE) that have elapsed.
+ *
+ *   v) 128-bit arithmetic used for the clock ticks to nsec conversion.
  *
  */
 
@@ -57,34 +80,42 @@
 #include <limits.h>
 #include <assert.h>
 #include <stdlib.h>
+#include "lib/seqlock.h"
 
 #define DEBUG 0
 #define MAX_CLOCK_SEC 365*24*60*60ULL
-#define MAX_CLOCK_SEC64 60*60ULL
+#define MAX_CLOCK_SEC_2STAGE 60*60ULL
 #define dprintf(...) if (DEBUG) { printf(__VA_ARGS__); }
 
 enum {
-	__CLOCK_64_BIT		= 1 << 0,
-	__CLOCK_128_BIT		= 1 << 1,
+	__CLOCK64_BIT		= 1 << 0,
+	__CLOCK128_BIT		= 1 << 1,
 	__CLOCK_MULT_SHIFT	= 1 << 2,
 	__CLOCK_EMULATE_128	= 1 << 3,
-	__CLOCK_REDUCE		= 1 << 4,
+	__CLOCK_2STAGE		= 1 << 4,
+	__CLOCK_LOCK		= 1 << 5,
 
-	CLOCK_64_MULT_SHIFT	= __CLOCK_64_BIT | __CLOCK_MULT_SHIFT,
-	CLOCK_64_EMULATE_128	= __CLOCK_64_BIT | __CLOCK_EMULATE_128,
-	CLOCK_64_2STAGE		= __CLOCK_64_BIT | __CLOCK_REDUCE,
-	CLOCK_128_MULT_SHIFT	= __CLOCK_128_BIT | __CLOCK_MULT_SHIFT,
+	CLOCK64_MULT_SHIFT	= __CLOCK64_BIT | __CLOCK_MULT_SHIFT,
+	CLOCK64_EMULATE_128	= __CLOCK64_BIT | __CLOCK_EMULATE_128,
+	CLOCK64_2STAGE		= __CLOCK64_BIT | __CLOCK_2STAGE,
+	CLOCK64_LOCK		= __CLOCK64_BIT | __CLOCK_LOCK,
+	CLOCK128_MULT_SHIFT	= __CLOCK128_BIT | __CLOCK_MULT_SHIFT,
 };
 
-unsigned int clock_shift;
+struct seqlock clock_seqlock;
+unsigned long long cycles_start;
+unsigned long long elapsed_nsec;
+
 unsigned int max_cycles_shift;
 unsigned long long max_cycles_mask;
-unsigned long long *nsecs;
-unsigned long long clock_mult;
 unsigned long long nsecs_for_max_cycles;
+
+unsigned int clock_shift;
+unsigned long long clock_mult;
+
+unsigned long long *nsecs;
 unsigned long long clock_mult64_128[2];
 __uint128_t clock_mult128;
-
 
 /*
  * Functions for carrying out 128-bit
@@ -97,6 +128,8 @@ __uint128_t clock_mult128;
  *
  * a[0] has the less significant bits
  * a[1] has the more significant bits
+ *
+ * NOT FULLY IMPLEMENTED
  */
 void do_mult(unsigned long long a[2], unsigned long long b, unsigned long long product[2])
 {
@@ -127,19 +160,27 @@ void do_shift(unsigned long long a[2], unsigned int count)
 		}
 }
 
-unsigned long long get_nsec(int mode, unsigned long long t)
+void update_clock(unsigned long long t)
+{
+	write_seqlock_begin(&clock_seqlock);
+	elapsed_nsec = (t >> max_cycles_shift) * nsecs_for_max_cycles;
+	cycles_start = t & ~max_cycles_mask;
+	write_seqlock_end(&clock_seqlock);
+}
+
+unsigned long long _get_nsec(int mode, unsigned long long t)
 {
 	switch(mode) {
-		case CLOCK_64_MULT_SHIFT: {
+		case CLOCK64_MULT_SHIFT: {
 			return (t * clock_mult) >> clock_shift;
 		}
-		case CLOCK_64_EMULATE_128: {
+		case CLOCK64_EMULATE_128: {
 			unsigned long long product[2];
 			do_mult(clock_mult64_128, t, product);
 			do_shift(product, clock_shift);
 			return product[0];
 		}
-		case CLOCK_64_2STAGE: {
+		case CLOCK64_2STAGE: {
 			unsigned long long multiples, nsec;
 			multiples = t >> max_cycles_shift;
 			dprintf("multiples=%llu\n", multiples);
@@ -147,7 +188,17 @@ unsigned long long get_nsec(int mode, unsigned long long t)
 			nsec += ((t & max_cycles_mask) * clock_mult) >> clock_shift;
 			return nsec;
 		}
-		case CLOCK_128_MULT_SHIFT: {
+		case CLOCK64_LOCK: {
+			unsigned int seq;
+			unsigned long long nsec;
+			do {
+				seq = read_seqlock_begin(&clock_seqlock);
+				nsec = elapsed_nsec;
+				nsec += ((t - cycles_start) * clock_mult) >> clock_shift;
+			} while (read_seqlock_retry(&clock_seqlock, seq));
+			return nsec;
+		}
+		case CLOCK128_MULT_SHIFT: {
 			return (unsigned long long)((t * clock_mult128) >> clock_shift);
 		}
 		default: {
@@ -156,13 +207,22 @@ unsigned long long get_nsec(int mode, unsigned long long t)
 	}
 }
 
+unsigned long long get_nsec(int mode, unsigned long long t)
+{
+	if (mode == CLOCK64_LOCK) {
+		update_clock(t);
+	}
+
+	return _get_nsec(mode, t);
+}
+
 void calc_mult_shift(int mode, void *mult, unsigned int *shift, unsigned long long max_sec, unsigned long long cycles_per_usec)
 {
 	unsigned long long max_ticks;
 	max_ticks = max_sec * cycles_per_usec * 1000000ULL;
 
 	switch (mode) {
-		case CLOCK_64_MULT_SHIFT: {
+		case CLOCK64_MULT_SHIFT: {
 			unsigned long long max_mult, tmp;
 			unsigned int sft = 0;
 
@@ -189,7 +249,7 @@ void calc_mult_shift(int mode, void *mult, unsigned int *shift, unsigned long lo
 			*((unsigned long long *)mult) = (unsigned long long) ((1ULL << sft) * 1000 / cycles_per_usec);
 			break;
 		}
-		case CLOCK_64_EMULATE_128: {
+		case CLOCK64_EMULATE_128: {
 			unsigned long long max_mult[2], tmp[2];
 			unsigned int sft = 0;
 
@@ -220,28 +280,28 @@ void calc_mult_shift(int mode, void *mult, unsigned int *shift, unsigned long lo
 //			*((unsigned long long *)mult) = (__uint128_t) (((__uint128_t)1 << sft) * 1000 / cycles_per_usec);
 			break;
 		}
-		case CLOCK_64_2STAGE: {
+		case CLOCK64_2STAGE: {
 			unsigned long long tmp;
 /*
  * This clock tick to nsec conversion requires two stages.
  *
- * Stage 1: Determine how many ~MAX_CLOCK_SEC64 periods worth of clock ticks
+ * Stage 1: Determine how many ~MAX_CLOCK_SEC_2STAGE periods worth of clock ticks
  * 	have elapsed and set nsecs to the appropriate value for those
- *	~MAX_CLOCK_SEC64 periods.
- * Stage 2: Subtract the ticks for the elapsed ~MAX_CLOCK_SEC64 periods from
+ *	~MAX_CLOCK_SEC_2STAGE periods.
+ * Stage 2: Subtract the ticks for the elapsed ~MAX_CLOCK_SEC_2STAGE periods from
  *	Stage 1. Convert remaining clock ticks to nsecs and add to previously
  *	set nsec value.
  *
  * To optimize the arithmetic operations, use the greatest power of 2 ticks
- * less than the number of ticks in MAX_CLOCK_SEC64 seconds.
+ * less than the number of ticks in MAX_CLOCK_SEC_2STAGE seconds.
  *
  */
 			// Use a period shorter than MAX_CLOCK_SEC here for better accuracy
-			calc_mult_shift(CLOCK_64_MULT_SHIFT, mult, shift, MAX_CLOCK_SEC64, cycles_per_usec);
+			calc_mult_shift(CLOCK64_MULT_SHIFT, mult, shift, MAX_CLOCK_SEC_2STAGE, cycles_per_usec);
 
-			// Find the greatest power of 2 clock ticks that is less than the ticks in MAX_CLOCK_SEC64
+			// Find the greatest power of 2 clock ticks that is less than the ticks in MAX_CLOCK_SEC_2STAGE
 			max_cycles_shift = max_cycles_mask = 0;
-			tmp = MAX_CLOCK_SEC64 * 1000000ULL * cycles_per_usec;
+			tmp = MAX_CLOCK_SEC_2STAGE * 1000000ULL * cycles_per_usec;
 			dprintf("tmp=%llu, max_cycles_shift=%u\n", tmp, max_cycles_shift);
 			while (tmp > 1) {
 				tmp >>= 1;
@@ -263,7 +323,24 @@ void calc_mult_shift(int mode, void *mult, unsigned int *shift, unsigned long lo
 
 			break;
 		}
-		case CLOCK_128_MULT_SHIFT: {
+		case CLOCK64_LOCK: {
+/*
+ * This clock tick to nsec conversion also requires two stages.
+ *
+ * Stage 1: Add to nsec the current running total of elapsed long periods
+ * Stage 2: Subtract from clock ticks the tick count corresponding to the
+ *	most recently elapsed long period. Convert the remaining ticks to
+ *	nsec and add to the previous nsec value.
+ *
+ * In practice the elapsed nsec from Stage 1 and the tick count subtracted
+ * in Stage 2 will be maintained in a separate thread.
+ *
+ */
+			calc_mult_shift(CLOCK64_2STAGE, mult, shift, MAX_CLOCK_SEC, cycles_per_usec);
+			cycles_start = 0;
+			break;
+		}
+		case CLOCK128_MULT_SHIFT: {
 			__uint128_t max_mult, tmp;
 			unsigned int sft = 0;
 
@@ -290,13 +367,13 @@ void calc_mult_shift(int mode, void *mult, unsigned int *shift, unsigned long lo
 				dprintf("tmp=0x%016llx%016llx, sft=%u\n",
 					(unsigned long long) (tmp >> 64),
 					(unsigned long long) tmp, sft);
- 			}
+			}
 
 			*shift = sft;
 			*((__uint128_t *)mult) = (__uint128_t) (((__uint128_t)1 << sft) * 1000 / cycles_per_usec);
 			break;
- 		}
- 	}
+		}
+	}
 }
 
 int discontinuity(int mode, int delta_ticks, int delta_nsec, unsigned long long start, unsigned long len)
@@ -358,19 +435,23 @@ long long test_clock(int mode, int cycles_per_usec, int fast_test, int quiet, in
 	max_ticks = MAX_CLOCK_SEC * (unsigned long long) cycles_per_usec * 1000000ULL;
 
 	switch(mode) {
-		case CLOCK_64_MULT_SHIFT: {
+		case CLOCK64_MULT_SHIFT: {
 			mult = &clock_mult;
 			break;
 		}
-		case CLOCK_64_EMULATE_128: {
+		case CLOCK64_EMULATE_128: {
 			mult = clock_mult64_128;
 			break;
 		}
-		case CLOCK_64_2STAGE: {
+		case CLOCK64_2STAGE: {
 			mult = &clock_mult;
 			break;
 		}
-		case CLOCK_128_MULT_SHIFT: {
+		case CLOCK64_LOCK: {
+			mult = &clock_mult;
+			break;
+		}
+		case CLOCK128_MULT_SHIFT: {
 			mult = &clock_mult128;
 			break;
 		}
@@ -379,7 +460,7 @@ long long test_clock(int mode, int cycles_per_usec, int fast_test, int quiet, in
 	nsecs = get_nsec(mode, max_ticks);
 	delta = nsecs/1000000 - MAX_CLOCK_SEC*1000;
 
-	if (mode == CLOCK_64_2STAGE) {
+	if (mode == CLOCK64_2STAGE) {
 		test_ns[0] = nsecs_for_max_cycles - 1;
 		test_ns[1] = nsecs_for_max_cycles;
 		test_ticks[0] = (1ULL << max_cycles_shift) - 1;
@@ -397,18 +478,19 @@ long long test_clock(int mode, int cycles_per_usec, int fast_test, int quiet, in
 		printf("cycles_per_usec=%d, delta_ticks=%d, delta_nsec=%d, max_ticks=%llu, shift=%u, 2^shift=%llu\n",
 			cycles_per_usec, delta_ticks, delta_nsec, max_ticks, clock_shift, (1ULL << clock_shift));
 		switch(mode) {
-			case CLOCK_64_2STAGE:
-			case CLOCK_64_MULT_SHIFT: {
+			case CLOCK64_LOCK:
+			case CLOCK64_2STAGE:
+			case CLOCK64_MULT_SHIFT: {
 				printf("clock_mult=%llu, clock_mult / 2^clock_shift=%f\n",
 					clock_mult, (double) clock_mult / (1ULL << clock_shift));
 				break;
 			}
-			case CLOCK_64_EMULATE_128: {
+			case CLOCK64_EMULATE_128: {
 				printf("clock_mult=0x%016llx%016llx\n",
 					clock_mult64_128[1], clock_mult64_128[0]);
 				break;
 			}
-			case CLOCK_128_MULT_SHIFT: {
+			case CLOCK128_MULT_SHIFT: {
 				printf("clock_mult=0x%016llx%016llx\n",
 					(unsigned long long) (clock_mult128 >> 64),
 					(unsigned long long) clock_mult128);
@@ -450,41 +532,41 @@ int main(int argc, char *argv[])
 	assert(nsecs != NULL);
 	days = MAX_CLOCK_SEC / 60 / 60 / 24;
 
-	test_clock(CLOCK_64_2STAGE, 3333, 1, 0, 0, 0);
-//	test_clock(CLOCK_64_MULT_SHIFT, 3333, 1, 0, 0, 0);
-//	test_clock(CLOCK_128_MULT_SHIFT, 3333, 1, 0, 0, 0);
+	test_clock(CLOCK64_LOCK, 3333, 1, 0, 0, 0);
+//	test_clock(CLOCK64_MULT_SHIFT, 3333, 1, 0, 0, 0);
+//	test_clock(CLOCK128_MULT_SHIFT, 3333, 1, 0, 0, 0);
 
 // Test 3 different clock types from 1000 to 10000 MHz
 // and calculate average error
 /*
 	for (i = 1000, mean = 0.0; i <= 10000; i++) {
-		error = test_clock(CLOCK_64_MULT_SHIFT, i, 1, 1, 0, 0);
+		error = test_clock(CLOCK64_MULT_SHIFT, i, 1, 1, 0, 0);
 		errors[i] = error > 0 ? error : -1LL * error;
 		mean += (double) errors[i] / 9000;
 	}
 	printf("  64-bit average error per %d days: %fms\n", days, mean);
 
 	for (i = 1000, mean = 0.0; i <= 10000; i++) {
-		error = test_clock(CLOCK_64_2STAGE, i, 1, 1, 0, 0);
+		error = test_clock(CLOCK64_2STAGE, i, 1, 1, 0, 0);
 		errors[i] = error > 0 ? error : -1LL * error;
 		mean += (double) errors[i] / 9000;
 	}
 	printf("  64-bit two-stage average error per %d days: %fms\n", days, mean);
 
 	for (i = 1000, mean = 0.0; i <= 10000; i++) {
-		error = test_clock(CLOCK_128_MULT_SHIFT, i, 1, 1, 0, 0);
+		error = test_clock(CLOCK128_MULT_SHIFT, i, 1, 1, 0, 0);
 		errors[i] = error > 0 ? error : -1LL * error;
 		mean += (double) errors[i] / 9000;
 	}
 	printf(" 128-bit average error per %d days: %fms\n", days, mean);
 */
-	test_clock(CLOCK_64_2STAGE, 1000, 1, 0, 1, 1);
-	test_clock(CLOCK_64_2STAGE, 1100, 1, 0, 11, 10);
-	test_clock(CLOCK_64_2STAGE, 3000, 1, 0, 3, 1);
-	test_clock(CLOCK_64_2STAGE, 3333, 1, 0, 3333, 1000);
-	test_clock(CLOCK_64_2STAGE, 3392, 1, 0, 424, 125);
-	test_clock(CLOCK_64_2STAGE, 4500, 1, 0, 9, 2);
-	test_clock(CLOCK_64_2STAGE, 5000, 1, 0, 5, 1);
+	test_clock(CLOCK64_LOCK, 1000, 1, 0, 1, 1);
+	test_clock(CLOCK64_LOCK, 1100, 1, 0, 11, 10);
+	test_clock(CLOCK64_LOCK, 3000, 1, 0, 3, 1);
+	test_clock(CLOCK64_LOCK, 3333, 1, 0, 3333, 1000);
+	test_clock(CLOCK64_LOCK, 3392, 1, 0, 424, 125);
+	test_clock(CLOCK64_LOCK, 4500, 1, 0, 9, 2);
+	test_clock(CLOCK64_LOCK, 5000, 1, 0, 5, 1);
 
 	free(nsecs);
 	return 0;

--- a/t/time-test.c
+++ b/t/time-test.c
@@ -1,0 +1,491 @@
+/*
+ * Carry out arithmetic to explore conversion of CPU clock ticks to nsec
+ *
+ * When we use the CPU clock for timing, we do the following:
+ *
+ * 1) Calibrate the CPU clock to relate the frequency of CPU clock ticks
+ *    to actual time.
+ *
+ *    Using gettimeofday() or clock_gettime(), count how many CPU clock
+ *    ticks occur per usec
+ *
+ * 2) Calculate conversion factors so that we can ultimately convert
+ *    from clocks ticks to nsec with
+ *      nsec = (ticks * clock_mult) >> clock_shift
+ *
+ *    This is equivalent to
+ *	nsec = ticks * (MULTIPLIER / cycles_per_nsec) / MULTIPLIER
+ *    where
+ *	clock_mult = MULTIPLIER / cycles_per_nsec
+ *      MULTIPLIER = 2^clock_shift
+ *
+ *    It would be simpler to just calculate nsec = ticks / cycles_per_nsec,
+ *    but all of this is necessary because of rounding when calculating
+ *    cycles_per_nsec. With a 3.0GHz CPU, cycles_per_nsec would simply
+ *    be 3. But with a 3.33GHz CPU or a 4.5GHz CPU, the fractional
+ *    portion is lost with integer arithmetic.
+ *
+ *    This multiply and shift calculation also has a performance benefit
+ *    as multiplication and bit shift operations are faster than integer
+ *    division.
+ *
+ * 3) Dynamically determine clock_shift and clock_mult at run time based
+ *    on MAX_CLOCK_SEC and cycles_per_usec. MAX_CLOCK_SEC is the maximum
+ *    duration for which the conversion will be valid.
+ *
+ *    The primary constraint is that (ticks * clock_mult) must not overflow
+ *    when ticks is at its maximum value.
+ *
+ *    So we have
+ *	max_ticks * clock_mult <= ULLONG_MAX
+ *	max_ticks * MULTIPLIER / cycles_per_nsec <= ULLONG_MAX
+ *      MULTIPLIER <= ULLONG_MAX / max_ticks * cycles_per_nsec
+ *
+ *    Then choose the largest clock_shift that satisfies
+ *	2^clock_shift <= ULLONG_MAX / max_ticks * cycles_per_nsec
+ *
+ *    Finally calculate the appropriate clock_mult associated with clock_shift
+ *	clock_mult = 2^clock_shift / cycles_per_nsec
+ *
+ * 4) In the code below we have cycles_per_usec and use
+ *	cycles_per_nsec = cycles_per_usec / 1000
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#define DEBUG 0
+#define MAX_CLOCK_SEC 365*24*60*60ULL
+#define MAX_CLOCK_SEC64 60*60ULL
+#define dprintf(...) if (DEBUG) { printf(__VA_ARGS__); }
+
+enum {
+	__CLOCK_64_BIT		= 1 << 0,
+	__CLOCK_128_BIT		= 1 << 1,
+	__CLOCK_MULT_SHIFT	= 1 << 2,
+	__CLOCK_EMULATE_128	= 1 << 3,
+	__CLOCK_REDUCE		= 1 << 4,
+
+	CLOCK_64_MULT_SHIFT	= __CLOCK_64_BIT | __CLOCK_MULT_SHIFT,
+	CLOCK_64_EMULATE_128	= __CLOCK_64_BIT | __CLOCK_EMULATE_128,
+	CLOCK_64_2STAGE		= __CLOCK_64_BIT | __CLOCK_REDUCE,
+	CLOCK_128_MULT_SHIFT	= __CLOCK_128_BIT | __CLOCK_MULT_SHIFT,
+};
+
+unsigned int clock_shift;
+unsigned int max_cycles_shift;
+unsigned long long max_cycles_mask;
+unsigned long long *nsecs;
+unsigned long long clock_mult;
+unsigned long long nsecs_for_max_cycles;
+unsigned long long clock_mult64_128[2];
+__uint128_t clock_mult128;
+
+
+/*
+ * Functions for carrying out 128-bit
+ * arithmetic using 64-bit integers
+ *
+ * 128-bit integers are stored as
+ * arrays of two 64-bit integers
+ *
+ * Ordering is little endian
+ *
+ * a[0] has the less significant bits
+ * a[1] has the more significant bits
+ */
+void do_mult(unsigned long long a[2], unsigned long long b, unsigned long long product[2])
+{
+	product[0] = product[1] = 0;
+	return;
+}
+
+void do_div(unsigned long long a[2], unsigned long long b, unsigned long long c[2])
+{
+	return;
+}
+
+void do_shift64(unsigned long long a[2], unsigned int count)
+{
+	a[0] = a[1] >> (count-64);
+	a[1] = 0;
+}
+
+void do_shift(unsigned long long a[2], unsigned int count)
+{
+	if (count > 64)
+		do_shift64(a, count);
+	else
+		while (count--) {
+			a[0] >>= 1;
+			a[0] |= a[1] << 63;
+			a[1] >>= 1;
+		}
+}
+
+unsigned long long get_nsec(int mode, unsigned long long t)
+{
+	switch(mode) {
+		case CLOCK_64_MULT_SHIFT: {
+			return (t * clock_mult) >> clock_shift;
+		}
+		case CLOCK_64_EMULATE_128: {
+			unsigned long long product[2];
+			do_mult(clock_mult64_128, t, product);
+			do_shift(product, clock_shift);
+			return product[0];
+		}
+		case CLOCK_64_2STAGE: {
+			unsigned long long multiples, nsec;
+			multiples = t >> max_cycles_shift;
+			dprintf("multiples=%llu\n", multiples);
+			nsec = multiples * nsecs_for_max_cycles;
+			nsec += ((t & max_cycles_mask) * clock_mult) >> clock_shift;
+			return nsec;
+		}
+		case CLOCK_128_MULT_SHIFT: {
+			return (unsigned long long)((t * clock_mult128) >> clock_shift);
+		}
+		default: {
+			assert(0);
+		}
+	}
+}
+
+void calc_mult_shift(int mode, void *mult, unsigned int *shift, unsigned long long max_sec, unsigned long long cycles_per_usec)
+{
+	unsigned long long max_ticks;
+	max_ticks = max_sec * cycles_per_usec * 1000000ULL;
+
+	switch (mode) {
+		case CLOCK_64_MULT_SHIFT: {
+			unsigned long long max_mult, tmp;
+			unsigned int sft = 0;
+
+			/*
+			 * Calculate the largest multiplier that will not
+			 * produce a 64-bit overflow in the multiplication
+			 * step of the clock ticks to nsec conversion
+			 */
+			max_mult = ULLONG_MAX / max_ticks;
+			dprintf("max_ticks=%llu, __builtin_clzll=%d, max_mult=%llu\n", max_ticks, __builtin_clzll(max_ticks), max_mult);
+
+			/*
+			 * Find the largest shift count that will produce
+			 * a multiplier less than max_mult
+			 */
+			tmp = max_mult * cycles_per_usec / 1000;
+			while (tmp > 1) {
+				tmp >>= 1;
+				sft++;
+				dprintf("tmp=%llu, sft=%u\n", tmp, sft);
+			}
+
+			*shift = sft;
+			*((unsigned long long *)mult) = (unsigned long long) ((1ULL << sft) * 1000 / cycles_per_usec);
+			break;
+		}
+		case CLOCK_64_EMULATE_128: {
+			unsigned long long max_mult[2], tmp[2];
+			unsigned int sft = 0;
+
+			/*
+			 * Calculate the largest multiplier that will not
+			 * produce a 128-bit overflow in the multiplication
+			 * step of the clock ticks to nsec conversion,
+			 * but use only 64-bit integers in the process
+			 */
+			max_mult[0] = max_mult[1] = ULLONG_MAX;
+			do_div(max_mult, max_ticks, max_mult);
+			dprintf("max_ticks=%llu, __builtin_clzll=%d, max_mult=0x%016llx%016llx\n",
+				max_ticks, __builtin_clzll(max_ticks), max_mult[1], max_mult[0]);
+
+			/*
+			 * Find the largest shift count that will produce
+			 * a multiplier less than max_mult
+			 */
+			do_div(max_mult, cycles_per_usec, tmp);
+			do_div(tmp, 1000ULL, tmp);
+			while (tmp[0] > 1 || tmp[1] > 1) {
+				do_shift(tmp, 1);
+				sft++;
+				dprintf("tmp=0x%016llx%016llx, sft=%u\n", tmp[1], tmp[0], sft);
+			}
+
+			*shift = sft;
+//			*((unsigned long long *)mult) = (__uint128_t) (((__uint128_t)1 << sft) * 1000 / cycles_per_usec);
+			break;
+		}
+		case CLOCK_64_2STAGE: {
+			unsigned long long tmp;
+/*
+ * This clock tick to nsec conversion requires two stages.
+ *
+ * Stage 1: Determine how many ~MAX_CLOCK_SEC64 periods worth of clock ticks
+ * 	have elapsed and set nsecs to the appropriate value for those
+ *	~MAX_CLOCK_SEC64 periods.
+ * Stage 2: Subtract the ticks for the elapsed ~MAX_CLOCK_SEC64 periods from
+ *	Stage 1. Convert remaining clock ticks to nsecs and add to previously
+ *	set nsec value.
+ *
+ * To optimize the arithmetic operations, use the greatest power of 2 ticks
+ * less than the number of ticks in MAX_CLOCK_SEC64 seconds.
+ *
+ */
+			// Use a period shorter than MAX_CLOCK_SEC here for better accuracy
+			calc_mult_shift(CLOCK_64_MULT_SHIFT, mult, shift, MAX_CLOCK_SEC64, cycles_per_usec);
+
+			// Find the greatest power of 2 clock ticks that is less than the ticks in MAX_CLOCK_SEC64
+			max_cycles_shift = max_cycles_mask = 0;
+			tmp = MAX_CLOCK_SEC64 * 1000000ULL * cycles_per_usec;
+			dprintf("tmp=%llu, max_cycles_shift=%u\n", tmp, max_cycles_shift);
+			while (tmp > 1) {
+				tmp >>= 1;
+				max_cycles_shift++;
+				dprintf("tmp=%llu, max_cycles_shift=%u\n", tmp, max_cycles_shift);
+			}
+			// if use use (1ULL << max_cycles_shift) * 1000 / cycles_per_usec here we will
+			// have a discontinuity every (1ULL << max_cycles_shift) cycles
+			nsecs_for_max_cycles = (1ULL << max_cycles_shift) * *((unsigned long long *)mult) >> *shift;
+
+			// Use a bitmask to calculate ticks % (1ULL << max_cycles_shift)
+			for (tmp = 0; tmp < max_cycles_shift; tmp++)
+				max_cycles_mask |= 1ULL << tmp;
+
+			dprintf("max_cycles_shift=%u, 2^max_cycles_shift=%llu, nsecs_for_max_cycles=%llu, max_cycles_mask=%016llx\n",
+				max_cycles_shift, (1ULL << max_cycles_shift),
+				nsecs_for_max_cycles, max_cycles_mask);
+
+
+			break;
+		}
+		case CLOCK_128_MULT_SHIFT: {
+			__uint128_t max_mult, tmp;
+			unsigned int sft = 0;
+
+			/*
+			 * Calculate the largest multiplier that will not
+			 * produce a 128-bit overflow in the multiplication
+			 * step of the clock ticks to nsec conversion
+			 */
+			max_mult = ((__uint128_t) ULLONG_MAX) << 64 | ULLONG_MAX;
+			max_mult /= max_ticks;
+			dprintf("max_ticks=%llu, __builtin_clzll=%d, max_mult=0x%016llx%016llx\n",
+				max_ticks, __builtin_clzll(max_ticks),
+				(unsigned long long) (max_mult >> 64),
+				(unsigned long long) max_mult);
+
+			/*
+			 * Find the largest shift count that will produce
+			 * a multiplier less than max_mult
+			 */
+			tmp = max_mult * cycles_per_usec / 1000;
+			while (tmp > 1) {
+				tmp >>= 1;
+				sft++;
+				dprintf("tmp=0x%016llx%016llx, sft=%u\n",
+					(unsigned long long) (tmp >> 64),
+					(unsigned long long) tmp, sft);
+ 			}
+
+			*shift = sft;
+			*((__uint128_t *)mult) = (__uint128_t) (((__uint128_t)1 << sft) * 1000 / cycles_per_usec);
+			break;
+ 		}
+ 	}
+}
+
+int discontinuity(int mode, int delta_ticks, int delta_nsec, unsigned long long start, unsigned long len)
+{
+	int i;
+	unsigned long mismatches = 0, bad_mismatches = 0;
+	unsigned long long delta, max_mismatch = 0;
+	unsigned long long *ns = nsecs;
+
+	for (i = 0; i < len; ns++, i++) {
+		*ns = get_nsec(mode, start + i);
+		if (i - delta_ticks >= 0) {
+			if (*ns > *(ns - delta_ticks))
+				delta = *ns - *(ns - delta_ticks);
+			else
+				delta = *(ns - delta_ticks) - *ns;
+			if (delta > delta_nsec)
+				delta -= delta_nsec;
+			else
+				delta = delta_nsec - delta;
+			if (delta) {
+				mismatches++;
+				if (delta > 1)
+					bad_mismatches++;
+				if (delta > max_mismatch)
+					max_mismatch = delta;
+			}
+		}
+		if (!bad_mismatches)
+			assert(max_mismatch == 0 || max_mismatch == 1);
+		if (!mismatches)
+			assert(max_mismatch == 0);
+	}
+
+	printf("%lu discontinuities (%lu%%) (%lu errors > 1ns, max delta = %lluns) for ticks = %llu...%llu\n",
+		mismatches, (mismatches * 100) / len, bad_mismatches, max_mismatch, start,
+		start + len - 1);
+	return mismatches;
+}
+
+#define MIN_TICKS 1ULL
+#define LEN 1000000000ULL
+#define NSEC_ONE_SEC 1000000000ULL
+#define TESTLEN 9
+long long test_clock(int mode, int cycles_per_usec, int fast_test, int quiet, int delta_ticks, int delta_nsec)
+{
+	int i;
+	long long delta;
+	unsigned long long max_ticks;
+	unsigned long long nsecs;
+	void *mult;
+	unsigned long long test_ns[TESTLEN] =
+			{NSEC_ONE_SEC, NSEC_ONE_SEC,
+			 NSEC_ONE_SEC, NSEC_ONE_SEC*60, NSEC_ONE_SEC*60*60,
+			 NSEC_ONE_SEC*60*60*2, NSEC_ONE_SEC*60*60*4,
+			 NSEC_ONE_SEC*60*60*8, NSEC_ONE_SEC*60*60*24};
+	unsigned long long test_ticks[TESTLEN];
+
+	max_ticks = MAX_CLOCK_SEC * (unsigned long long) cycles_per_usec * 1000000ULL;
+
+	switch(mode) {
+		case CLOCK_64_MULT_SHIFT: {
+			mult = &clock_mult;
+			break;
+		}
+		case CLOCK_64_EMULATE_128: {
+			mult = clock_mult64_128;
+			break;
+		}
+		case CLOCK_64_2STAGE: {
+			mult = &clock_mult;
+			break;
+		}
+		case CLOCK_128_MULT_SHIFT: {
+			mult = &clock_mult128;
+			break;
+		}
+	}
+	calc_mult_shift(mode, mult, &clock_shift, MAX_CLOCK_SEC, cycles_per_usec);
+	nsecs = get_nsec(mode, max_ticks);
+	delta = nsecs/1000000 - MAX_CLOCK_SEC*1000;
+
+	if (mode == CLOCK_64_2STAGE) {
+		test_ns[0] = nsecs_for_max_cycles - 1;
+		test_ns[1] = nsecs_for_max_cycles;
+		test_ticks[0] = (1ULL << max_cycles_shift) - 1;
+		test_ticks[1] = (1ULL << max_cycles_shift);
+
+		for (i = 2; i < TESTLEN; i++)
+			test_ticks[i] = test_ns[i] / 1000 * cycles_per_usec;
+	}
+	else {
+		for (i = 0; i < TESTLEN; i++)
+			test_ticks[i] = test_ns[i] / 1000 * cycles_per_usec;
+	}
+
+	if (!quiet) {
+		printf("cycles_per_usec=%d, delta_ticks=%d, delta_nsec=%d, max_ticks=%llu, shift=%u, 2^shift=%llu\n",
+			cycles_per_usec, delta_ticks, delta_nsec, max_ticks, clock_shift, (1ULL << clock_shift));
+		switch(mode) {
+			case CLOCK_64_2STAGE:
+			case CLOCK_64_MULT_SHIFT: {
+				printf("clock_mult=%llu, clock_mult / 2^clock_shift=%f\n",
+					clock_mult, (double) clock_mult / (1ULL << clock_shift));
+				break;
+			}
+			case CLOCK_64_EMULATE_128: {
+				printf("clock_mult=0x%016llx%016llx\n",
+					clock_mult64_128[1], clock_mult64_128[0]);
+				break;
+			}
+			case CLOCK_128_MULT_SHIFT: {
+				printf("clock_mult=0x%016llx%016llx\n",
+					(unsigned long long) (clock_mult128 >> 64),
+					(unsigned long long) clock_mult128);
+				break;
+			}
+		}
+		printf("get_nsec(max_ticks) = %lluns, should be %lluns, error<=abs(%lld)ms\n",
+			nsecs, MAX_CLOCK_SEC*1000000000ULL, delta);
+	}
+
+	for (i = 0; i < TESTLEN; i++)
+	{
+		nsecs = get_nsec(mode, test_ticks[i]);
+		delta = nsecs > test_ns[i] ? nsecs - test_ns[i] : test_ns[i] - nsecs;
+		if (!quiet || delta > 0)
+			printf("get_nsec(%llu)=%llu, expected %llu, delta=%llu\n",
+				test_ticks[i], nsecs, test_ns[i], delta);
+	}
+
+	if (!fast_test) {
+		discontinuity(mode, delta_ticks, delta_nsec, max_ticks - LEN + 1, LEN);
+		discontinuity(mode, delta_ticks, delta_nsec, MIN_TICKS, LEN);
+	}
+
+	if (!quiet)
+		printf("\n\n");
+
+	return delta;
+}
+
+int main(int argc, char *argv[])
+{
+	int i, days;
+	long long error;
+	long long errors[10001];
+	double mean;
+
+	nsecs = malloc(LEN * sizeof(unsigned long long));
+	assert(nsecs != NULL);
+	days = MAX_CLOCK_SEC / 60 / 60 / 24;
+
+	test_clock(CLOCK_64_2STAGE, 3333, 1, 0, 0, 0);
+//	test_clock(CLOCK_64_MULT_SHIFT, 3333, 1, 0, 0, 0);
+//	test_clock(CLOCK_128_MULT_SHIFT, 3333, 1, 0, 0, 0);
+
+// Test 3 different clock types from 1000 to 10000 MHz
+// and calculate average error
+/*
+	for (i = 1000, mean = 0.0; i <= 10000; i++) {
+		error = test_clock(CLOCK_64_MULT_SHIFT, i, 1, 1, 0, 0);
+		errors[i] = error > 0 ? error : -1LL * error;
+		mean += (double) errors[i] / 9000;
+	}
+	printf("  64-bit average error per %d days: %fms\n", days, mean);
+
+	for (i = 1000, mean = 0.0; i <= 10000; i++) {
+		error = test_clock(CLOCK_64_2STAGE, i, 1, 1, 0, 0);
+		errors[i] = error > 0 ? error : -1LL * error;
+		mean += (double) errors[i] / 9000;
+	}
+	printf("  64-bit two-stage average error per %d days: %fms\n", days, mean);
+
+	for (i = 1000, mean = 0.0; i <= 10000; i++) {
+		error = test_clock(CLOCK_128_MULT_SHIFT, i, 1, 1, 0, 0);
+		errors[i] = error > 0 ? error : -1LL * error;
+		mean += (double) errors[i] / 9000;
+	}
+	printf(" 128-bit average error per %d days: %fms\n", days, mean);
+*/
+	test_clock(CLOCK_64_2STAGE, 1000, 1, 0, 1, 1);
+	test_clock(CLOCK_64_2STAGE, 1100, 1, 0, 11, 10);
+	test_clock(CLOCK_64_2STAGE, 3000, 1, 0, 3, 1);
+	test_clock(CLOCK_64_2STAGE, 3333, 1, 0, 3333, 1000);
+	test_clock(CLOCK_64_2STAGE, 3392, 1, 0, 424, 125);
+	test_clock(CLOCK_64_2STAGE, 4500, 1, 0, 9, 2);
+	test_clock(CLOCK_64_2STAGE, 5000, 1, 0, 5, 1);
+
+	free(nsecs);
+	return 0;
+}

--- a/tools/hist/fiologparser_hist.py
+++ b/tools/hist/fiologparser_hist.py
@@ -373,7 +373,7 @@ if __name__ == '__main__':
         help='print warning messages to stderr')
 
     arg('--group_nr',
-        default=19,
+        default=29,
         type=int,
         help='FIO_IO_U_PLAT_GROUP_NR as defined in stat.h')
 

--- a/verify.c
+++ b/verify.c
@@ -1167,7 +1167,7 @@ static void __fill_hdr(struct thread_data *td, struct io_u *io_u,
 	hdr->rand_seed = rand_seed;
 	hdr->offset = io_u->offset + header_num * td->o.verify_interval;
 	hdr->time_sec = io_u->start_time.tv_sec;
-	hdr->time_usec = io_u->start_time.tv_usec;
+	hdr->time_usec = io_u->start_time.tv_nsec / 1000;
 	hdr->thread = td->thread_number;
 	hdr->numberio = io_u->numberio;
 	hdr->crc32 = fio_crc32c(p, offsetof(struct verify_header, crc32));


### PR DESCRIPTION
Jens, please consider this pull request that adds nanosecond timing to fio (#324).

The changes include the following:

- Change most of the places that used struct timeval to instead use struct timespec
-  Add nsec bins for the latency counters: io_u_plat[][] in thread_stat is much larger now to accommodate the increased precision while retaining the top end ~9sec max latency value
- Change the normal and JSON output to accommodate nsec latencies. This will break scripts that parse fio output.
- Add t/time-test to carry out experiments with various ways of doing the clock ticks to nsec conversion
- For the clock ticks to nsec conversion I chose a two-stage approach to resolve the 64-bit overflow problem
-- First, consume hours' worth of clock ticks at a time
-- Then, carry out the standard multiply and shift conversion with the remaining clock ticks
-- This provides the means to accurately track small differences in time while simultaneously dealing with long periods of time
-- I was never able to get the seqlock to work; the time values would always be corrupted as if the lock was not really being held
-- This two-stage approach does a little bit more work for each call compared to using a seqlock, but it avoids the latency spike that occurs when the CPU clock must be read a second time because the lock is held
-- Here is a comparison of the compiler output for different clock ticks to nsec conversion strategies: https://godbolt.org/g/uN99Gb