### PR TITLE
Increase maximum length of line in jobs file to 8192

### DIFF
--- a/fio.1
+++ b/fio.1
@@ -201,6 +201,8 @@ argument, \fB\-\-cmdhelp\fR will detail the given \fIcommand\fR.
 See the `examples/' directory for inspiration on how to write job files. Note
 the copyright and license requirements currently apply to
 `examples/' files.
+
+Note that the maximum length of a line in the job file is 8192 bytes.
 .SH "JOB FILE PARAMETERS"
 Some parameters take an option of a given type, such as an integer or a
 string. Anywhere a numeric value is required, an arithmetic expression may be

--- a/init.c
+++ b/init.c
@@ -1887,7 +1887,7 @@ static int __parse_jobs_ini(struct thread_data *td,
 		}
 	}
 
-	string = malloc(4096);
+	string = malloc(OPT_LEN_MAX);
 
 	/*
 	 * it's really 256 + small bit, 280 should suffice
@@ -1920,7 +1920,7 @@ static int __parse_jobs_ini(struct thread_data *td,
 			if (is_buf)
 				p = strsep(&file, "\n");
 			else
-				p = fgets(string, 4096, f);
+				p = fgets(string, OPT_LEN_MAX, f);
 			if (!p)
 				break;
 		}
@@ -1989,7 +1989,7 @@ static int __parse_jobs_ini(struct thread_data *td,
 				if (is_buf)
 					p = strsep(&file, "\n");
 				else
-					p = fgets(string, 4096, f);
+					p = fgets(string, OPT_LEN_MAX, f);
 				if (!p)
 					break;
 				dprint(FD_PARSE, "%s", p);

--- a/parse.h
+++ b/parse.h
@@ -37,7 +37,7 @@ struct value_pair {
 	void *cb;			/* sub-option callback */
 };
 
-#define OPT_LEN_MAX 	4096
+#define OPT_LEN_MAX 	8192
 #define PARSE_MAX_VP	24
 
 /*


### PR DESCRIPTION
Per issue #794, double the maximum length of a line in a fio job file to 8192 bytes. This changes the hard-coded malloc and fgets in init.c to use OPT_LEN_MAX instead of 4096 and increases OPT_LEN_MAX to 8192. I've also documented the maximum length of a line in the man page, since 8192 is a somewhat arbitrary increase and someone may need it increased further later on.