### PR TITLE
rate_submit: synchronize accesses to io_u_queue->nr

### DIFF
--- a/rate-submit.c
+++ b/rate-submit.c
@@ -126,7 +126,7 @@ static int io_workqueue_init_worker_fn(struct submit_worker *sw)
 	clear_io_state(td, 1);
 
 	td_set_runstate(td, TD_RUNNING);
-	td->flags |= TD_F_CHILD;
+	td->flags |= TD_F_CHILD | TD_F_NEED_LOCK;
 	td->parent = parent;
 	return 0;
 


### PR DESCRIPTION
Jens, please consider this pull request.

Another way to resolve this issue would be to set td = td->parent before calculating needs_lock in put_io_u(). If that is better, I can submit a patch for that change instead.