### PR TITLE
Aarch64 crc32c + minor style fixes

### DIFF
--- a/arch/arch-aarch64.h
+++ b/arch/arch-aarch64.h
@@ -27,8 +27,4 @@ static inline int arch_ffz(unsigned long bitmask)
 
 #define ARCH_HAVE_FFZ
 
-#ifdef ARCH_HAVE_CRC_CRYPTO
-#define ARCH_HAVE_ARM64_CRC_CRYPTO
-#endif
-
 #endif

--- a/configure
+++ b/configure
@@ -2108,18 +2108,23 @@ if test "$march_armv8_a_crc_crypto" != "yes" ; then
 fi
 if test "$cpu" = "arm64" ; then
   cat > $TMPC <<EOF
-#include <sys/auxv.h>
 #include <arm_acle.h>
 #include <arm_neon.h>
+#include <sys/auxv.h>
 
 int main(void)
 {
-  return 0;
+  /* Can we also do a runtime probe? */
+#if __linux__
+  return getauxval(AT_HWCAP);
+#else
+# error "Don't know how to do runtime probe for ARM CRC32c"
+#endif
 }
 EOF
-  if compile_prog "-march=armv8-a+crc+crypto" "" ""; then
+  if compile_prog "-march=armv8-a+crc+crypto" "" "ARM CRC32c"; then
     march_armv8_a_crc_crypto="yes"
-    CFLAGS="$CFLAGS -march=armv8-a+crc+crypto -DARCH_HAVE_CRC_CRYPTO"
+    CFLAGS="$CFLAGS -march=armv8-a+crc+crypto"
     march_set="yes"
   fi
 fi
@@ -2420,6 +2425,9 @@ if test "$zlib" = "no" ; then
   if test "$build_static" = "yes"; then
     echo "Note that some distros have separate packages for static libraries."
   fi
+fi
+if test "$march_armv8_a_crc_crypto" = "yes" ; then
+  output_sym "ARCH_HAVE_CRC_CRYPTO"
 fi
 if test "$cuda" = "yes" ; then
   output_sym "CONFIG_CUDA"

--- a/configure
+++ b/configure
@@ -600,7 +600,7 @@ int main(void)
 EOF
 if compile_prog "" "" "posixaio" ; then
   posix_aio="yes"
-elif compile_prog "" "-lrt" "posixaio"; then
+elif compile_prog "" "-lrt" "posixaio -lrt"; then
   posix_aio="yes"
   posix_aio_lrt="yes"
   LIBS="-lrt $LIBS"

--- a/crc/crc32c-arm64.c
+++ b/crc/crc32c-arm64.c
@@ -1,4 +1,9 @@
 #include "crc32c.h"
+#include "../os/os.h"
+
+bool crc32c_arm64_available = false;
+
+#ifdef ARCH_HAVE_CRC_CRYPTO
 
 #define CRC32C3X8(ITR) \
 	crc1 = __crc32cd(crc1, *((const uint64_t *)data + 42*1 + (ITR)));\
@@ -15,15 +20,6 @@
 	CRC32C3X8((ITR)*7+6) \
 	} while(0)
 
-#ifndef HWCAP_CRC32
-#define HWCAP_CRC32             (1 << 7)
-#endif /* HWCAP_CRC32 */
-
-bool crc32c_arm64_available = false;
-
-#ifdef ARCH_HAVE_ARM64_CRC_CRYPTO
-
-#include <sys/auxv.h>
 #include <arm_acle.h>
 #include <arm_neon.h>
 
@@ -102,13 +98,10 @@ uint32_t crc32c_arm64(unsigned char const *data, unsigned long length)
 
 void crc32c_arm64_probe(void)
 {
-	unsigned long hwcap;
-
 	if (!crc32c_probed) {
-		hwcap = getauxval(AT_HWCAP);
-		crc32c_arm64_available = (hwcap & HWCAP_CRC32) != 0;
+		crc32c_arm64_available = os_cpu_has(CPU_ARM64_CRC32C);
 		crc32c_probed = true;
 	}
 }
 
-#endif /* ARCH_HAVE_ARM64_CRC_CRYPTO */
+#endif /* ARCH_HAVE_CRC_CRYPTO */

--- a/crc/crc32c-intel.c
+++ b/crc/crc32c-intel.c
@@ -84,4 +84,4 @@ void crc32c_intel_probe(void)
 	}
 }
 
-#endif /* ARCH_HAVE_SSE */
+#endif /* ARCH_HAVE_SSE4_2 */

