### PR TITLE
filter out records with duplicate timestamps

### DIFF
--- a/tools/hist/fio-histo-log-pctiles.py
+++ b/tools/hist/fio-histo-log-pctiles.py
@@ -59,6 +59,8 @@ def parse_hist_file(logfn, buckets_per_interval):
     with open(logfn, 'r') as f:
         records = [ l.strip() for l in f.readlines() ]
     intervals = []
+    last_time_ms = -1
+    last_direction = -1
     for k, r in enumerate(records):
         if r == '':
             continue
@@ -91,6 +93,15 @@ def parse_hist_file(logfn, buckets_per_interval):
         if len(buckets) != buckets_per_interval:
             raise FioHistoLogExc('%d buckets per interval but %d expected in %s' % 
                     (len(buckets), buckets_per_interval, exception_suffix(k+1, logfn)))
+
+        # hack to filter out records with the same timestamp
+        # we should not have to do this if fio logs histogram records correctly
+
+        if time_ms == last_time_ms and direction == last_direction:
+            continue
+        last_time_ms = time_ms
+        last_direction = direction
+
         intervals.append((time_ms, direction, bsz, buckets))
     if len(intervals) == 0:
         raise FioHistoLogExc('no records in %s' % logfn)


### PR DESCRIPTION
This is a workaround for bug in fio-3.3. It causes this to happen:

```
$ python ~/ceph/fio/fork/fio/tools/hist/fio-histo-log-pctiles.py ~/tmp/fio_clat_hist.1.log 

Traceback (most recent call last):
  File "/home/bengland/ceph/fio/fork/fio/tools/hist/fio-histo-log-pctiles.py", line 656, in <module>
    compute_percentiles_from_logs()
  File "/home/bengland/ceph/fio/fork/fio/tools/hist/fio-histo-log-pctiles.py", line 390, in compute_percentiles_from_logs
    max_timestamp_all_logs)
  File "/home/bengland/ceph/fio/fork/fio/tools/hist/fio-histo-log-pctiles.py", line 206, in align_histo_log
    weight /= (time_msec_end - time_msec)
ZeroDivisionError: float division by zero
```

Here is the log file [fio_clat_hist.1.log](https://github.com/axboe/fio/files/2376204/fio_clat_hist.1.log), column 1 of the first 4 records shows the problem.  This was generated with the job file

```
[global]
ioengine=libaio
bs=4k
iodepth=4
direct=1
fsync_on_close=1
time_based=1
runtime=3160
clocksource=clock_gettime
ramp_time=10
startdelay=64
rate_iops=200

[fio]
rw=randwrite
size=95g
write_bw_log=fio
write_iops_log=fio
write_lat_log=fio
write_hist_log=fio
numjobs=1
per_job_logs=1
log_avg_msec=60000
log_hist_msec=10000
directory=/mnt/ceph/fio
```
and the fio command:

```
/usr/local/bin/fio --client=/root/vms.list.512 --max-jobs=512 --output-format=json /var/lib/pbench-agent/fio__2018.09.11T13.52.32/1-randwrite-4KiB/sample1/fio.job
```


