### PR TITLE
Fix group percent

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -497,13 +497,13 @@ static void show_ddir_status(struct group_run_stats *rs, struct thread_stat *ts,
 		}
 
 		log_buf(out, "   bw (%5s/s): min=%5llu, max=%5llu, per=%3.2f%%, "
-			"avg=%5.02f, stdev=%5.02f, samples=%5lu\n",
+			"avg=%5.02f, stdev=%5.02f, samples=%" PRIu64 "\n",
 			bw_str, min, max, p_of_agg, mean, dev,
 			(&ts->bw_stat[ddir])->samples);
 	}
 	if (calc_lat(&ts->iops_stat[ddir], &min, &max, &mean, &dev)) {
 		log_buf(out, "   iops        : min=%5llu, max=%5llu, "
-			"avg=%5.02f, stdev=%5.02f, samples=%5lu\n",
+			"avg=%5.02f, stdev=%5.02f, samples=%" PRIu64 "\n",
 			min, max, mean, dev, (&ts->iops_stat[ddir])->samples);
 	}
 }
@@ -935,12 +935,12 @@ static void show_ddir_status_terse(struct thread_stat *ts,
 
 	if (ver == 5) {
 		if (bw_stat)
-			log_buf(out, ";%lu", (&ts->bw_stat[ddir])->samples);
+			log_buf(out, ";%" PRIu64, (&ts->bw_stat[ddir])->samples);
 		else
 			log_buf(out, ";%lu", 0UL);
 
 		if (calc_lat(&ts->iops_stat[ddir], &min, &max, &mean, &dev))
-			log_buf(out, ";%llu;%llu;%f;%f;%lu", min, max,
+			log_buf(out, ";%llu;%llu;%f;%f;%" PRIu64, min, max,
 				mean, dev, (&ts->iops_stat[ddir])->samples);
 		else
 			log_buf(out, ";%llu;%llu;%f;%f;%lu", 0ULL, 0ULL, 0.0, 0.0, 0UL);

--- a/stat.c
+++ b/stat.c
@@ -483,7 +483,7 @@ static void show_ddir_status(struct group_run_stats *rs, struct thread_stat *ts,
 		}
 
 		if (rs->agg[ddir]) {
-			p_of_agg = mean * 100 / (double) rs->agg[ddir];
+			p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024);
 			if (p_of_agg > 100.0)
 				p_of_agg = 100.0;
 		}


### PR DESCRIPTION
When samples was added it started generating warning when compiling on OSX. Further when the kilobytes/kibibytes change was introduced it broke the group percentage calculation. These patches should fix both of these up.

Sadly I've noticed the group percentage sometimes gets close to 100% when using one thread in the group but without actually being 100%. This might be because the aggregate bandwidth is exact whereas the mean used is from samples which introduces a "average of averages" scenario... 