### PR TITLE
enforce strtoll string parsing

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -383,6 +383,8 @@ int str_to_decimal(const char *str, long long *val, int kilo, void *data,
 		*val = strtoll(str, &endptr, base);
 		if (*val == 0 && endptr == str)
 			return 1;
+		if (! (*str != '\0' && *endptr == '\0') )
+			return 1;
 		if (*val == LONG_MAX && errno == ERANGE)
 			return 1;
 	}


### PR DESCRIPTION
From strtoll(3):
  In particular, if *nptr is not '\0' but **endptr is '\0' on return, the entire string is valid.

- check implemented as close to above spec as possible.