### PR TITLE
parse: Silence discard-const warning on OpenBSD

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1048,7 +1048,20 @@ struct fio_option *find_option(struct fio_option *options, const char *opt)
 const struct fio_option *
 find_option_c(const struct fio_option *options, const char *opt)
 {
-	return find_option((struct fio_option *)options, opt);
+	const struct fio_option *o;
+
+	for (o = &options[0]; o->name; o++) {
+		if (!o_match(o, opt))
+			continue;
+		if (o->type == FIO_OPT_UNSUPPORTED) {
+			log_err("Option <%s>: %s\n", o->name, o->help);
+			continue;
+		}
+
+		return o;
+	}
+
+	return NULL;
 }
 
 static const struct fio_option *


### PR DESCRIPTION
This might be overkill just to silence the warnings, but having
a common function for const and non-const version makes it discard
const pointer at some point.

```
--
    CC parse.o
parse.c: In function 'find_option_c':
parse.c:1051: warning: passing argument 1 of 'find_option' discards qualifiers from pointer target type
parse.c: In function 'get_option':
parse.c:1051: warning: passing argument 1 of 'find_option' discards qualifiers from pointer target type
parse.c:1051: warning: passing argument 1 of 'find_option' discards qualifiers from pointer target type
parse.c: In function 'parse_cmd_option':
parse.c:1051: warning: passing argument 1 of 'find_option' discards qualifiers from pointer target type
```