### PR TITLE
Correct slave device dev path

### DIFF
--- a/diskutil.c
+++ b/diskutil.c
@@ -253,7 +253,7 @@ static void find_add_disk_slaves(struct thread_data *td, char *path,
 		}
 		slavepath[linklen] = '\0';
 
-		sprintf(temppath, "%s/%s/dev", slavesdir, slavepath);
+		sprintf(temppath, "%s/%s/device/dev", slavesdir, slavepath);
 		if (read_block_dev_entry(temppath, &majdev, &mindev)) {
 			perror("Error getting slave device numbers.");
 			closedir(dirhandle);


### PR DESCRIPTION
Running fio over NVMEoF multipath slave devices is failing with "No such
file or directory" error.
Corrected the dev path for slave devices.
Supposed fix for issue #525

Signed-off-by: Potnuri Bharat Teja <bharat@chelsio.com>