### PR TITLE
lib/axmap: Remove an assert() statement that is no longer correct

### DIFF
--- a/lib/axmap.c
+++ b/lib/axmap.c
@@ -244,7 +244,6 @@ static bool axmap_set_fn(struct axmap_level *al, unsigned long offset,
 		mask = bit_masks[nr_bits] << bit;
 	}
 
-	assert(mask);
 	assert(!(al->map[offset] & mask));
 	al->map[offset] |= mask;
 


### PR DESCRIPTION
Due to patch "lib/axmap: Simplify axmap_set_fn()" it is now possible
that mask is zero. Avoid that this causes fio to abort.

Fixes: 15a4f4962fad ("lib/axmap: Simplify axmap_set_fn()")
Signed-off-by: Bart Van Assche <bart.vanassche@wdc.com>