### PR TITLE
iolog: allow to read_iolog from unix socket

### DIFF
--- a/os/os-windows.h
+++ b/os/os-windows.h
@@ -74,6 +74,10 @@ int rand_r(unsigned *);
 /* Winsock doesn't support MSG_WAIT */
 #define OS_MSG_DONTWAIT	0
 
+#ifndef S_ISSOCK
+#define S_ISSOCK(x) 0
+#endif
+
 #define SIGCONT	0
 #define SIGUSR1	1
 #define SIGUSR2 2


### PR DESCRIPTION
	Checks is file provided via --read_iolog parameter is a unix socket.
	In such case connect to it and fetch data from there.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>