--- a/crc/crc32c.h
+++ b/crc/crc32c.h
@@ -27,7 +27,7 @@ extern uint32_t crc32c_sw(unsigned char const *, unsigned long);
 extern bool crc32c_arm64_available;
 extern bool crc32c_intel_available;
 
-#ifdef ARCH_HAVE_ARM64_CRC_CRYPTO
+#ifdef ARCH_HAVE_CRC_CRYPTO
 extern uint32_t crc32c_arm64(unsigned char const *, unsigned long);
 extern void crc32c_arm64_probe(void);
 #else
@@ -35,7 +35,7 @@ extern void crc32c_arm64_probe(void);
 static inline void crc32c_arm64_probe(void)
 {
 }
-#endif
+#endif /* ARCH_HAVE_CRC_CRYPTO */
 
 #ifdef ARCH_HAVE_SSE4_2
 extern uint32_t crc32c_intel(unsigned char const *, unsigned long);

--- a/crc/crc32c.h
+++ b/crc/crc32c.h
@@ -45,7 +45,7 @@ extern void crc32c_intel_probe(void);
 static inline void crc32c_intel_probe(void)
 {
 }
-#endif
+#endif /* ARCH_HAVE_SSE4_2 */
 
 static inline uint32_t fio_crc32c(unsigned char const *buf, unsigned long len)
 {

--- a/os/os-linux.h
+++ b/os/os-linux.h
@@ -19,6 +19,13 @@
 #include <linux/fs.h>
 #include <scsi/sg.h>
 
+#ifdef ARCH_HAVE_CRC_CRYPTO
+#include <sys/auxv.h>
+#ifndef HWCAP_CRC32
+#define HWCAP_CRC32             (1 << 7)
+#endif /* HWCAP_CRC32 */
+#endif /* ARCH_HAVE_CRC_CRYPTO */
+
 #include "./os-linux-syscall.h"
 #include "binject.h"
 #include "../file.h"
@@ -409,5 +416,25 @@ static inline bool fio_fallocate(struct fio_file *f, uint64_t offset,
 	return false;
 }
 #endif
+
+#define FIO_HAVE_CPU_HAS
+static inline bool os_cpu_has(cpu_features feature)
+{
+	bool have_feature;
+	unsigned long fio_unused hwcap;
+
+	switch (feature) {
+#ifdef ARCH_HAVE_CRC_CRYPTO
+	case CPU_ARM64_CRC32C:
+		hwcap = getauxval(AT_HWCAP);
+		have_feature = (hwcap & HWCAP_CRC32) != 0;
+		break;
+#endif
+	default:
+		have_feature = false;
+	}
+
+	return have_feature;
+}
 
 #endif

--- a/os/os.h
+++ b/os/os.h
@@ -27,6 +27,10 @@ enum {
 	os_nr,
 };
 
+typedef enum {
+        CPU_ARM64_CRC32C,
+} cpu_features;
+
 /* IWYU pragma: begin_exports */
 #if defined(__ANDROID__)
 #include "os-android.h"
@@ -385,6 +389,13 @@ static inline bool fio_fallocate(struct fio_file *f, uint64_t offset, uint64_t l
 
 #if defined(CONFIG_POSIX_FALLOCATE) || defined(FIO_HAVE_NATIVE_FALLOCATE)
 # define FIO_HAVE_ANY_FALLOCATE
+#endif
+
+#ifndef FIO_HAVE_CPU_HAS
+static inline bool os_cpu_has(cpu_features feature)
+{
+	return false;
+}
 #endif
 
 #endif


### PR DESCRIPTION
It turns out FreeBSD 12 has added a `sys/auxv.h` header but does not implement `getauxval()` (they have added a slightly incompatible alternative called `elf_aux_info()`) causing issues so the first commit makes the configure test more robust by checking we also have `getauxval()` (but only on Linux) and erroring in other cases. Also move Linux specific runtime check into `os/os.h` and reduce some defines.

(I've a follow on commit in https://github.com/sitsofe/fio/tree/aarch64-crc32c-freebsd that adds runtime CRC32c detection for FreeBSD/arm64 it but FreeBSD haven't gotten around to hooking up the code in their kernel that fills out `AT_HWCAP2` on aarch64 so my commit couldn't be tested in the case where the feature should be detected successfully at runtime...)

The second commit here just adds some #endif comments and makes it clearer what the second posixaio test is doing when you look in `config.log`.