### PR TITLE
Fix Linux NVMe disk stats

### DIFF
--- a/diskutil.c
+++ b/diskutil.c
@@ -246,7 +246,7 @@ static void find_add_disk_slaves(struct thread_data *td, char *path,
 		 * devices?
 		 */
 		linklen = readlink(temppath, slavepath, PATH_MAX - 1);
-		if (linklen  < 0) {
+		if (linklen < 0) {
 			perror("readlink() for slave device.");
 			closedir(dirhandle);
 			return;
@@ -257,7 +257,7 @@ static void find_add_disk_slaves(struct thread_data *td, char *path,
 		if (access(temppath, F_OK) != 0)
 			sprintf(temppath, "%s/%s/device/dev", slavesdir, slavepath);
 		if (read_block_dev_entry(temppath, &majdev, &mindev)) {
-			perror("Error getting slave device numbers.");
+			perror("Error getting slave device numbers");
 			closedir(dirhandle);
 			return;
 		}

--- a/diskutil.c
+++ b/diskutil.c
@@ -254,6 +254,8 @@ static void find_add_disk_slaves(struct thread_data *td, char *path,
 		slavepath[linklen] = '\0';
 
 		sprintf(temppath, "%s/%s/dev", slavesdir, slavepath);
+		if (access(temppath, F_OK) != 0)
+			sprintf(temppath, "%s/%s/device/dev", slavesdir, slavepath);
 		if (read_block_dev_entry(temppath, &majdev, &mindev)) {
 			perror("Error getting slave device numbers.");
 			closedir(dirhandle);


### PR DESCRIPTION
The main commit builds on the work of @bharatpotnuri in https://github.com/axboe/fio/pull/526. As the the main NVMe disk doesn't record any stats when NVMe multipath is in use and virtual NVMe slave devices aren't real block devices it is necessary to try a different sysfs path when the usual one fails.

The second commit just changes some spacing and remove a dot in logging.