### PR TITLE
NVML renamed to PMDK

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -1854,12 +1854,12 @@ I/O engine
 
 		**pmemblk**
 			Read and write using filesystem DAX to a file on a filesystem
-			mounted with DAX on a persistent memory device through the NVML
+			mounted with DAX on a persistent memory device through the PMDK
 			libpmemblk library.
 
 		**dev-dax**
 			Read and write using device DAX to a persistent memory device (e.g.,
-			/dev/dax0.0) through the NVML libpmem library.
+			/dev/dax0.0) through the PMDK libpmem library.
 
 		**external**
 			Prefix to specify loading an external I/O engine object file. Append
@@ -1875,7 +1875,7 @@ I/O engine
 
 		**libpmem**
 			Read and write using mmap I/O to a file on a filesystem
-			mounted with DAX on a persistent memory device through the NVML
+			mounted with DAX on a persistent memory device through the PMDK
 			libpmem library.
 
 I/O engine specific parameters

--- a/configure
+++ b/configure
@@ -1894,15 +1894,15 @@ fi
 
 ##########################################
 # Report whether pmemblk engine is enabled
-print_config "NVML pmemblk engine" "$pmemblk"
+print_config "PMDK pmemblk engine" "$pmemblk"
 
 ##########################################
 # Report whether dev-dax engine is enabled
-print_config "NVML dev-dax engine" "$devdax"
+print_config "PMDK dev-dax engine" "$devdax"
 
 ##########################################
 # Report whether libpmem engine is enabled
-print_config "NVML libpmem engine" "$pmem"
+print_config "PMDK libpmem engine" "$pmem"
 
 ##########################################
 # Check if we have lex/yacc available

--- a/engines/libpmem.c
+++ b/engines/libpmem.c
@@ -1,5 +1,5 @@
 /*
- * libpmem: IO engine that uses NVML libpmem to read and write data
+ * libpmem: IO engine that uses PMDK libpmem to read and write data
  *
  * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation.
  *

--- a/engines/pmemblk.c
+++ b/engines/pmemblk.c
@@ -1,5 +1,5 @@
 /*
- * pmemblk: IO engine that uses NVML libpmemblk to read and write data
+ * pmemblk: IO engine that uses PMDK libpmemblk to read and write data
  *
  * Copyright (C) 2016 Hewlett Packard Enterprise Development LP
  *

--- a/fio.1
+++ b/fio.1
@@ -1628,12 +1628,12 @@ constraint.
 .TP
 .B pmemblk
 Read and write using filesystem DAX to a file on a filesystem
-mounted with DAX on a persistent memory device through the NVML
+mounted with DAX on a persistent memory device through the PMDK
 libpmemblk library.
 .TP
 .B dev\-dax
 Read and write using device DAX to a persistent memory device (e.g.,
-/dev/dax0.0) through the NVML libpmem library.
+/dev/dax0.0) through the PMDK libpmem library.
 .TP
 .B external
 Prefix to specify loading an external I/O engine object file. Append
@@ -1649,7 +1649,7 @@ done other than creating the file.
 .TP
 .B libpmem
 Read and write using mmap I/O to a file on a filesystem
-mounted with DAX on a persistent memory device through the NVML
+mounted with DAX on a persistent memory device through the PMDK
 libpmem library.
 .SS "I/O engine specific parameters"
 In addition, there are some parameters which are only valid when a specific

--- a/options.c
+++ b/options.c
@@ -1851,7 +1851,7 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 #endif
 #ifdef CONFIG_PMEMBLK
 			  { .ival = "pmemblk",
-			    .help = "NVML libpmemblk based IO engine",
+			    .help = "PMDK libpmemblk based IO engine",
 			  },
 
 #endif
@@ -1870,7 +1870,7 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 			  },
 #ifdef CONFIG_LIBPMEM
 			  { .ival = "libpmem",
-			    .help = "NVML libpmem based IO engine",
+			    .help = "PMDK libpmem based IO engine",
 			  },
 #endif
 		},


### PR DESCRIPTION
The NVML library was renamed to PMDK (Persistent Memory Development Kit).  Project homepage can be found at http://pmem.io/pmdk/.  The PMDK code is hosted at https://github.com/pmem/pmdk/.  A blog entry announcing the change can be found here: http://pmem.io/2017/12/11/NVML-is-now-PMDK.html.