### PR TITLE
Realloc io_u buffers to adapt to operation size.

### DIFF
--- a/iolog.h
+++ b/iolog.h
@@ -244,6 +244,7 @@ extern void write_iolog_close(struct thread_data *);
 extern int iolog_compress_init(struct thread_data *, struct sk_out *);
 extern void iolog_compress_exit(struct thread_data *);
 extern size_t log_chunk_sizes(struct io_log *);
+extern int init_io_u_buffers(struct thread_data *);
 
 #ifdef CONFIG_ZLIB
 extern int iolog_file_inflate(const char *);


### PR DESCRIPTION
When iolog is read in chunked mode, some prefetching is done. Based on this size of buffers are determined.
Further operations may need larger buffers. If so, io_u buffers are reallocated.
Example that cause problem when read_iolog_chunked=1:
fio version 2 iolog
rbd_data.0 add
rbd_data.0 open
rbd_data.0 write 0 4096 (x20)
rbd_data.0 write 0 4096000 (x10)
rbd_data.0 close