### PR TITLE
Disable march optimisations in a couple of scenarios

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - SET PATH=%CYG_ROOT%\bin;%PATH% # NB: Changed env variables persist to later sections
 
 build_script:
-  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && ./configure --extra-cflags=\"-Werror\" ${CONFIGURE_OPTIONS} && make.exe'
+  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && ./configure --disable-native --extra-cflags=\"-Werror\" ${CONFIGURE_OPTIONS} && make.exe'
 
 after_build:
   - cd os\windows && dobuild.cmd %PLATFORM%

--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # Fio configure script. Heavily influenced by the manual qemu configure
-# script. Sad this this is easier than autoconf and enemies.
+# script. Sad this is easier than autoconf and enemies.
 #
 
 # set temporary file name
@@ -2114,7 +2114,8 @@ int main(int argc, char **argv)
   return 0;
 }
 EOF
-if test "$disable_native" = "no" && compile_prog "-march=native" "" "march=native"; then
+if test "$disable_native" = "no" && test "$disable_opt" != "yes" && \
+   compile_prog "-march=native" "" "march=native"; then
   build_native="yes"
 fi
 print_config "Build march=native" "$build_native"


### PR DESCRIPTION
* If the user is specifying `--disable-optimizations` turn off `march=native` setting too because the chances are they aren't interested. This should keep some distros that already specify `--disable-optimizations` when building their fio packages from getting surprised...
* Disable `march=native` setting in AppVeyor builds. While this technically means we aren't running with the same defaults users get out of the box it's safer to prevent the downloadable MSI binaries from gaining instructions that might be specific to the cloud build host. I suppose if we care enough we can introduce a "native" CI build too but it doesn't seem worth it for now.