### PR TITLE
Fix incompatible pointer types warning on Solaris with gcc 6.4

### DIFF
--- a/engines/solarisaio.c
+++ b/engines/solarisaio.c
@@ -105,7 +105,7 @@ static struct io_u *fio_solarisaio_event(struct thread_data *td, int event)
 	return sd->aio_events[event];
 }
 
-static int fio_solarisaio_queue(struct thread_data fio_unused *td,
+static enum fio_q_status fio_solarisaio_queue(struct thread_data fio_unused *td,
 			      struct io_u *io_u)
 {
 	struct solarisaio_data *sd = td->io_ops_data;


### PR DESCRIPTION
I have been seeing this warning for a while and felt, while seemingly minor, should not be there.

This is what I am observing before this changeset...
```
engines/solarisaio.c:216:12: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
  .queue  = fio_solarisaio_queue,
            ^~~~~~~~~~~~~~~~~~~~
engines/solarisaio.c:216:12: note: (near initialization for ‘ioengine.queue’)
```
... after this patch, building on an Illumos-based system is clean.