### PR TITLE
doc: remove '--runtime' command line option

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -111,9 +111,6 @@ Command line options
 	format.  `json+` is like `json`, except it adds a full dump of the latency
 	buckets.
 
-.. option:: --runtime
-	Limit run time to runtime seconds.
-
 .. option:: --bandwidth-log
 
 	Generate aggregate bandwidth logs.

--- a/fio.1
+++ b/fio.1
@@ -29,9 +29,6 @@ Set the reporting \fIformat\fR to `normal', `terse', `json', or
 is a CSV based format. `json+' is like `json', except it adds a full
 dump of the latency buckets.
 .TP
-.BI \-\-runtime \fR=\fPruntime
-Limit run time to \fIruntime\fR seconds.
-.TP
 .BI \-\-bandwidth\-log
 Generate aggregate bandwidth logs.
 .TP


### PR DESCRIPTION
Commit 5bba8b3acee1bf1359470a82cac030942018405a ("Remove '--runtime'
command line option") removed the --runtime option from the fio tool and
its internal help. This commit removes it from the documentation files
too.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>