### PR TITLE
Make nowarn_snprintf() call va_end()

### DIFF
--- a/lib/nowarn_snprintf.h
+++ b/lib/nowarn_snprintf.h
@@ -8,17 +8,20 @@ static inline int nowarn_snprintf(char *str, size_t size, const char *format,
 				  ...)
 {
 	va_list args;
+	int res;
 
 	va_start(args, format);
 #if __GNUC__ -0 >= 8
 #pragma GCC diagnostic push "-Wformat-truncation"
 #pragma GCC diagnostic ignored "-Wformat-truncation"
 #endif
-	return vsnprintf(str, size, format, args);
+	res = vsnprintf(str, size, format, args);
 #if __GNUC__ -0 >= 8
 #pragma GCC diagnostic pop "-Wformat-truncation"
 #endif
 	va_end(args);
+
+	return res;
 }
 
 #endif


### PR DESCRIPTION
This patch suppresses the following Coverity complaint:

CID 175867:  API usage errors  (VARARGS)
    va_end was not called for "args".
