### PR TITLE
stats and documentation fixes

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -1204,7 +1204,7 @@ I/O type
 		**pareto**
 				Pareto distribution
 
-		**gauss**
+		**normal**
 				Normal (Gaussian) distribution
 
 		**zoned**
@@ -1217,8 +1217,8 @@ I/O type
 	values will yield in terms of hit rates.  If you wanted to use **zipf** with
 	a `theta` of 1.2, you would use ``random_distribution=zipf:1.2`` as the
 	option. If a non-uniform model is used, fio will disable use of the random
-	map. For the **gauss** distribution, a normal deviation is supplied as a
-	value between 0 and 100.
+	map. For the **normal** distribution, a normal (Gaussian) deviation is
+	supplied as a value between 0 and 100.
 
 	For a **zoned** distribution, fio supports specifying percentages of I/O
 	access that should fall within what range of the file or device. For

--- a/fio.1
+++ b/fio.1
@@ -1004,8 +1004,8 @@ Zipf distribution
 .B pareto
 Pareto distribution
 .TP
-.B gauss
-Normal (gaussian) distribution
+.B normal
+Normal (Gaussian) distribution
 .TP
 .B zoned
 Zoned random distribution
@@ -1017,8 +1017,8 @@ For \fBpareto\fR, it's the pareto power. Fio includes a test program, genzipf,
 that can be used visualize what the given input values will yield in terms of
 hit rates. If you wanted to use \fBzipf\fR with a theta of 1.2, you would use
 random_distribution=zipf:1.2 as the option. If a non-uniform model is used,
-fio will disable use of the random map. For the \fBgauss\fR distribution, a
-normal deviation is supplied as a value between 0 and 100.
+fio will disable use of the random map. For the \fBnormal\fR distribution, a
+normal (Gaussian) deviation is supplied as a value between 0 and 100.
 .P
 .RS
 For a \fBzoned\fR distribution, fio supports specifying percentages of IO

--- a/stat.c
+++ b/stat.c
@@ -475,17 +475,17 @@ static void show_ddir_status(struct group_run_stats *rs, struct thread_stat *ts,
 		else
 			bw_str = "kB";
 
+		if (rs->agg[ddir]) {
+			p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024);
+			if (p_of_agg > 100.0)
+				p_of_agg = 100.0;
+		}
+
 		if (rs->unit_base == 1) {
 			min *= 8.0;
 			max *= 8.0;
 			mean *= 8.0;
 			dev *= 8.0;
-		}
-
-		if (rs->agg[ddir]) {
-			p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024);
-			if (p_of_agg > 100.0)
-				p_of_agg = 100.0;
 		}
 
 		if (mean > fkb_base * fkb_base) {
@@ -924,7 +924,7 @@ static void show_ddir_status_terse(struct thread_stat *ts,
 		double p_of_agg = 100.0;
 
 		if (rs->agg[ddir]) {
-			p_of_agg = mean * 100 / (double) rs->agg[ddir];
+			p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024);
 			if (p_of_agg > 100.0)
 				p_of_agg = 100.0;
 		}
@@ -1055,7 +1055,7 @@ static void add_ddir_status_json(struct thread_stat *ts,
 
 	if (calc_lat(&ts->bw_stat[ddir], &min, &max, &mean, &dev)) {
 		if (rs->agg[ddir]) {
-			p_of_agg = mean * 100 / (double) rs->agg[ddir];
+			p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024);
 			if (p_of_agg > 100.0)
 				p_of_agg = 100.0;
 		}


### PR DESCRIPTION
The first commit finishes off the group percentage fix from a previous commit. The second changes the documentation to state that random_distribution's parameter for a Gaussian distribution is called
"normal" (but curiously file_service_type uses "gauss" for its Gaussian distribution parameter)