### PR TITLE
./configure: Fix --enable-libaio-uring

### DIFF
--- a/configure
+++ b/configure
@@ -607,9 +607,9 @@ int main(void)
   return 0;
 }
 EOF
-  if test "$libaio_uring" = "yes" && compile_prog "" "-luring" "libaio io_uring" ; then
+  if test "$libaio_uring" = "yes" && compile_prog "" "-laio -luring" "libaio io_uring" ; then
     libaio=yes
-    LIBS="-luring $LIBS"
+    LIBS="-laio -luring $LIBS"
   elif compile_prog "" "-laio" "libaio" ; then
     libaio=yes
     libaio_uring=no


### PR DESCRIPTION
Try compiling test code with libaio; otherwise, the test will fail.
CONFIG_LIBAIO_URING will be enabled if both of libaio and liburing
are available.

Signed-off-by: Takeshi HASEGAWA <hasegaw@gmail.com>