### PR TITLE
backend: Fix output redirection of exec_prerun/_postrun

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1469,12 +1469,12 @@ static bool keep_running(struct thread_data *td)
 
 static int exec_string(struct thread_options *o, const char *string, const char *mode)
 {
-	size_t newlen = strlen(string) + strlen(o->name) + strlen(mode) + 9 + 1;
+	size_t newlen = strlen(string) + strlen(o->name) + strlen(mode) + 13 + 1;
 	int ret;
 	char *str;
 
 	str = malloc(newlen);
-	sprintf(str, "%s &> %s.%s.txt", string, o->name, mode);
+	sprintf(str, "%s > %s.%s.txt 2>&1", string, o->name, mode);
 
 	log_info("%s : Saving output of %s in %s.%s.txt\n",o->name, mode, o->name, mode);
 	ret = system(str);


### PR DESCRIPTION
The previous version used the bashism "&>" to redirect stdout and stderr of the prerun/postrun commands to an output file. Since system() executes the command using "/bin/sh sh -c …". If /bin/sh is not bash, this wont work (for example, Ubuntu uses dash since 6.10).

Use the "posixly-correct" way of redirecting stdout to the output file and then redirect stderr to stdout.

Signed-off-by: Hannes Weisbach <hannes.weisbach@gmail.com>