### PR TITLE
configure: stop enabling fdatasync on OSX

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -1279,7 +1279,7 @@ I/O type
 .. option:: fdatasync=int
 
 	Like :option:`fsync` but uses :manpage:`fdatasync(2)` to only sync data and
-	not metadata blocks.  In Windows, FreeBSD, and DragonFlyBSD there is no
+	not metadata blocks. In Windows, FreeBSD, DragonFlyBSD or OSX there is no
 	:manpage:`fdatasync(2)` so this falls back to using :manpage:`fsync(2)`.
 	Defaults to 0, which means fio does not periodically issue and wait for a
 	data-only sync to complete.

--- a/configure
+++ b/configure
@@ -88,14 +88,14 @@ do_cc() {
 }
 
 compile_object() {
-  do_cc $CFLAGS -c -o $TMPO $TMPC
+  do_cc $CFLAGS -Werror-implicit-function-declaration -c -o $TMPO $TMPC
 }
 
 compile_prog() {
   local_cflags="$1"
   local_ldflags="$2 $LIBS"
   echo "Compiling test case $3" >> config.log
-  do_cc $CFLAGS $local_cflags -o $TMPE $TMPC $LDFLAGS $local_ldflags
+  do_cc $CFLAGS -Werror-implicit-function-declaration $local_cflags -o $TMPE $TMPC $LDFLAGS $local_ldflags
 }
 
 feature_not_found() {

--- a/fio.1
+++ b/fio.1
@@ -1050,7 +1050,7 @@ see \fBend_fsync\fR and \fBfsync_on_close\fR.
 .TP
 .BI fdatasync \fR=\fPint
 Like \fBfsync\fR but uses \fBfdatasync\fR\|(2) to only sync data and
-not metadata blocks. In Windows, FreeBSD, and DragonFlyBSD there is no
+not metadata blocks. In Windows, FreeBSD, DragonFlyBSD or OSX there is no
 \fBfdatasync\fR\|(2) so this falls back to using \fBfsync\fR\|(2).
 Defaults to 0, which means fio does not periodically issue and wait for a
 data\-only sync to complete.

--- a/os/os-mac.h
+++ b/os/os-mac.h
@@ -97,12 +97,6 @@ static inline int gettid(void)
 }
 #endif
 
-/*
- * For some reason, there's no header definition for fdatasync(), even
- * if it exists.
- */
-extern int fdatasync(int fd);
-
 static inline bool fio_fallocate(struct fio_file *f, uint64_t offset, uint64_t len)
 {
 	fstore_t store = {F_ALLOCATEALL, F_PEOFPOSMODE, offset, len};


### PR DESCRIPTION
Change configure compile probes to fail on implicit declarations. This
(correctly) stops us from enabling fdatasync on OSX which was
problematic because we were actually calling a syscall stub with
arguments different to what was declared in its prototype (see
https://github.com/gbrault/picoc/issues/145#issuecomment-89734655 and
https://gitlab.freedesktop.org/xdg/shared-mime-info/issues/7 ).

Fixes: https://github.com/axboe/fio/issues/834 ("Drop macOS support for
fdatasync")

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>

@axboe This patch is simplistic and basically adds erroring on `implicit-function-declaration` warnings to the two probe compilation functions. It might be better to just error on all warnings during compilation probes (if so let me know and I'll recreate the patch). I couldn't find a situation where compilation probes weren't clean against basic warnings but I haven't built with all possible libraries/options/platforms...