### PR TITLE
.travis.yml: xcode11.2 scipy issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,16 @@ before_install:
         fi;
         sudo apt-get -qq update;
         sudo apt-get install --no-install-recommends -qq -y "${pkgs[@]}";
-    fi
+    fi;
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update;
         brew install cunit;
         if [[ "$TRAVIS_OSX_IMAGE" == "xcode11.2" ]]; then
             pip3 install scipy;
-        else
-            pip install scipy;
         fi;
-    fi
+        pip install scipy;
+    fi;
 script:
   - ./configure --extra-cflags="${EXTRA_CFLAGS}" && make
   - make test
-  - sudo python3 t/run-fio-tests.py --skip 6 1007 1008
+  - sudo python3 t/run-fio-tests.py --skip 6 1007 1008 --debug


### PR DESCRIPTION
The previous commit that added support for xcode11.2 resolved the
steadystate_tests scipy dependency with 'pip3 install scipy'. However,
the travis xcode11.2 image changed and now we need 'pip install scipy'
to provide the scipy dependency. To forestall future issues, install
scipy for both python2 and python3.

Also enable debug output in run-fio-tests.py to provide more information
in case of failure.

This resolves the Travis-CI problem @sitsofe encountered in https://github.com/axboe/fio/pull/879