### PR TITLE
backend: verify-trigger fixes

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1391,6 +1391,8 @@ static bool keep_running(struct thread_data *td)
 
 	if (td->done)
 		return false;
+	if (td->terminate)
+		return false;
 	if (td->o.time_based)
 		return true;
 	if (td->o.loops) {
@@ -2042,7 +2044,10 @@ static bool __check_trigger_file(void)
 static bool trigger_timedout(void)
 {
 	if (trigger_timeout)
-		return time_since_genesis() >= trigger_timeout;
+		if (time_since_genesis() >= trigger_timeout) {
+			trigger_timeout = 0;
+			return true;
+		}
 
 	return false;
 }
@@ -2051,7 +2056,7 @@ void exec_trigger(const char *cmd)
 {
 	int ret;
 
-	if (!cmd)
+	if (!cmd || cmd[0] == '\0')
 		return;
 
 	ret = system(cmd);

--- a/server.c
+++ b/server.c
@@ -970,6 +970,7 @@ static int handle_trigger_cmd(struct fio_net_cmd *cmd)
 	} else
 		fio_net_queue_cmd(FIO_NET_CMD_VTRIGGER, rep, sz, NULL, SK_F_FREE | SK_F_INLINE);
 
+	fio_terminate_threads(TERMINATE_ALL);
 	exec_trigger(buf);
 	return 0;
 }


### PR DESCRIPTION
Clear the trigger_timeout after we have found it has been exceeded in
trigger_timedout() to stop us repeatedly firing the trigger again and
again in the future.

When --trigger-remote is unset, the server winds up with the remote
trigger command represented by buf[] being zero length rather than buf
being NULL in handle_trigger_cmd(). Cope with this by returning right
away if we find the cmd string is NULL or empty in exec_trigger().

Make server mode fio terminate after sending the verify state back to
the client so it goes on behave the same way as standalone fio. This
stops the while loop in thread_main() restating and in turn prevents
state being cleared away by clear_io_state().

Make keep_running() return false if td->terminate has been set Just In
Case.

The below would trigger the above problem before this patch:

cat <<EOF > trigger.fio
[global]
ioengine=null
time_based=1
runtime=10s
size=1M
bs=4k
rate=4k

[trigtest]
EOF
./fio --server &
./fio --trigger-timeout=2s --trigger='hostname' --client=localhost \
 --debug=net trigger.fio

Fixes https://github.com/axboe/fio/issues/431 ("fio intermittently fails
to perform IO when --trigger-timeout, --trigger is specified").

Reported-by: saurabhbpl <saurabh.shiva@gmail.com>
Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>