### PR TITLE
Eta display fixes

### DIFF
--- a/eta.c
+++ b/eta.c
@@ -531,6 +531,7 @@ void display_thread_status(struct jobs_eta *je)
 
 	if (eta_new_line_pending) {
 		eta_new_line_pending = 0;
+		linelen_last = 0;
 		p += sprintf(p, "\n");
 	}
 

--- a/eta.c
+++ b/eta.c
@@ -565,6 +565,7 @@ void display_thread_status(struct jobs_eta *je)
 		size_t left;
 		int l;
 		int ddir;
+		int linelen;
 
 		if ((!je->eta_sec && !eta_good) || je->nr_ramp == je->nr_running ||
 		    je->eta_sec == -1)
@@ -606,9 +607,10 @@ void display_thread_status(struct jobs_eta *je)
 		if (l >= left)
 			l = left - 1;
 		p += l;
-		if (l >= 0 && l < linelen_last)
-			p += sprintf(p, "%*s", linelen_last - l, "");
-		linelen_last = l;
+		linelen = p - output;
+		if (l >= 0 && linelen < linelen_last)
+			p += sprintf(p, "%*s", linelen_last - linelen, "");
+		linelen_last = linelen;
 
 		for (ddir = 0; ddir < DDIR_RWDIR_CNT; ddir++) {
 			free(rate_str[ddir]);

--- a/eta.c
+++ b/eta.c
@@ -520,7 +520,7 @@ void display_thread_status(struct jobs_eta *je)
 	static int eta_new_line_init, eta_new_line_pending;
 	static int linelen_last;
 	static int eta_good;
-	char output[REAL_MAX_JOBS + 512], *p = output;
+	char output[__THREAD_RUNSTR_SZ(REAL_MAX_JOBS) + 512], *p = output;
 	char eta_str[128];
 	double perc = 0.0;
 

--- a/eta.c
+++ b/eta.c
@@ -585,7 +585,7 @@ void display_thread_status(struct jobs_eta *je)
 			iops_str[ddir] = num2str(je->iops[ddir], 4, 1, 0, N2S_NONE);
 		}
 
-		left = sizeof(output) - (p - output) - 2;
+		left = sizeof(output) - (p - output) - 1;
 
 		if (je->rate[DDIR_TRIM] || je->iops[DDIR_TRIM])
 			l = snprintf(p, left,
@@ -601,8 +601,9 @@ void display_thread_status(struct jobs_eta *je)
 				rate_str[DDIR_READ], rate_str[DDIR_WRITE],
 				iops_str[DDIR_READ], iops_str[DDIR_WRITE],
 				eta_str);
-		if (l > left)
-			l = left;
+		/* If truncation occurred adjust l so p is on the null */
+		if (l >= left)
+			l = left - 1;
 		p += l;
 		if (l >= 0 && l < linelen_last)
 			p += sprintf(p, "%*s", linelen_last - l, "");

--- a/eta.c
+++ b/eta.c
@@ -9,7 +9,7 @@
 #include "lib/pow2.h"
 
 static char __run_str[REAL_MAX_JOBS + 1];
-static char run_str[__THREAD_RUNSTR_SZ(REAL_MAX_JOBS)];
+static char run_str[__THREAD_RUNSTR_SZ(REAL_MAX_JOBS) + 1];
 
 static void update_condensed_str(char *rstr, char *run_str_condensed)
 {


### PR DESCRIPTION
A bunch of commits around the eta display that

* Fix various off-by-one errors
* Skip the clearing the stale parts of a line when we are starting a new line anyway
* A change how we work out how much of a line is stale
* An increase of the output buffer (as requested in https://github.com/axboe/fio/issues/500#issuecomment-353374981 )

The new stale line clearing is inexact - if the eta line had a newline and then printed 40 characters and the current eta line just prints 40 characters then we will end up thinking we need to clear one character. If you think that is necessary it could be fixed by introducing a variable to track where the "true" start of the line is within the buffer.