### PR TITLE
travis: add 32 bit build, minor updates and cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ compiler:
   - clang
   - gcc
 env:
+  matrix:
+    - BUILD_ARCH="x86"
+    - BUILD_ARCH="x86_64"
   global:
     - MAKEFLAGS="-j 2"
 matrix:
   include:
     - os: osx
       compiler: clang # Workaround travis setting CC=["clang", "gcc"]
+      env: BUILD_ARCH="x86_64"
     # Build using the 10.12 SDK but target and run on OSX 10.11
 #   - os: osx
 #     compiler: clang
@@ -19,12 +23,29 @@ matrix:
     # Build on the latest OSX version (will eventually become obsolete)
     - os: osx
       compiler: clang
-      osx_image: xcode8.2
+      osx_image: xcode8.3
+      env: BUILD_ARCH="x86_64"
   exclude:
     - os: osx
       compiler: gcc
+  exclude:
+    - os: linux
+      compiler: clang
+      env: BUILD_ARCH="x86" # Only do the gcc x86 build to reduce clutter
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq -y libaio-dev libnuma-dev libz-dev librbd-dev glusterfs-common libibverbs-dev librdmacm-dev; fi
+  - EXTRA_CFLAGS="-Werror"
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        pkgs=(libaio-dev libnuma-dev libz-dev librbd-dev libibverbs-dev librdmacm-dev);
+        if [[ "$BUILD_ARCH" == "x86" ]]; then
+            pkgs=("${pkgs[@]/%/:i386}");
+            pkgs+=(gcc-multilib);
+            EXTRA_CFLAGS="${EXTRA_CFLAGS} -m32";
+        else
+            pkgs+=(glusterfs-common);
+        fi;
+        sudo apt-get -qq update;
+        sudo apt-get install --no-install-recommends -qq -y "${pkgs[@]}";
+    fi
 script:
-  - ./configure --extra-cflags="-Werror" && make && make test
+  - ./configure --extra-cflags="${EXTRA_CFLAGS}" && make
+  - make test


### PR DESCRIPTION
Get Travis to build a 32 bit fio (although sadly the one engine that would have benefitted the most from this (glusterfs) has a dependency that is not multilib compatible), minor Travis file reformatting and up the version of Xcode the OSX build targets.