### PR TITLE
io_uring: fix possible infinite loop

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -233,6 +233,8 @@ static int fio_ioring_getevents(struct thread_data *td, unsigned int min,
 		r = fio_ioring_cqring_reap(td, events, max);
 		if (r) {
 			events += r;
+			if (actual_min != 0)
+				actual_min -= r;
 			continue;
 		}
 


### PR DESCRIPTION
When reaping some completed I/O before io_uring_enter(), it waits forever.

Signed-off-by: Satoru Takeuchi <sat@cybozu.co.jp>