### PR TITLE
Check if `MPOL_LOCAL` declared before defining

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -57,7 +57,9 @@
 /*
  * "local" is pseudo-policy
  */
-#define MPOL_LOCAL MPOL_MAX
+#ifndef MPOL_LOCAL
+#define MPOL_LOCAL 4
+#endif
 #endif
 
 #ifdef CONFIG_CUDA


### PR DESCRIPTION
`MPOL_LOCAL` will be defined in `numaif.h` in the future.

Also, `MPOL_MAX` will be changed to match the kernel values.