### PR TITLE
Increase MAX_FILELOCKS for highly parallel IO test

### DIFF
--- a/filelock.c
+++ b/filelock.c
@@ -22,7 +22,7 @@ struct fio_filelock {
 	unsigned int references;
 };
 
-#define MAX_FILELOCKS	128
+#define MAX_FILELOCKS	1024
 	
 static struct filelock_data {
 	struct flist_head list;


### PR DESCRIPTION
When running hundreds of threads and collecting CLAT, SLAT, IOS on a
per-thread basis, FIO can need a lot of file locks to complete.  When
it can't get them, it gives the cryptic error message:
> fio: filelock.c:182: __fio_lock_file: Assertion `!trylock' failed.

Bump the maximum from 128 to 1024 to give headroom for high core count,
high thread count testing.