### PR TITLE
io_uring: fix possible infinite loop

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -233,6 +233,7 @@ static int fio_ioring_getevents(struct thread_data *td, unsigned int min,
 		r = fio_ioring_cqring_reap(td, events, max);
 		if (r) {
 			events += r;
+			actual_min -= r;
 			continue;
 		}
 


### PR DESCRIPTION
If the number of reaped I/O is greater than actual_min, io_uring_enter()
blocks forever.

Signed-off-by: Satoru Takeuchi <sat@cybozu.co.jp>