### PR TITLE
engines/io_uring: Handle EINTR.

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -259,7 +259,7 @@ static int fio_ioring_getevents(struct thread_data *td, unsigned int min,
 			r = io_uring_enter(ld, 0, actual_min,
 						IORING_ENTER_GETEVENTS);
 			if (r < 0) {
-				if (errno == EAGAIN)
+				if (errno == EAGAIN || errno == EINTR)
 					continue;
 				td_verror(td, errno, "io_uring_enter");
 				break;
@@ -370,7 +370,7 @@ static int fio_ioring_commit(struct thread_data *td)
 			io_u_mark_submit(td, ret);
 			continue;
 		} else {
-			if (errno == EAGAIN) {
+			if (errno == EAGAIN || errno == EINTR) {
 				ret = fio_ioring_cqring_reap(td, 0, ld->queued);
 				if (ret)
 					continue;


### PR DESCRIPTION
Several paths in io_uring_enter can trigger EINTR, but it was not
handled, leading to fio failing with spurious error messages.

An easy way to trigger EINTR is to just strace a running fio using
the io_uring engine and detach again.

Signed-off-by: Andres Freund <andres@anarazel.de>