### PR TITLE
Make switch_ioscheduler() easier to analyze

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1364,13 +1364,13 @@ static int switch_ioscheduler(struct thread_data *td)
 	/*
 	 * Read back and check that the selected scheduler is now the default.
 	 */
-	memset(tmp, 0, sizeof(tmp));
-	ret = fread(tmp, sizeof(tmp), 1, f);
+	ret = fread(tmp, 1, sizeof(tmp) - 1, f);
 	if (ferror(f) || ret < 0) {
 		td_verror(td, errno, "fread");
 		fclose(f);
 		return 1;
 	}
+	tmp[ret] = '\0';
 	/*
 	 * either a list of io schedulers or "none\n" is expected.
 	 */

--- a/backend.c
+++ b/backend.c
@@ -1328,7 +1328,7 @@ static int init_io_u(struct thread_data *td)
 static int switch_ioscheduler(struct thread_data *td)
 {
 #ifdef FIO_HAVE_IOSCHED_SWITCH
-	char tmp[256], tmp2[128];
+	char tmp[256], tmp2[128], *p;
 	FILE *f;
 	int ret;
 
@@ -1372,9 +1372,11 @@ static int switch_ioscheduler(struct thread_data *td)
 	}
 	tmp[ret] = '\0';
 	/*
-	 * either a list of io schedulers or "none\n" is expected.
+	 * either a list of io schedulers or "none\n" is expected. Strip the
+	 * trailing newline.
 	 */
-	tmp[strlen(tmp) - 1] = '\0';
+	p = tmp;
+	strsep(&p, "\n");
 
 	/*
 	 * Write to "none" entry doesn't fail, so check the result here.


### PR DESCRIPTION
The two patches in this pull request do not change the behavior of switch_ioscheduler() but make this function easier to analyze for static analyzers like Coverity.