### PR TITLE
Remove unused code in lib/axmap.c

### DIFF
--- a/lib/axmap.h
+++ b/lib/axmap.h
@@ -8,7 +8,6 @@ struct axmap;
 struct axmap *axmap_new(unsigned long nr_bits);
 void axmap_free(struct axmap *bm);
 
-void axmap_clear(struct axmap *axmap, uint64_t bit_nr);
 void axmap_set(struct axmap *axmap, uint64_t bit_nr);
 unsigned int axmap_set_nr(struct axmap *axmap, uint64_t bit_nr, unsigned int nr_bits);
 bool axmap_isset(struct axmap *axmap, uint64_t bit_nr);


### PR DESCRIPTION
With the new axmap_next_free() implementation, the "first_free" cache
is no longer used.  Remove all references to it.  Also axmap_clear()
is never referenced, so remove it and related code.