### PR TITLE
stat: fix calculation of bw and iops statistics based on samples

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -3106,7 +3106,7 @@ static int __add_samples(struct thread_data *td, struct timespec *parent_tv,
 		stat_io_bytes[ddir] = this_io_bytes[ddir];
 	}
 
-	timespec_add_msec(parent_tv, avg_time);
+	*parent_tv = *t;
 
 	if (needs_lock)
 		__td_io_u_unlock(td);


### PR DESCRIPTION
It is obvious on many runs that bw and iops averages from statistics based
on samples are way off (sometimes by an order of magnitude) in comparison
to the main numbers reported for these values.

When sampling these values fio assumes that their each next averaging
interval starts exactly the set averaging interval later from the start of
the previous averaging interval.

However, this isn't necessary true as scheduling delays may lengthen such
intervals, so the next one should start when the previous one has actually
ended, since that's when the collected totals are counted.

On my test system (with fio set to the default averaging interval length of
500 msec) the actual lengths are usually around 650 msec, however
700+ msec intervals aren't unusual.

This causes pretty significant bw and iops measurement discrepancy between
the sample-based values and the overall measurements.

Let's make sure that we use the actual end time of the previous averaging
interval as the beginning of the next averaging interval.

With this change the bw and iops sample-based values become almost the
same as the main numbers reported.
