### PR TITLE
Fix floating point option range formatting

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -71,13 +71,17 @@ static void show_option_range(const struct fio_option *o,
 			      size_t (*logger)(const char *format, ...))
 {
 	if (o->type == FIO_OPT_FLOAT_LIST) {
+		const char *sep = "";
 		if (!o->minfp && !o->maxfp)
 			return;
 
-		if (o->minfp != DBL_MIN)
-			logger("%20s: min=%f", "range", o->minfp);
+		logger("%20s: ", "range");
+		if (o->minfp != DBL_MIN) {
+			logger("min=%f", o->minfp);
+			sep = ", ";
+		}
 		if (o->maxfp != DBL_MAX)
-			logger(", max=%f", o->maxfp);
+			logger("%smax=%f", sep, o->maxfp);
 		logger("\n");
 	} else if (!o->posval[0].ival) {
 		if (!o->minval && !o->maxval)


### PR DESCRIPTION
Ensure that floating point option ranges are properly formatted if
only one of the two boundaries is specified. A few examples of how
option ranges are formatted with this patch applied:

               range: max=100.000000
               range: min=0.000000, max=100.000000
               range: min=0.000000

Reported-by: Sitsofe Wheeler <sitsofe@gmail.com>
Signed-off-by: Bart Van Assche <bart.vanassche@wdc.com>