### PR TITLE
rados: ddd reuse support to rados engine

### DIFF
--- a/examples/rados.fio
+++ b/examples/rados.fio
@@ -15,10 +15,27 @@ ioengine=rados
 clientname=admin
 pool=rados
 busy_poll=0
-rw=randwrite
-bs=4k
 
 [rbd_iodepth32]
 iodepth=32
 size=128m
-nr_files=32
+nr_files=128
+rw=randwrite
+# whether cleanup the pool or not
+cleanup=0
+# reuse the object with namespace
+reuse=1
+bs=1M
+io_size=1G
+stonewall
+
+[rbd_iodepth64]
+iodepth=64
+size=128m
+nr_files=128
+rw=randread
+cleanup=1
+reuse=1
+bs=4k
+io_size=10M
+stonewall


### PR DESCRIPTION
This patch adds reuse support to Rados engine. There are two main reasons to add the new options "reuse" and "cleanup".

- Since creating and removing objects linearly cost too much time, especially with a lot of small files, the different jobs could reuse the objects with the option "reuse=[same id]", and purge those objects in the last job to save time.
- In Ceph Mimic with bluestore, when fio want to read an unallocated data, the read ops would return immediately in OSD without DISK IOs, which cause unreal high read speed. With options "reuse", users could write full data to objects first and then perform the reading bench.

Any idea?

Signed-off-by: Hanjie Zhou <miller_maxwell@outlook.com>