### PR TITLE
serialize_overlap with io_submit_mode=offload

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2339,8 +2339,8 @@ I/O depth
 	``serialize_overlap`` tells fio to avoid provoking this behavior by explicitly
 	serializing in-flight I/Os that have a non-zero overlap. Note that setting
 	this option can reduce both performance and the :option:`iodepth` achieved.
-	Additionally this option does not work when :option:`io_submit_mode` is set to
-	offload. Default: false.
+	Threads must be used when this option is combined with offload
+	:option:`io_submit_mode`. Default: false.
 
 .. option:: io_submit_mode=str
 

--- a/fio.1
+++ b/fio.1
@@ -2070,8 +2070,8 @@ changing data and the overlapping region has a non-zero size. Setting
 \fBserialize_overlap\fR tells fio to avoid provoking this behavior by explicitly
 serializing in-flight I/Os that have a non-zero overlap. Note that setting
 this option can reduce both performance and the \fBiodepth\fR achieved.
-Additionally this option does not work when \fBio_submit_mode\fR is set to
-offload. Default: false.
+Threads must be used when this option is combined with offload \fBio_submit_mode\fR.
+Default: false.
 .TP
 .BI io_submit_mode \fR=\fPstr
 This option controls how fio submits the I/O to the I/O engine. The default

--- a/init.c
+++ b/init.c
@@ -741,23 +741,6 @@ static int fixup_options(struct thread_data *td)
 	if (o->iodepth_batch_complete_min > o->iodepth_batch_complete_max)
 		o->iodepth_batch_complete_max = o->iodepth_batch_complete_min;
 
-	/*
-	 * There's no need to check for in-flight overlapping IOs if the job
-	 * isn't changing data or the maximum iodepth is guaranteed to be 1
-	 */
-	if (o->serialize_overlap && !(td->flags & TD_F_READ_IOLOG) &&
-	    (!(td_write(td) || td_trim(td)) || o->iodepth == 1))
-		o->serialize_overlap = 0;
-	/*
-	 * Currently can't check for overlaps in offload mode
-	 */
-	if (o->serialize_overlap && o->io_submit_mode == IO_MODE_OFFLOAD) {
-		log_err("fio: checking for in-flight overlaps when the "
-			"io_submit_mode is offload is not supported\n");
-		o->serialize_overlap = 0;
-		ret |= warnings_fatal;
-	}
-
 	if (o->nr_files > td->files_index)
 		o->nr_files = td->files_index;
 

--- a/workqueue.h
+++ b/workqueue.h
@@ -71,7 +71,8 @@ struct workqueue {
 int workqueue_init(struct thread_data *td, struct workqueue *wq, struct workqueue_ops *ops, unsigned int max_workers, struct sk_out *sk_out);
 void workqueue_exit(struct workqueue *wq);
 
-void workqueue_enqueue(struct workqueue *wq, struct workqueue_work *work);
+enum fio_q_status workqueue_enqueue(struct workqueue *wq, struct workqueue_work *work);
+enum fio_q_status workqueue_enqueue_serial_overlap(struct workqueue *wq, struct workqueue_work *work);
 void workqueue_flush(struct workqueue *wq);
 
 static inline bool workqueue_pre_sleep_check(struct submit_worker *sw)


### PR DESCRIPTION
Jens, please consider this pull request.

We are interested in running workloads that avoid overlap among in-flight IOs across different jobs. Based on the mailing list discussion from a few months ago, we implemented this using offload submission mode.