### PR TITLE
engines/filestat: change "lstat" bool option to "stat_type" str option

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2261,9 +2261,10 @@ with the caveat that when used on the command line, they must come after the
 	multiple paths exist between the client and the server or in certain loopback
 	configurations.
 
-.. option:: lstat=bool : [filestat]
+.. option:: stat_type=str : [filestat]
 
-	Use lstat(2) to measure lookup/getattr performance. Default is 0.
+	Specify stat system call type to measure lookup/getattr performance.
+	Default is **stat** for :manpage:`stat(2)`.
 
 .. option:: readfua=bool : [sg]
 

--- a/fio.1
+++ b/fio.1
@@ -2032,8 +2032,9 @@ on the client site it will be used in the rdma_resolve_add()
 function. This can be useful when multiple paths exist between the
 client and the server or in certain loopback configurations.
 .TP
-.BI (filestat)lstat \fR=\fPbool
-Use \fBlstat\fR\|(2) to measure lookup/getattr performance. Default: 0.
+.BI (filestat)stat_type \fR=\fPstr
+Specify stat system call type to measure lookup/getattr performance.
+Default is \fBstat\fR for \fBstat\fR\|(2).
 .TP
 .BI (sg)readfua \fR=\fPbool
 With readfua option set to 1, read operations include the force


### PR DESCRIPTION
Per suggestion from Jens, change a bool option to str option
to better support `stat(2)` variants (at this point before 3.18).

https://github.com/axboe/fio/pull/912#issuecomment-577814885
