### PR TITLE
Use swap16/32/64 on OpenBSD.

### DIFF
--- a/os/os-openbsd.h
+++ b/os/os-openbsd.h
@@ -31,9 +31,9 @@
 #define PTHREAD_STACK_MIN 4096
 #endif
 
-#define fio_swap16(x)	bswap16(x)
-#define fio_swap32(x)	bswap32(x)
-#define fio_swap64(x)	bswap64(x)
+#define fio_swap16(x)	swap16(x)
+#define fio_swap32(x)	swap32(x)
+#define fio_swap64(x)	swap64(x)
 
 static inline int blockdev_size(struct fio_file *f, unsigned long long *bytes)
 {


### PR DESCRIPTION
OpenBSD uses swap16/32/64, not bswap16/32/64:
https://man.openbsd.org/swap32

On OpenBSD architectures that still use gcc this results in compilation warnings and linking errors:
```
cc -o crc/sha3.o -std=gnu99 -Wwrite-strings -Wall -Wdeclaration-after-statement -g -ffast-math -O2 -pipe   -D_GNU_SOURCE -include config-host.h -I. -I/usr/obj/ports/fio-3.17/fio-fio-3.17 -DBITS_PER_LONG=64 -DFIO_VERSION='"fio-3.17"' -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DFIO_INTERNAL -DFIO_INC_DEBUG -c /usr/obj/ports/fio-3.17/fio-fio-3.17/crc/sha3.c
/usr/obj/ports/fio-3.17/fio-fio-3.17/crc/sha3.c: In function 'fio_sha3_final':
/usr/obj/ports/fio-3.17/fio-fio-3.17/crc/sha3.c:169: warning: implicit declaration of function 'bswap64'
...
/usr/ports/pobj/fio-3.17/fio-fio-3.17/crc/sha3.c:169: undefined reference to `bswap64'
```
This pull request corrects the use of bswap and has be tested on OpenBSD sparc64/aarch64/amd64.
