### PR TITLE
arch: fix build breakage on armv6

### DIFF
--- a/arch/arch-arm.h
+++ b/arch/arch-arm.h
@@ -6,7 +6,8 @@
 #if defined (__ARM_ARCH_4__) || defined (__ARM_ARCH_4T__) \
 	|| defined (__ARM_ARCH_5__) || defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5E__)\
 	|| defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5TEJ__) \
-	|| defined(__ARM_ARCH_6__)  || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__)
+	|| defined(__ARM_ARCH_6__)  || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) \
+	|| defined(__ARM_ARCH_6KZ__)
 #define nop             __asm__ __volatile__("mov\tr0,r0\t@ nop\n\t")
 #define read_barrier()	__asm__ __volatile__ ("" : : : "memory")
 #define write_barrier()	__asm__ __volatile__ ("" : : : "memory")


### PR DESCRIPTION
The FreeBSD folks found fio didn't build on their armv6 systems
(https://svnweb.freebsd.org/ports/head/benchmarks/fio/Makefile?revision=432897&view=markup
) but Mikaël Urankar fixed the issue in
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=228042 so copy the fix
to mainline.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>