### PR TITLE
rand: fix compressible data ratio per segment

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -166,6 +166,7 @@ void __fill_random_buf_percentage(unsigned long seed, void *buf,
 		if (!len)
 			break;
 		buf += this_len;
+		this_len = segment - this_len;
 
 		if (this_len > len)
 			this_len = len;


### PR DESCRIPTION
Fio should write (100 - compress_percentage) * segemnt of random data
followed by compress_percentage * segemnt of compressible
data.

Currently, at each itereation fio fills (100 - compress_percentage) * segemnt
data, followed by (100 - compress_percentage) * segemnt of compressible
data until a the segment is filled.

This commit fixes a bug that was mistakenly
created by a code change in:
811ac503a6196f13da22565eb165c278988da4da

Signed-off-by: Bari Antebi <bari@lightbitslabs.com>