### PR TITLE
Add note for increasing shmmax if necessary

### DIFF
--- a/fio.1
+++ b/fio.1
@@ -113,6 +113,8 @@ All fio parser warnings are fatal, causing fio to exit with an error.
 .TP
 .BI \-\-max\-jobs \fR=\fPnr
 Set the maximum number of threads/processes to support to \fInr\fR.
+NOTE: On Linux, it may be necessary to increase the shared-memory limit
+(`/proc/sys/kernel/shmmax') if fio runs into errors while creating jobs.
 .TP
 .BI \-\-server \fR=\fPargs
 Start a backend server, with \fIargs\fR specifying what to listen to.


### PR DESCRIPTION
While trying out a large-ish fio test in a machine with 4 GB of RAM, `fio` ran out of shared memory by a small amount.  After checking with `strace` for clues, I've noticed the probing for shmem.  The system could accomodate using 64 MB instead of ~33 MB (auto-tuned by the kernel).  `fio` ran happily.