### PR TITLE
fio: refactor explicit directio calls

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -103,6 +103,37 @@ static void fallocate_file(struct thread_data *td, struct fio_file *f)
 }
 
 /*
+ * Helper for OSes (e.g. macOS, Solaris) that have a distinct call to mark the
+ * file non-buffered instead of using the O_DIRECT flag with open.
+ */
+static int fio_directio(struct thread_data *td, struct fio_file *f)
+{
+#ifdef FIO_OS_DIRECTIO
+	int ret;
+
+	if (!td->o.odirect) {
+		return 0;
+	}
+
+	dprint(FD_FILE, "set directio on file %s\n", f->file_name);
+	ret = fio_set_odirect(f->fd);
+	if (ret) {
+		td_verror(td, ret, "fio_set_odirect");
+		if (ret == ENOTTY) { /* ENOTTY suggests RAW device or ZFS */
+			log_err("fio: doing direct IO to RAW devices or ZFS "
+				"not supported\n");
+		} else {
+			log_err("fio: looks like your filesystem does not "
+				"support direct=1/buffered=0\n");
+		}
+
+		return ret;
+	}
+#endif
+	return 0;
+}
+
+/*
  * Leaves f->fd open on success, caller must close
  */
 static int extend_file(struct thread_data *td, struct fio_file *f)
@@ -164,7 +195,8 @@ static int extend_file(struct thread_data *td, struct fio_file *f)
 		else
 			td_verror(td, err, "open");
 		return 1;
-	}
+	} else if (fio_directio(td, f) != 0)
+		goto err;
 
 	fallocate_file(td, f);
 
@@ -709,7 +741,8 @@ open_again:
 
 		td_verror(td, __e, buf);
 		return 1;
-	}
+	} else if (fio_directio(td, f) != 0)
+		goto err;
 
 	if (!from_hash && f->fd != -1) {
 		if (add_file_hash(f)) {
@@ -737,6 +770,11 @@ open_again:
 	}
 
 	return 0;
+err:
+	close(f->fd);
+	f->fd = -1;
+
+	return 1;
 }
 
 /*

--- a/ioengines.c
+++ b/ioengines.c
@@ -495,27 +495,6 @@ int td_io_open_file(struct thread_data *td, struct fio_file *f)
 	}
 #endif
 
-#ifdef FIO_OS_DIRECTIO
-	/*
-	 * Some OS's have a distinct call to mark the file non-buffered,
-	 * instead of using O_DIRECT (Solaris)
-	 */
-	if (td->o.odirect) {
-		int ret = fio_set_odirect(f->fd);
-
-		if (ret) {
-			td_verror(td, ret, "fio_set_odirect");
-			if (ret == ENOTTY) { /* ENOTTY suggests RAW device or ZFS */
-				log_err("fio: doing directIO to RAW devices or ZFS not supported\n");
-			} else {
-				log_err("fio: the file system does not seem to support direct IO\n");
-			}
-
-			goto err;
-		}
-	}
-#endif
-
 done:
 	log_file(td, f, FIO_LOG_OPEN_FILE);
 	return 0;


### PR DESCRIPTION
Create an fio_directio() helper for the explicit directio setting call
and refactor its usage to be entirely within filesetup.c by calling it
from generic_open_file(). Also make initial layout in extend_file() call
it thus keeping up with the change introduced by
6e344dc3445bfec0583072e82bea728ab8d54d58 ("filesetup: keep OS_O_DIRECT
flag when pre-allocating file").

A positive side effect of this change means the following job

rm -f /tmp/fiofile; ./fio --loops=10 --filename /tmp/fiofile --bs=4k \
 --size=1M --direct=1 --name=go

that creates a brand new file will no longer report cached I/O speeds
(such as 2000MiB/s) on macOS. This was happening because macOS fio is
unable to invalidate already cached data (see
https://github.com/axboe/fio/issues/48 ) and data was being cached
during the layout phase.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>