### PR TITLE
iolog: Fix problem with setup() not invoked when read_iolog is used.

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -908,9 +908,6 @@ int setup_files(struct thread_data *td)
 
 	old_state = td_bump_runstate(td, TD_SETTING_UP);
 
-	if (o->read_iolog_file)
-		goto done;
-
 	/*
 	 * Find out physical size of files or devices for this thread,
 	 * before we determine I/O size and range of our targets.
@@ -926,6 +923,9 @@ int setup_files(struct thread_data *td)
 	if (err)
 		goto err_out;
 
+	if (o->read_iolog_file)
+		goto done;
+	
 	/*
 	 * check sizes. if the files/devices do not exist and the size
 	 * isn't passed to fio, abort.


### PR DESCRIPTION
Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>