### PR TITLE
gettime: fix cycles_per_msec overflow when using 32 bit longs

### DIFF
--- a/gettime.c
+++ b/gettime.c
@@ -15,7 +15,7 @@
 
 #if defined(ARCH_HAVE_CPU_CLOCK)
 #ifndef ARCH_CPU_CLOCK_CYCLES_PER_USEC
-static unsigned long cycles_per_msec;
+static unsigned long long cycles_per_msec;
 static unsigned long long cycles_start;
 static unsigned long long clock_mult;
 static unsigned long long max_cycles_mask;


### PR DESCRIPTION
Compiling fio with clang's undefined behaviour sanitizer and unsigned
wraparound detection enabled on a 32 bit Linux build turned up the
following:

gettime.c:313:28: runtime error: unsigned integer overflow: 3600 * 2600730 cannot be represented in type 'unsigned long'

Fix this by make cycles_per_msec a long long.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>