### PR TITLE
Fix build on architectures that don't have both cpu clock and __thread support.

### DIFF
--- a/gettime.c
+++ b/gettime.c
@@ -371,7 +371,7 @@ static int calibrate_cpu_clock(void)
 }
 #endif // ARCH_HAVE_CPU_CLOCK
 
-#ifndef CONFIG_TLS_THREAD
+#if defined(ARCH_HAVE_CPU_CLOCK) && !defined(CONFIG_TLS_THREAD)
 void fio_local_clock_init(void)
 {
 	struct tv_valid *t;
@@ -398,7 +398,7 @@ void fio_clock_init(void)
 	if (fio_clock_source == fio_clock_source_inited)
 		return;
 
-#ifndef CONFIG_TLS_THREAD
+#if defined(ARCH_HAVE_CPU_CLOCK) && !defined(CONFIG_TLS_THREAD)
 	if (pthread_key_create(&tv_tls_key, kill_tv_tls_key))
 		log_err("fio: can't create TLS key\n");
 #endif


### PR DESCRIPTION
OpenBSD sparc64 doesn't have __thread support and there's no cpu clock support in fio for sparc64 which results in the following compilation error:
```
cc -o gettime.o -std=gnu99 -Wwrite-strings -Wall -Wdeclaration-after-statement -g -ffast-math -O2 -pipe   -D_GNU_SOURCE -include config-host.h -I. -I/usr/obj/ports/fio-3.17/fio-fio-3.17 -DBITS_PER_LONG=64 -DFIO_VERSION='"fio-3.17"' -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DFIO_INTERNAL -DFIO_INC_DEBUG -c /usr/obj/ports/fio-3.17/fio-fio-3.17/gettime.c
/usr/obj/ports/fio-3.17/fio-fio-3.17/gettime.c: In function 'fio_local_clock_init':
/usr/obj/ports/fio-3.17/fio-fio-3.17/gettime.c:380: error: 'tv_tls_key' undeclared (first use in this function)
/usr/obj/ports/fio-3.17/fio-fio-3.17/gettime.c:380: error: (Each undeclared identifier is reported only once
/usr/obj/ports/fio-3.17/fio-fio-3.17/gettime.c:380: error: for each function it appears in.)
/usr/obj/ports/fio-3.17/fio-fio-3.17/gettime.c: In function 'fio_clock_init':
/usr/obj/ports/fio-3.17/fio-fio-3.17/gettime.c:402: error: 'tv_tls_key' undeclared (first use in this function)
gmake: *** [/usr/obj/ports/fio-3.17/fio-fio-3.17/Makefile:375: gettime.o] Error 1
```
This pull request fixes that error.