### PR TITLE
arch: fix build breakage on armv6 again

### DIFF
--- a/arch/arch-arm.h
+++ b/arch/arch-arm.h
@@ -7,7 +7,7 @@
 	|| defined (__ARM_ARCH_5__) || defined (__ARM_ARCH_5T__) || defined (__ARM_ARCH_5E__)\
 	|| defined (__ARM_ARCH_5TE__) || defined (__ARM_ARCH_5TEJ__) \
 	|| defined(__ARM_ARCH_6__)  || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) \
-	|| defined(__ARM_ARCH_6KZ__)
+	|| defined(__ARM_ARCH_6KZ__) || defined(__ARM_ARCH_6K__)
 #define nop             __asm__ __volatile__("mov\tr0,r0\t@ nop\n\t")
 #define read_barrier()	__asm__ __volatile__ ("" : : : "memory")
 #define write_barrier()	__asm__ __volatile__ ("" : : : "memory")


### PR DESCRIPTION
6K was missing from the defines.

Signed-off-by: Rosen Penev <rosenp@gmail.com>