### PR TITLE
arch/ppc: Fix get_cpu_clock asm clobber list

### DIFF
--- a/arch/arch-ppc.h
+++ b/arch/arch-ppc.h
@@ -62,7 +62,8 @@ static inline unsigned long long get_cpu_clock(void)
 		"	cmpwi %0,0;\n"
 		"	beq-  90b;\n"
 	: "=r" (rval)
-	: "i" (SPRN_TBRL));
+	: "i" (SPRN_TBRL)
+	: "cr0");
 
 	return rval;
 }


### PR DESCRIPTION
Mark condition register 0 (cr0) as being clobbered by the inline asm in
the ppc version of get_cpu_clock(). Not doing this results in strange
behaviour due to GCC optimising away some checking. For example:

  $ ./fio examples/null.fio --output-format=json
  time     5500  cycles_start=8085227422910      <--- bad!
  {
    "fio version" : "fio-2.21-89-gb034",
    <snip>

The extra output is due to the flag checking in dprint being removed
at higher optimisation levels.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>