### PR TITLE
stat: increase the size of base to avoid overflow

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -100,7 +100,8 @@ static unsigned int plat_val_to_idx(unsigned long long val)
  */
 static unsigned long long plat_idx_to_val(unsigned int idx)
 {
-	unsigned int error_bits, k, base;
+	unsigned int error_bits;
+	unsigned long long k, base;
 
 	assert(idx < FIO_IO_U_PLAT_NR);
 
@@ -111,7 +112,7 @@ static unsigned long long plat_idx_to_val(unsigned int idx)
 
 	/* Find the group and compute the minimum value of that group */
 	error_bits = (idx >> FIO_IO_U_PLAT_BITS) - 1;
-	base = 1 << (error_bits + FIO_IO_U_PLAT_BITS);
+	base = ((unsigned long long) 1) << (error_bits + FIO_IO_U_PLAT_BITS);
 
 	/* Find its bucket number of the group */
 	k = idx % FIO_IO_U_PLAT_VAL;


### PR DESCRIPTION
**plat_idx_to_val()** in stat.c has a variable base that is defined as an
unsigned int but it was designed to fit old settings where
FIO_IO_U_PLAT_GROUP_NR = 19.
However, with the alteration from usec to nsec in commit d6bb62 
(nanosecond: update completion latency recording and normal, json 
output to use nanoseconds), FIO_IO_U_PLAT_GROUP_NR is now 29 
and the range of latency changed from uint32_t to uint64_t. 
This means variable base can easily exceed a 32-bit range 
and overflow after error_bits reaches 26.

Eg

Group Id | MSB | discarded error_bits | range of value
------------ | ------------- | ------------ | -------------
27 | 32 | 26 | [4294967296, 8589934591]     
28 | 33 | 27 | [8589934591, 17179869183]
29 | 34 | 28 | [17179869184, +inf]

It should be like this if I'm not getting this wrong.

At https://github.com/axboe/fio/blob/master/stat.c#L112 in **plat_idx_to_val()**
```
/* Find the group and compute the minimum value of that group */
error_bits = (idx >> FIO_IO_U_PLAT_BITS) - 1;
base = 1 << (error_bits + FIO_IO_U_PLAT_BITS);
```
"1 << 32" and "base = " will overflow
Thus I modified it to:
```
unsigned long long k, base;
base = ((unsigned long long) 1) << (error_bits + FIO_IO_U_PLAT_BITS);
```
I also defined k as unsigned long long, just to fix this:
`return base + ((k + 0.5) * (1 << error_bits))`
(1 << error_bits) is within 32 bit range, but if multiplied by k, overflow can happen.

also see https://github.com/axboe/fio/issues/433