### PR TITLE
backend: populate numberio in do_dry_run()

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1508,7 +1508,7 @@ static uint64_t do_dry_run(struct thread_data *td)
 		io_u->error = 0;
 		io_u->resid = 0;
 		if (ddir_rw(acct_ddir(io_u)))
-			td->io_issues[acct_ddir(io_u)]++;
+			io_u->numberio = td->io_issues[acct_ddir(io_u)]++;
 		if (ddir_rw(io_u->ddir)) {
 			io_u_mark_depth(td, 1);
 			td->ts.total_io_u[io_u->ddir]++;


### PR DESCRIPTION
io->numberio was not pulated in dry_run() when running a verify-only fio
run. Use td->io_issues to fill numberio. It will be added to io_u->ipo
for later verification.

Without this fix, using write_random
[write_stress]
filename=${FILENAME}
size=${FILESIZE}
verify_only=${VERIFY_ONLY}
readwrite=randwrite
bs=4k
ioengine=libaio
iodepth=32
direct=1
do_verify=1
verify=crc32c

'VERIFY_ONLY=1 FILENAME=/dev/sda1 FILESIZE=1M fio write_random' passes,
but
'VERIFY_ONLY=0 FILENAME=/dev/sda1 FILESIZE=1M fio write_random' fails:
"""verify_only option fails with verify: bad header numberio 1, wanted
0""".
With the fix, the later command passes as well.

Signed-off-by: Gwendal Grignou <gwendal@chromium.org> #732 