### PR TITLE
filesetup: skip fallback invalidation with diskless ioengines

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -490,6 +490,10 @@ static int __file_invalidate_cache(struct thread_data *td, struct fio_file *f,
 		ret = td->io_ops->invalidate(td, f);
 		if (ret < 0)
 			errval = -ret;
+	} else if (td_ioengine_flagged(td, FIO_DISKLESSIO)) {
+		dprint(FD_IO, "invalidate not supported by ioengine %s\n",
+		       td->io_ops->name);
+		ret = 0;
 	} else if (f->filetype == FIO_TYPE_FILE) {
 		dprint(FD_IO, "declare unneeded cache %s: %llu/%llu\n",
 			f->file_name, off, len);


### PR DESCRIPTION
Since commit 0bcf41cdc22dfee6b3f3b2ba9a533b4b103c70c2 ("io_u:
re-invalidate cache when looping around without file open/close") the
job:

./fio --ioengine=null --size=4k --bs=4k --rate=4k \
 --time_based --runtime=2s --name=badinvalidate

repeatedly produces the following warning while running:

fio: cache invalidation of badinvalidate.0.0 failed: Bad file descriptor

Fix this by skipping cache invalidation and logging a debug message for
diskless ioengines that don't define an explicit invalidation op.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>