### PR TITLE
engines/filestat: add "lstat" option to use lstat(2)

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2261,6 +2261,10 @@ with the caveat that when used on the command line, they must come after the
 	multiple paths exist between the client and the server or in certain loopback
 	configurations.
 
+.. option:: lstat=bool : [filestat]
+
+	Use lstat(2) to measure lookup/getattr performance. Default is 0.
+
 .. option:: readfua=bool : [sg]
 
 	With readfua option set to 1, read operations include

--- a/fio.1
+++ b/fio.1
@@ -2032,6 +2032,9 @@ on the client site it will be used in the rdma_resolve_add()
 function. This can be useful when multiple paths exist between the
 client and the server or in certain loopback configurations.
 .TP
+.BI (filestat)lstat \fR=\fPbool
+Use \fBlstat\fR\|(2) to measure lookup/getattr performance. Default: 0.
+.TP
 .BI (sg)readfua \fR=\fPbool
 With readfua option set to 1, read operations include the force
 unit access (fua) flag. Default: 0.

--- a/optgroup.h
+++ b/optgroup.h
@@ -65,6 +65,7 @@ enum opt_category_group {
 	__FIO_OPT_G_ISCSI,
 	__FIO_OPT_G_NBD,
 	__FIO_OPT_G_IOURING,
+	__FIO_OPT_G_FILESTAT,
 	__FIO_OPT_G_NR,
 
 	FIO_OPT_G_RATE		= (1ULL << __FIO_OPT_G_RATE),
@@ -106,6 +107,7 @@ enum opt_category_group {
 	FIO_OPT_G_ISCSI         = (1ULL << __FIO_OPT_G_ISCSI),
 	FIO_OPT_G_NBD		= (1ULL << __FIO_OPT_G_NBD),
 	FIO_OPT_G_IOURING	= (1ULL << __FIO_OPT_G_IOURING),
+	FIO_OPT_G_FILESTAT	= (1ULL << __FIO_OPT_G_FILESTAT),
 };
 
 extern const struct opt_group *opt_group_from_mask(uint64_t *mask);


### PR DESCRIPTION
Use `stat(2)` by default, but `lstat(2)` if "lstat" bool option specified.
