### PR TITLE
ZBD support improvement and cleanup

### DIFF
--- a/zbd.c
+++ b/zbd.c
@@ -31,7 +31,7 @@ static uint32_t zbd_zone_idx(const struct fio_file *f, uint64_t offset)
 {
 	uint32_t zone_idx;
 
-	if (f->zbd_info->zone_size_log2)
+	if (f->zbd_info->zone_size_log2 > 0)
 		zone_idx = offset >> f->zbd_info->zone_size_log2;
 	else
 		zone_idx = (offset >> 9) / f->zbd_info->zone_size;

--- a/zbd.h
+++ b/zbd.h
@@ -95,8 +95,6 @@ int zbd_init(struct thread_data *td);
 void zbd_file_reset(struct thread_data *td, struct fio_file *f);
 bool zbd_unaligned_write(int error_code);
 enum io_u_action zbd_adjust_block(struct thread_data *td, struct io_u *io_u);
-int zbd_do_trim(struct thread_data *td, const struct io_u *io_u);
-void zbd_update_wp(struct thread_data *td, const struct io_u *io_u);
 char *zbd_write_status(const struct thread_stat *ts);
 #else
 static inline void zbd_free_zone_info(struct fio_file *f)
@@ -121,16 +119,6 @@ static inline enum io_u_action zbd_adjust_block(struct thread_data *td,
 						struct io_u *io_u)
 {
 	return io_u_accept;
-}
-
-static inline int zbd_do_trim(struct thread_data *td, const struct io_u *io_u)
-{
-	return 1;
-}
-
-static inline void zbd_update_wp(struct thread_data *td,
-				 const struct io_u *io_u)
-{
 }
 
 static inline char *zbd_write_status(const struct thread_stat *ts)


### PR DESCRIPTION
Two patches: the first one improves randomness of reads for a random read pattern with read_beyond_wp=0 by adjusting an I/O offset to a random value within the zone with valid data chosen. The second patch removes declaration for dead code.