### PR TITLE
Clock setaffinity problem on Solaris and Friends

### DIFF
--- a/os/os-solaris.h
+++ b/os/os-solaris.h
@@ -97,7 +97,7 @@ static inline int fio_set_odirect(struct fio_file *f)
  * pset binding hooks for fio
  */
 #define fio_setaffinity(pid, cpumask)		\
-	pset_bind((cpumask), P_PID, (pid), NULL)
+	pset_bind((cpumask), P_LWPID, (pid), NULL)
 #define fio_getaffinity(pid, ptr)	({ 0; })
 
 #define fio_cpu_clear(mask, cpu)	pset_assign(PS_NONE, (cpu), NULL)


### PR DESCRIPTION
This pull request addresses an issue which was mentioned a number of times now. First mention was in https://github.com/axboe/fio/issues/46. It was just yesterday updated: https://github.com/axboe/fio/issues/46#issuecomment-328369445

I believe this problem arises due to incorrect ID type used in os-solaris.h. This fix attempts to rectify this. I tested with dtrace before and after to confirm that in fact outcome is different before change after change.

Below are results, before and after making this minor change. Result value we expect to be 0 in all instances. We observe a couple of different error codes in the before test, and they correspond to the following strings observed at the time a job is started.

```
clock setaffinity failed: Operation not supported
...and...
clock setaffinity failed: No such process
```

After making this change there are no longer any errors being printed, and dtrace confirms that we get zeros for each call.

 ```
 dtrace -qn '
    /*
        Function Arguments:
        args[0]: psetid_t
        args[1]: idtype_t
        args[2]: id_t
        args[3]: int *
     */
    ::pset_bind:entry {
        self->x = 1;
        this->a0 = args[0];
        this->a1 = args[1];
        this->a2 = args[2];
        this->a3 = args[3];        
    }
    ::pset_bind:return /self->x/ {
      @[tid, this->a0, this->a1, this->a2, this->a3, args[1]] = count();
        self->x = 0;
    }
    END {
      printa("tid=%-4d pset=%-4d idtype=%-4d id=%-4d opset=%-8p result=%-4d count=%@d\n", @);
    }'

### Before ###
tid=2    pset=11   idtype=0    id=18   opset=0        result=48   count=1
tid=3    pset=0    idtype=0    id=0    opset=0        result=48   count=1
tid=4    pset=14   idtype=0    id=24   opset=0        result=48   count=1
tid=5    pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=6    pset=14   idtype=0    id=24   opset=0        result=48   count=1
tid=7    pset=23   idtype=0    id=25   opset=0        result=3    count=1
tid=8    pset=14   idtype=0    id=24   opset=0        result=3    count=1
tid=9    pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=10   pset=16   idtype=0    id=10   opset=0        result=0    count=1
tid=11   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=12   pset=0    idtype=0    id=0    opset=0        result=0    count=1
tid=13   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=14   pset=17   idtype=0    id=12   opset=0        result=3    count=1
tid=15   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=16   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=17   pset=18   idtype=0    id=15   opset=0        result=3    count=1
tid=18   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=19   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=20   pset=16   idtype=0    id=10   opset=0        result=3    count=1
tid=21   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=22   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=23   pset=0    idtype=0    id=0    opset=0        result=3    count=1
tid=24   pset=14   idtype=0    id=24   opset=0        result=3    count=1
tid=25   pset=23   idtype=0    id=25   opset=0        result=3    count=1


### After ###
tid=2    pset=0    idtype=0    id=0    opset=0        result=0    count=1
tid=3    pset=3    idtype=8    id=3    opset=0        result=0    count=1
tid=4    pset=15   idtype=8    id=6    opset=0        result=0    count=1
tid=5    pset=19   idtype=8    id=13   opset=0        result=0    count=1
tid=6    pset=15   idtype=8    id=6    opset=0        result=0    count=1
tid=7    pset=17   idtype=8    id=9    opset=0        result=0    count=1
tid=8    pset=15   idtype=8    id=6    opset=0        result=0    count=1
tid=9    pset=17   idtype=8    id=9    opset=0        result=0    count=1
tid=10   pset=15   idtype=8    id=6    opset=0        result=0    count=1
tid=11   pset=19   idtype=8    id=13   opset=0        result=0    count=1
tid=12   pset=0    idtype=0    id=0    opset=0        result=0    count=1
tid=13   pset=19   idtype=8    id=13   opset=0        result=0    count=1
tid=14   pset=15   idtype=8    id=6    opset=0        result=0    count=1
tid=15   pset=17   idtype=8    id=9    opset=0        result=0    count=1
tid=16   pset=15   idtype=8    id=6    opset=0        result=0    count=1
tid=17   pset=10   idtype=8    id=17   opset=0        result=0    count=1
tid=18   pset=11   idtype=8    id=20   opset=0        result=0    count=1
tid=19   pset=17   idtype=8    id=9    opset=0        result=0    count=1
tid=20   pset=11   idtype=8    id=20   opset=0        result=0    count=1
tid=21   pset=5    idtype=8    id=8    opset=0        result=0    count=1
tid=22   pset=3    idtype=8    id=22   opset=0        result=0    count=1
tid=23   pset=11   idtype=8    id=20   opset=0        result=0    count=1
tid=24   pset=11   idtype=8    id=20   opset=0        result=0    count=1
tid=25   pset=17   idtype=8    id=9    opset=0        result=0    count=1
```