### PR TITLE
engines/rados: fix error with getting last instead of first element from list

### DIFF
--- a/engines/rados.c
+++ b/engines/rados.c
@@ -342,7 +342,7 @@ int fio_rados_getevents(struct thread_data *td, unsigned int min,
 		}
 		assert(!flist_empty(&rados->completed_operations));
 		
-		fri = flist_last_entry(&rados->completed_operations, struct fio_rados_iou, list);
+		fri = flist_first_entry(&rados->completed_operations, struct fio_rados_iou, list);
 		assert(fri->completion);
 		assert(rados_aio_is_complete(fri->completion));
 		if (fri->write_op != NULL) {


### PR DESCRIPTION

    A thinko has popped in implementation. Consumer function `getevent()` did pick last (newest) instead of first (oldest).

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>