### PR TITLE
Percentile fixes

### DIFF
--- a/init.c
+++ b/init.c
@@ -938,6 +938,11 @@ static int fixup_options(struct thread_data *td)
 		ret = 1;
 	}
 
+	if (o->disable_lat)
+		o->lat_percentiles = 0;
+	if (o->disable_clat)
+		o->clat_percentiles = 0;
+
 	/*
 	 * Fix these up to be nsec internally
 	 */

--- a/stat.c
+++ b/stat.c
@@ -460,8 +460,15 @@ static void show_ddir_status(struct group_run_stats *rs, struct thread_stat *ts,
 		display_lat(" lat", min, max, mean, dev, out);
 
 	if (ts->clat_percentiles || ts->lat_percentiles) {
+		uint64_t samples;
+
+		if (ts->clat_percentiles)
+			samples = ts->clat_stat[ddir].samples;
+		else
+			samples = ts->lat_stat[ddir].samples;
+
 		show_clat_percentiles(ts->io_u_plat[ddir],
-					ts->clat_stat[ddir].samples,
+					samples,
 					ts->percentile_list,
 					ts->percentile_precision,
 					ts->clat_percentiles, out);


### PR DESCRIPTION
First fix address total latency percentiles being 0 when only completion latency is disabled.

The second disables percentile gathering when the corresponding latency option has been disabled. This later change might be more contentious as it might make some outputs (e.g. percentiles with JSON) no longer appear to be present when using conflicting options...