### PR TITLE
libiscsi: continue working when meets EINTR or EAGAIN

### DIFF
--- a/engines/libiscsi.c
+++ b/engines/libiscsi.c
@@ -351,6 +351,9 @@ static int fio_iscsi_getevents(struct thread_data *td, unsigned int min,
 
 		ret = poll(iscsi_info->pfds, iscsi_info->nr_luns, -1);
 		if (ret < 0) {
+			if (errno == EINTR || errno == EAGAIN) {
+				continue;
+			}
 			log_err("iscsi: failed to poll events: %s.\n",
 				strerror(errno));
 			break;


### PR DESCRIPTION
When poll meets EINTR, it should continue working rather than return
error.

Signed-off-by: Kyle Zhang <kyle@smartx.com>