### PR TITLE
lib/memalign: remove smalloc()/sfree() dependency

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -36,6 +36,8 @@
 #include "lib/rand.h"
 #include "lib/rbtree.h"
 #include "lib/num2str.h"
+#include "lib/memalign.h"
+#include "smalloc.h"
 #include "client.h"
 #include "server.h"
 #include "stat.h"
@@ -855,5 +857,15 @@ extern void check_trigger_file(void);
 
 extern bool in_flight_overlap(struct io_u_queue *q, struct io_u *io_u);
 extern pthread_mutex_t overlap_check;
+
+static inline void *fio_memalign(size_t alignment, size_t size, bool shared)
+{
+	return __fio_memalign(alignment, size, shared ? smalloc : malloc);
+}
+
+static inline void fio_memfree(void *ptr, size_t size, bool shared)
+{
+	return __fio_memfree(ptr, size, shared ? sfree : free);
+}
 
 #endif

--- a/lib/memalign.c
+++ b/lib/memalign.c
@@ -11,18 +11,14 @@ struct align_footer {
 	unsigned int offset;
 };
 
-void *fio_memalign(size_t alignment, size_t size, bool shared)
+void *__fio_memalign(size_t alignment, size_t size, malloc_fn fn)
 {
 	struct align_footer *f;
 	void *ptr, *ret = NULL;
 
 	assert(!(alignment & (alignment - 1)));
 
-	if (shared)
-		ptr = smalloc(size + alignment + sizeof(*f) - 1);
-	else
-		ptr = malloc(size + alignment + sizeof(*f) - 1);
-
+	ptr = fn(size + alignment + sizeof(*f) - 1);
 	if (ptr) {
 		ret = PTR_ALIGN(ptr, alignment - 1);
 		f = ret + size;
@@ -32,12 +28,9 @@ void *fio_memalign(size_t alignment, size_t size, bool shared)
 	return ret;
 }
 
-void fio_memfree(void *ptr, size_t size, bool shared)
+void __fio_memfree(void *ptr, size_t size, free_fn fn)
 {
 	struct align_footer *f = ptr + size;
 
-	if (shared)
-		sfree(ptr - f->offset);
-	else
-		free(ptr - f->offset);
+	fn(ptr - f->offset);
 }

--- a/lib/memalign.h
+++ b/lib/memalign.h
@@ -4,7 +4,10 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
-extern void *fio_memalign(size_t alignment, size_t size, bool shared);
-extern void fio_memfree(void *ptr, size_t size, bool shared);
+typedef void* (*malloc_fn)(size_t);
+typedef void (*free_fn)(void*);
+
+extern void *__fio_memalign(size_t alignment, size_t size, malloc_fn fn);
+extern void __fio_memfree(void *ptr, size_t size, free_fn fn);
 
 #endif

--- a/t/dedupe.c
+++ b/t/dedupe.c
@@ -10,13 +10,13 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#include "../fio.h"
 #include "../flist.h"
 #include "../log.h"
 #include "../fio_sem.h"
 #include "../smalloc.h"
 #include "../minmax.h"
 #include "../crc/md5.h"
-#include "../lib/memalign.h"
 #include "../os/os.h"
 #include "../gettime.h"
 #include "../fio_time.h"

--- a/unittests/lib/memalign.c
+++ b/unittests/lib/memalign.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "../unittest.h"
 
 #include "../../lib/memalign.h"
@@ -5,7 +6,7 @@
 static void test_memalign_1(void)
 {
 	size_t align = 4096;
-	void *p = fio_memalign(align, 1234, false);
+	void *p = __fio_memalign(align, 1234, malloc);
 
 	if (p)
 		CU_ASSERT_EQUAL(((int)(uintptr_t)p) & (align - 1), 0);

--- a/unittests/unittest.c
+++ b/unittests/unittest.c
@@ -8,17 +8,6 @@
 
 #include "./unittest.h"
 
-/* XXX workaround lib/memalign.c's dependency on smalloc.c */
-void *smalloc(size_t size)
-{
-	return malloc(size);
-}
-
-void sfree(void *ptr)
-{
-	free(ptr);
-}
-
 CU_ErrorCode fio_unittest_add_suite(const char *name, CU_InitializeFunc initfn,
 	CU_CleanupFunc cleanfn, struct fio_unittest_entry *tvec)
 {

--- a/unittests/unittest.h
+++ b/unittests/unittest.h
@@ -11,10 +11,6 @@ struct fio_unittest_entry {
 	CU_TestFunc fn;
 };
 
-/* XXX workaround lib/memalign.c's dependency on smalloc.c */
-void *smalloc(size_t);
-void sfree(void*);
-
 CU_ErrorCode fio_unittest_add_suite(const char*, CU_InitializeFunc,
 	CU_CleanupFunc, struct fio_unittest_entry*);
 


### PR DESCRIPTION
`fio_memalign()`/`fio_memfree()` implementation shouldn't depend on
`smalloc()`/`sfree()` which has dependency on fio code itself.
e.g. This forces unittest code to prepare stab functions for `smalloc()`/`sfree()`.

This `smalloc()`/`sfree()` dependency was added by 3114b675fd
("fio: enable cross-thread overlap checking with processes").

Rename `fio_memalign()`/`fio_memfree()` to `__fio_memalign()`/`__fio_memfree()`
and take a function pointer instead of a boolean flag.
Add `fio_memalign()`/`fio_memfree()` as an inlined wrapper for
`__fio_memalign()`/`__fio_memfree()` without API change.
The only real change here is `lib/memalign` functions got renamed.

Signed-off-by: Tomohiro Kusumi <kusumi.tomohiro@gmail.com>