### PR TITLE
Use default version of the system python

### DIFF
--- a/tools/fiologparser.py
+++ b/tools/fiologparser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 # Note: this script is python2 and python 3 compatible.
 #
 # fiologparser.py


### PR DESCRIPTION
As the script is compatible both with python2 and python3 then it makes sense do not hardcode to python2.7 and use the system pytohn version.