### PR TITLE
backend: fix the memory leak if fio_memalign fails,

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1236,7 +1236,7 @@ static int init_io_u(struct thread_data *td)
 		ptr = fio_memalign(cl_align, sizeof(*io_u), td_offload_overlap(td));
 		if (!ptr) {
 			log_err("fio: unable to allocate aligned memory\n");
-			break;
+			return 1;
 		}
 
 		io_u = ptr;


### PR DESCRIPTION
We should not use break, we should use return 1 and explictly fails this,
then the cleanup routine will work. If not, this function may still
return 0.

Signed-off-by: Gang Cao <cao.gang@intel.com>
Signed-off-by: Ziye Yang <ziye.yang@intel.com>