### PR TITLE
Add an asprintf() implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ endif
 ifdef CONFIG_RBD
   SOURCE += engines/rbd.c
 endif
+SOURCE += oslib/asprintf.c
 ifndef CONFIG_STRSEP
   SOURCE += oslib/strsep.c
 endif

--- a/configure
+++ b/configure
@@ -784,6 +784,40 @@ fi
 print_config "rdmacm" "$rdmacm"
 
 ##########################################
+# asprintf() and vasprintf() probes
+if test "$have_asprintf" != "yes" ; then
+  have_asprintf="no"
+fi
+cat > $TMPC << EOF
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  return asprintf(NULL, "%s", "str") == 0;
+}
+EOF
+if compile_prog "" "" "have_asprintf"; then
+    have_asprintf="yes"
+fi
+print_config "asprintf()" "$have_asprintf"
+
+if test "$have_vasprintf" != "yes" ; then
+  have_vasprintf="no"
+fi
+cat > $TMPC << EOF
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  return vasprintf(NULL, "%s", NULL) == 0;
+}
+EOF
+if compile_prog "" "" "have_vasprintf"; then
+    have_vasprintf="yes"
+fi
+print_config "vasprintf()" "$have_vasprintf"
+
+##########################################
 # Linux fallocate probe
 if test "$linux_fallocate" != "yes" ; then
   linux_fallocate="no"
@@ -2168,6 +2202,12 @@ if test "$posix_aio_fsync" = "yes" ; then
 fi
 if test "$posix_pshared" = "yes" ; then
   output_sym "CONFIG_PSHARED"
+fi
+if test "$have_asprintf" = "yes" ; then
+    output_sym "HAVE_ASPRINTF"
+fi
+if test "$have_vasprintf" = "yes" ; then
+    output_sym "HAVE_VASPRINTF"
 fi
 if test "$linux_fallocate" = "yes" ; then
   output_sym "CONFIG_LINUX_FALLOCATE"

--- a/oslib/asprintf.c
+++ b/oslib/asprintf.c
@@ -1,0 +1,43 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "oslib/asprintf.h"
+
+#ifndef HAVE_VASPRINTF
+int vasprintf(char **strp, const char *fmt, va_list ap)
+{
+    va_list ap_copy;
+    char *str;
+    int len;
+
+#ifdef va_copy
+    va_copy(ap_copy, ap);
+#else
+    __va_copy(ap_copy, ap);
+#endif
+    len = vsnprintf(NULL, 0, fmt, ap_copy);
+    va_end(ap_copy);
+
+    if (len < 0)
+        return len;
+
+    len++;
+    str = malloc(len);
+    *strp = str;
+    return str ? vsnprintf(str, len, fmt, ap) : -1;
+}
+#endif
+
+#ifndef HAVE_ASPRINTF
+int asprintf(char **strp, const char *fmt, ...)
+{
+    va_list arg;
+    int done;
+
+    va_start(arg, fmt);
+    done = vasprintf(strp, fmt, arg);
+    va_end(arg);
+
+    return done;
+}
+#endif

--- a/oslib/asprintf.h
+++ b/oslib/asprintf.h
@@ -1,0 +1,11 @@
+#ifndef FIO_ASPRINTF_H
+#define FIO_ASPRINTF_H
+
+#ifndef HAVE_VASPRINTF
+int vasprintf(char **strp, const char *fmt, va_list ap);
+#endif
+#ifndef HAVE_ASPRINTF
+int asprintf(char **strp, const char *fmt, ...);
+#endif
+
+#endif /* FIO_ASPRINTF_H */


### PR DESCRIPTION
Since I would like to use the asprintf() function in the ZBC code and since that function is not available on every platform supported by fio, add an asprintf() implementation. Use asprintf() where appropriate.