### PR TITLE
filesetup: keep O_DIRECT flag same as test  when pre-allocte file

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -146,6 +146,8 @@ static int extend_file(struct thread_data *td, struct fio_file *f)
 		flags |= O_CREAT;
 	if (new_layout)
 		flags |= O_TRUNC;
+	if (td->o.odirect)
+		flags |= OS_O_DIRECT;
 
 #ifdef WIN32
 	flags |= _O_BINARY;


### PR DESCRIPTION
if set direct=1, but fs not support direct io, should use O_DIRECT when
pre-allocte test file, otherwise file open success and then fallocate
will alloc memory for it.

Signed-off-by: weiping zhang <zhangweiping@didichuxing.com>