### PR TITLE
build: change where we set -static for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ endif
 ifneq (,$(findstring CYGWIN,$(CONFIG_TARGET_OS)))
   SOURCE += os/windows/posix.c
   LIBS	 += -lpthread -lpsapi -lws2_32
-  CFLAGS += -DPSAPI_VERSION=1 -Ios/windows/posix/include -Wno-format -static
+  CFLAGS += -DPSAPI_VERSION=1 -Ios/windows/posix/include -Wno-format
 endif
 
 OBJS := $(SOURCE:.c=.o)

--- a/configure
+++ b/configure
@@ -361,6 +361,7 @@ CYGWIN*)
   output_sym "CONFIG_WINDOWSAIO"
   # We now take the regular configuration path without having exit 0 here.
   # Flags below are still necessary mostly for MinGW.
+  build_static="yes"
   socklen_t="yes"
   rusage_thread="yes"
   fdatasync="yes"


### PR DESCRIPTION
The Makefile forced static Windows builds by adding -static to the
CFLAGS but this is long after the configure tests had run. This could
lead to problems (such as https://github.com/axboe/fio/issues/683 "Fio
fails to link libcurl on windows (undefined references to
__imp_curl_easy_cleanup)") where the availability of a dynamic version
of library causes a feature to be enabled but when it comes to final
linking time we find that there's no static version of the library
available and fall over.

Fix the above by asking for a static build via the "Forcing some known
good options on Windows" section of the configure file which occurs
prior to configure tests. This also means configure will correctly
display that we are doing a static build.

Fixes https://github.com/axboe/fio/issues/683

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>