### PR TITLE
rate_process=skew implementation

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2252,13 +2252,21 @@ I/O rate
 
 .. option:: rate_process=str
 
-	This option controls how fio manages rated I/O submissions. The default is
-	`linear`, which submits I/O in a linear fashion with fixed delays between
-	I/Os that gets adjusted based on I/O completion rates. If this is set to
-	`poisson`, fio will submit I/O based on a more real world random request
-	flow, known as the Poisson process
-	(https://en.wikipedia.org/wiki/Poisson_point_process). The lambda will be
-	10^6 / IOPS for the given workload.
+	This option controls how fio manages rated I/O submissions:
+	
+	**linear** (default)
+		fio submits I/Os in a linear fashion with fixed delays between
+		I/Os that are adjusted based on I/O completion rates.
+	**poisson**
+		fio will submit I/O based on a more real world random request
+		flow, known as the Poisson process
+		(https://en.wikipedia.org/wiki/Poisson_point_process). 
+		The lambda will be 10^6 / IOPS for the given workload.
+	**skew**
+		when numjobs > 1, fio submits I/Os in a linear fashion, but
+		with I/Os from each subjob spread evenly within the calculated seconds
+		per I/O (skewed between each job). Thus, the operations will not be 
+		mostly synchronized between jobs (as occurs with the `linear` process).
 
 .. option:: rate_ignore_thinktime=bool
 

--- a/fio.1
+++ b/fio.1
@@ -1999,13 +1999,26 @@ Comma\-separated values may be specified for reads, writes, and trims as
 described in \fBblocksize\fR.
 .TP
 .BI rate_process \fR=\fPstr
-This option controls how fio manages rated I/O submissions. The default is
-`linear', which submits I/O in a linear fashion with fixed delays between
-I/Os that gets adjusted based on I/O completion rates. If this is set to
-`poisson', fio will submit I/O based on a more real world random request
-flow, known as the Poisson process
+This option controls how fio manages rated I/O submissions:
+.RS
+.RS
+.TP
+.B linear (default)
+fio submits I/Os in a linear fashion with fixed delays between 
+I/Os that are adjusted based on I/O completion rates.
+.TP
+.B poisson
+fio will submit I/O based on a more real world random request flow, known as the Poisson process
 (\fIhttps://en.wikipedia.org/wiki/Poisson_point_process\fR). The lambda will be
 10^6 / IOPS for the given workload.
+.TP
+.B skew
+when numjobs > 1, fio submits I/Os in a linear fashion, but
+with I/Os from each subjob spread evenly within the calculated seconds
+per I/O (skewed between each job). Thus, the operations will not be 
+mostly synchronized between jobs (as occurs with the `linear` process).
+.RE
+.RE
 .TP
 .BI rate_ignore_thinktime \fR=\fPbool
 By default, fio will attempt to catch up to the specified rate setting, if any

--- a/fio.h
+++ b/fio.h
@@ -144,6 +144,7 @@ enum {
 
 	RATE_PROCESS_LINEAR = 0,
 	RATE_PROCESS_POISSON = 1,
+	RATE_PROCESS_SKEW = 2,
 };
 
 enum {
@@ -319,6 +320,7 @@ struct thread_data {
 	struct timespec lastrate[DDIR_RWDIR_CNT];
 	int64_t last_usec[DDIR_RWDIR_CNT];
 	struct frand_state poisson_state[DDIR_RWDIR_CNT];
+	uint64_t rate_skew[DDIR_RWDIR_CNT];
 
 	/*
 	 * Enforced rate submission/completion workqueue

--- a/init.c
+++ b/init.c
@@ -545,6 +545,14 @@ static int __setup_rate(struct thread_data *td, enum fio_ddir ddir)
 		return -1;
 	}
 
+	if (td->o.rate_process == RATE_PROCESS_SKEW) {
+		td->rate_skew[ddir] = (uint64_t)bs * 1000000 / td->rate_bps[ddir]
+								/ td->o.num_related_jobs * td->subjob_number;
+		dprint(FD_RATE, "skew rate thd=%d, ddir=%d, subjob=%d, numjobs=%d, usskew=%llu\n",
+				td->thread_number, ddir, td->subjob_number,	td->o.num_related_jobs,
+				(unsigned long long)td->rate_skew[ddir]);
+	}
+
 	td->rate_next_io_time[ddir] = 0;
 	td->rate_io_issue_bytes[ddir] = 0;
 	td->last_usec[ddir] = 0;
@@ -1516,6 +1524,8 @@ static int add_job(struct thread_data *td, const char *jobname, int job_add_num,
 		goto err;
 	}
 
+	if (!recursed)
+		o->num_related_jobs = o->numjobs;
 	if (setup_rate(td))
 		goto err;
 

--- a/options.c
+++ b/options.c
@@ -3481,6 +3481,11 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 			    .oval = RATE_PROCESS_POISSON,
 			    .help = "Rate follows Poisson process",
 			  },
+			  {
+			    .ival = "skew",
+			    .oval = RATE_PROCESS_SKEW,
+			    .help = "Skew IOs for each job, while IO's still linear rate.",
+			  },
 		},
 		.parent = "rate",
 	},

--- a/thread_options.h
+++ b/thread_options.h
@@ -272,6 +272,7 @@ struct thread_options {
 	unsigned int rate_iops_min[DDIR_RWDIR_CNT];
 	unsigned int rate_process;
 	unsigned int rate_ign_think;
+	unsigned int num_related_jobs;
 
 	char *ioscheduler;
 
@@ -547,7 +548,7 @@ struct thread_options_pack {
 	uint32_t rate_iops_min[DDIR_RWDIR_CNT];
 	uint32_t rate_process;
 	uint32_t rate_ign_think;
-	uint32_t pad;
+	uint32_t num_related_jobs;
 
 	uint8_t ioscheduler[FIO_TOP_STR_MAX];
 


### PR DESCRIPTION
Requesting this change to add a "skew" option to the "rate_process" value.  When "numjobs" is greater than 1 with a rate, the operation arrival times from each subjob actually occur synchronized.  That is, each job sends the op at effectively the same time.   What I'd like, is to do a "linear" process, but have each subjob delay the operation slightly - spread the arrival times across the rate time (time it takes to perform one operation).  

The point is to have multiple streams of equal activity (numjobs), but to not have them issue ops at the same time.  Poisson process works, but the arrival variation is too extreme, I really wanted more of a linear rate.  Using "start_delay" introduced other side effects, which I'll address later.  My intent is also to have some randomization in the number of blocks between thinktime, and in thinktime itself, but again - that's a different consideration.

The "skew" implementation adds to the thread_options a "rate_skew" value for each subjob.  However, in order to calculate, I needed each subjob to also know what was the original "numjobs" value.  However,  the numjobs value is set to 1 for all subjobs.  There seem to be a number of dependencies on that value, so I created a "related_numjobs" value as well, which then could be used by calculation code.

I was not able to discover another place to get the original "numjobs" option value.  So if there is one, please let me know and I will change.

I really didn't intend my "push" to get recorded in the base tree yet - I thought it would occur only to my github clone so I could start a discussion.  However, it's done and I'll avoid that in the future.  I have 

Thanks much, 
Kris Davis