### PR TITLE
iolog: Now --read_iolog can contain multiple replay files, separated by ':'.

### DIFF
--- a/fio.1
+++ b/fio.1
@@ -2056,6 +2056,10 @@ to replay a workload captured by blktrace. See
 \fBblktrace\fR\|(8) for how to capture such logging data. For blktrace
 replay, the file needs to be turned into a blkparse binary data file first
 (`blkparse <device> \-o /dev/null \-d file_for_fio.bin').
+You can specify a number of files by separating the names with a ':' character.
+See the \fBfilename\fR option for information on how to escape ':' and '\'
+characters within the file names. These files will be sequentially assigned to
+job clones created by \fBnumjobs\fR.
 .TP
 .BI read_iolog_chunked \fR=\fPbool
 Determines how iolog is read. If false (default) entire \fBread_iolog\fR will

--- a/iolog.c
+++ b/iolog.c
@@ -447,7 +447,7 @@ static bool read_iolog2(struct thread_data *td)
 					dprint(FD_FILE, "iolog: ignoring"
 						" re-add of file %s\n", fname);
 				} else {
-					fileno = add_file(td, fname, 0, 1);
+					fileno = add_file(td, fname, td->subjob_number, 1);
 					file_action = FIO_LOG_ADD_FILE;
 				}
 				continue;
@@ -596,13 +596,17 @@ static bool init_iolog_read(struct thread_data *td)
 	char buffer[256], *p;
 	FILE *f = NULL;
 	bool ret;
-	if (is_socket(td->o.read_iolog_file)) {
-		int fd = open_socket(td->o.read_iolog_file);
+	char* fname = get_name_by_idx(td->o.read_iolog_file, td->subjob_number);
+	dprint(FD_IO, "iolog: name=%s\n", fname);
+
+	if (is_socket(fname)) {
+		int fd = open_socket(fname);
 		if (fd >= 0) {
 			f = fdopen(fd, "r");
 		}
 	} else
-		f = fopen(td->o.read_iolog_file, "r");
+		f = fopen(fname, "r");
+	free(fname);
 	if (!f) {
 		perror("fopen read iolog");
 		return false;

--- a/options.c
+++ b/options.c
@@ -1284,6 +1284,23 @@ int set_name_idx(char *target, size_t tlen, char *input, int index,
 	return len;
 }
 
+char* get_name_by_idx(char *input, int index)
+{
+	unsigned int cur_idx;
+	char *fname, *str, *p;
+
+	p = str = strdup(input);
+
+	index %= get_max_name_idx(input);
+	for (cur_idx = 0; cur_idx <= index; cur_idx++)
+		fname = get_next_name(&str);
+
+	fname = strdup(fname);
+	free(p);
+
+	return fname;
+}
+
 static int str_filename_cb(void *data, const char *input)
 {
 	struct thread_data *td = cb_data_to_td(data);

--- a/options.h
+++ b/options.h
@@ -16,6 +16,7 @@ void add_opt_posval(const char *, const char *, const char *);
 void del_opt_posval(const char *, const char *);
 struct thread_data;
 void fio_options_free(struct thread_data *);
+char* get_name_by_idx(char *input, int index);
 int set_name_idx(char *, size_t, char *, int, bool);
 
 extern char client_sockaddr_str[];  /* used with --client option */


### PR DESCRIPTION
    Useful when --numjobs is more then 1. Each job gets subsequent iolog to process.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>