### PR TITLE
Suppress gcc 8 compiler warnings

### DIFF
--- a/diskutil.c
+++ b/diskutil.c
@@ -242,7 +242,8 @@ static void find_add_disk_slaves(struct thread_data *td, char *path,
 		    !strcmp(dirent->d_name, ".."))
 			continue;
 
-		sprintf(temppath, "%s/%s", slavesdir, dirent->d_name);
+		nowarn_snprintf(temppath, sizeof(temppath), "%s/%s", slavesdir,
+				dirent->d_name);
 		/* Can we always assume that the slaves device entries
 		 * are links to the real directories for the slave
 		 * devices?
@@ -255,9 +256,12 @@ static void find_add_disk_slaves(struct thread_data *td, char *path,
 		}
 		slavepath[linklen] = '\0';
 
-		sprintf(temppath, "%s/%s/dev", slavesdir, slavepath);
+		nowarn_snprintf(temppath, sizeof(temppath), "%s/%s/dev",
+				slavesdir, slavepath);
 		if (access(temppath, F_OK) != 0)
-			sprintf(temppath, "%s/%s/device/dev", slavesdir, slavepath);
+			nowarn_snprintf(temppath, sizeof(temppath),
+					"%s/%s/device/dev", slavesdir,
+					slavepath);
 		if (read_block_dev_entry(temppath, &majdev, &mindev)) {
 			perror("Error getting slave device numbers");
 			closedir(dirhandle);
@@ -271,7 +275,8 @@ static void find_add_disk_slaves(struct thread_data *td, char *path,
 		if (slavedu)
 			continue;
 
-		sprintf(temppath, "%s/%s", slavesdir, slavepath);
+		nowarn_snprintf(temppath, sizeof(temppath), "%s/%s", slavesdir,
+				slavepath);
 		__init_per_file_disk_util(td, majdev, mindev, temppath);
 		slavedu = disk_util_exists(majdev, mindev);
 

--- a/fio.h
+++ b/fio.h
@@ -44,6 +44,7 @@
 #include "io_u_queue.h"
 #include "workqueue.h"
 #include "steadystate.h"
+#include "nowarn_snprintf.h"
 
 #ifdef CONFIG_SOLARISAIO
 #include <sys/asynch.h>
@@ -468,7 +469,9 @@ enum {
 			break;						\
 		(td)->error = ____e;					\
 		if (!(td)->first_error)					\
-			snprintf(td->verror, sizeof(td->verror), "file:%s:%d, func=%s, error=%s", __FILE__, __LINE__, (func), (msg));		\
+			nowarn_snprintf(td->verror, sizeof(td->verror),	\
+					"file:%s:%d, func=%s, error=%s", \
+					__FILE__, __LINE__, (func), (msg)); \
 	} while (0)
 
 

--- a/nowarn_snprintf.h
+++ b/nowarn_snprintf.h
@@ -1,0 +1,24 @@
+#ifndef _NOWARN_SNPRINTF_H_
+#define _NOWARN_SNPRINTF_H_
+
+#include <stdio.h>
+#include <stdarg.h>
+
+static inline int nowarn_snprintf(char *str, size_t size, const char *format,
+				  ...)
+{
+	va_list args;
+
+	va_start(args, format);
+#if __GNUC__ -0 >= 8
+#pragma GCC diagnostic push "-Wformat-truncation"
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+	return vsnprintf(str, size, format, args);
+#if __GNUC__ -0 >= 8
+#pragma GCC diagnostic pop "-Wformat-truncation"
+#endif
+	va_end(args);
+}
+
+#endif

--- a/verify-state.h
+++ b/verify-state.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <limits.h>
+#include "nowarn_snprintf.h"
 
 struct thread_rand32_state {
 	uint32_t s[4];
@@ -101,7 +102,7 @@ static inline void verify_state_gen_name(char *out, size_t size,
 		name++;
 	} while (1);
 
-	snprintf(out, size, "%s-%s-%d-verify.state", prefix, ename, num);
+	nowarn_snprintf(out, size, "%s-%s-%d-verify.state", prefix, ename, num);
 	out[size - 1] = '\0';
 }
 


### PR DESCRIPTION
Introduce a new function nowarn_snprintf() that behaves identically
to snprintf() except that it does not make gcc complain about potential
truncation of the output buffer.

Signed-off-by: Bart Van Assche <bart.vanassche@wdc.com>