### PR TITLE
glusterfs: silence printf specifier warnings

### DIFF
--- a/engines/glusterfs.c
+++ b/engines/glusterfs.c
@@ -165,11 +165,11 @@ int fio_gf_open_file(struct thread_data *td, struct fio_file *f)
 	if (td_read(td)) {
 		if (glfs_lstat(g->fs, f->file_name, &sb)
 		    || sb.st_size < f->real_file_size) {
-			dprint(FD_FILE, "fio extend file %s from %ld to %ld\n",
-			       f->file_name, sb.st_size, f->real_file_size);
+			dprint(FD_FILE, "fio extend file %s from %jd to %" PRIu64 "\n",
+			       f->file_name, (intmax_t) sb.st_size, f->real_file_size);
 			ret = glfs_ftruncate(g->fd, f->real_file_size);
 			if (ret) {
-				log_err("failed fio extend file %s to %ld\n",
+				log_err("failed fio extend file %s to %" PRIu64 "\n",
 					f->file_name, f->real_file_size);
 			} else {
 				unsigned long long left;
@@ -190,7 +190,7 @@ int fio_gf_open_file(struct thread_data *td, struct fio_file *f)
 
 					r = glfs_write(g->fd, b, bs, 0);
 					dprint(FD_IO,
-					       "fio write %d of %ld file %s\n",
+					       "fio write %d of %" PRIu64 " file %s\n",
 					       r, f->real_file_size,
 					       f->file_name);
 

--- a/engines/glusterfs_async.c
+++ b/engines/glusterfs_async.c
@@ -92,7 +92,7 @@ static void gf_async_cb(glfs_fd_t * fd, ssize_t ret, void *data)
 	struct io_u *io_u = data;
 	struct fio_gf_iou *iou = io_u->engine_data;
 
-	dprint(FD_IO, "%s ret %lu\n", __FUNCTION__, ret);
+	dprint(FD_IO, "%s ret %zd\n", __FUNCTION__, ret);
 	iou->io_complete = 1;
 }
 


### PR DESCRIPTION
On 32 bit systems compiling the gluterfs ioengine would generate some printf specifier warning so try and silence with macros and casts.