### PR TITLE
Enable --serialize-overlap when --io_submit_mode=offload

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2339,8 +2339,13 @@ I/O depth
 	``serialize_overlap`` tells fio to avoid provoking this behavior by explicitly
 	serializing in-flight I/Os that have a non-zero overlap. Note that setting
 	this option can reduce both performance and the :option:`iodepth` achieved.
-	Additionally this option does not work when :option:`io_submit_mode` is set to
-	offload. Default: false.
+
+	This option only applies to I/Os issued for a single job except when it is
+	enabled along with :option:`io_submit_mode`=offload. In offload mode, fio
+	will check for overlap among all I/Os submitted by offload jobs with :option:`serialize_overlap`
+	enabled. Threads must be used for all such jobs.
+
+	Default: false.
 
 .. option:: io_submit_mode=str
 

--- a/fio.1
+++ b/fio.1
@@ -2070,8 +2070,15 @@ changing data and the overlapping region has a non-zero size. Setting
 \fBserialize_overlap\fR tells fio to avoid provoking this behavior by explicitly
 serializing in-flight I/Os that have a non-zero overlap. Note that setting
 this option can reduce both performance and the \fBiodepth\fR achieved.
-Additionally this option does not work when \fBio_submit_mode\fR is set to
-offload. Default: false.
+.RS
+.P
+This option only applies to I/Os issued for a single job except when it is
+enabled along with \fBio_submit_mode\fR=offload. In offload mode, fio
+will check for overlap among all I/Os submitted by offload jobs with \fBserialize_overlap\fR
+enabled. Threads must be used for all such jobs.
+.P
+Default: false.
+.RE
 .TP
 .BI io_submit_mode \fR=\fPstr
 This option controls how fio submits the I/O to the I/O engine. The default

--- a/fio.h
+++ b/fio.h
@@ -852,4 +852,7 @@ enum {
 extern void exec_trigger(const char *);
 extern void check_trigger_file(void);
 
+extern bool in_flight_overlap(struct io_u_queue *q, struct io_u *io_u);
+extern pthread_mutex_t overlap_check;
+
 #endif

--- a/init.c
+++ b/init.c
@@ -744,19 +744,12 @@ static int fixup_options(struct thread_data *td)
 	/*
 	 * There's no need to check for in-flight overlapping IOs if the job
 	 * isn't changing data or the maximum iodepth is guaranteed to be 1
+	 * when we are not in offload mode
 	 */
 	if (o->serialize_overlap && !(td->flags & TD_F_READ_IOLOG) &&
-	    (!(td_write(td) || td_trim(td)) || o->iodepth == 1))
+	    (!(td_write(td) || td_trim(td)) || o->iodepth == 1) &&
+	    o->io_submit_mode != IO_MODE_OFFLOAD)
 		o->serialize_overlap = 0;
-	/*
-	 * Currently can't check for overlaps in offload mode
-	 */
-	if (o->serialize_overlap && o->io_submit_mode == IO_MODE_OFFLOAD) {
-		log_err("fio: checking for in-flight overlaps when the "
-			"io_submit_mode is offload is not supported\n");
-		o->serialize_overlap = 0;
-		ret |= warnings_fatal;
-	}
 
 	if (o->nr_files > td->files_index)
 		o->nr_files = td->files_index;

--- a/ioengines.c
+++ b/ioengines.c
@@ -288,6 +288,8 @@ enum fio_q_status td_io_queue(struct thread_data *td, struct io_u *io_u)
 
 	assert((io_u->flags & IO_U_F_FLIGHT) == 0);
 	io_u_set(td, io_u, IO_U_F_FLIGHT);
+	if (td->o.serialize_overlap && td->o.io_submit_mode == IO_MODE_OFFLOAD)
+		pthread_mutex_unlock(&overlap_check);
 
 	assert(fio_file_open(io_u->file));
 

--- a/rate-submit.c
+++ b/rate-submit.c
@@ -83,10 +83,6 @@ static int io_workqueue_fn(struct submit_worker *sw,
 		ret = io_u_queued_complete(td, min_evts);
 		if (ret > 0)
 			td->cur_depth -= ret;
-	} else if (ret == FIO_Q_BUSY) {
-		ret = io_u_queued_complete(td, td->cur_depth);
-		if (ret > 0)
-			td->cur_depth -= ret;
 	}
 
 	return 0;


### PR DESCRIPTION
Jens, please consider this follow-up to #700 

We used blktrace to collect data from runs with 4K r/w jobs combined with a 1G trim and found no overlapping IOs submitted.

Here are responses to your earlier comments and changes from the previous version:

- moved overlap check from main job thread to submit worker threads
- use original serialize_overlap check function to compare each io_u with io_u_all queues for each running thread of interest
- moved init changes to a separate patch
- there needs to be a single overlap check mutex for all threads (instead of one per workqueue) to prevent two threads with overlapping IOs from finding that the coast is clear and submitting IOs that overlap
- I could not think of a way to avoid iterating over threads. I could create an array of *io_u_queue and have relevant threads insert/remove their io_u_all as they start/stop running, but each check would still have to iterate over the entire array of size thread_number.
- added a patch to remove an impossible branch from rate-submit.c