### PR TITLE
Link to the system logging library on Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ endif
 ifeq ($(CONFIG_TARGET_OS), Android)
   SOURCE += diskutil.c fifo.c blktrace.c cgroup.c trim.c profiles/tiobench.c \
 		oslib/linux-dev-lookup.c
-  LIBS += -ldl
+  LIBS += -ldl -llog
   LDFLAGS += -rdynamic
 endif
 ifeq ($(CONFIG_TARGET_OS), SunOS)


### PR DESCRIPTION
Android replaces syslog calls with calls to the Android system logging library, `liblog`. Link to `liblog` when compiling for Android to fix the following undefined reference errors:

```
aarch64-linux-android-ld: log.o: in function `android_polyfill_vsyslog':
/usr/include/syslog.h:185: undefined reference to `__android_log_print'
aarch64-linux-android-ld: /usr/include/syslog.h:182: undefined reference to `__android_log_vprint'
```