### PR TITLE
Makefile: don't fail to remove conditionally compiled binaries on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,7 @@ endif
 
 clean: FORCE
 	@rm -f .depend $(FIO_OBJS) $(GFIO_OBJS) $(OBJS) $(T_OBJS) $(UT_OBJS) $(PROGS) $(T_PROGS) $(T_TEST_PROGS) core.* core gfio unittests/unittest FIO-VERSION-FILE *.[do] lib/*.d oslib/*.[do] crc/*.d engines/*.[do] profiles/*.[do] t/*.[do] unittests/*.[do] unittests/*/*.[do] config-host.mak config-host.h y.tab.[ch] lex.yy.c exp/*.[do] lexer.h
+	@rm -f t/fio-btrace2fio t/io_uring t/read-to-pipe-async
 	@rm -rf  doc/output
 
 distclean: clean FORCE


### PR DESCRIPTION
`rm -f $(T_PROGS) $(T_TEST_PROGS)` in `clean` target is intended to
remove all binaries under t directory, but it actually fails to remove
`t/{fio-btrace2fio,io_uring,read-to-pipe-async}` files for not
evaluating platform specific variables on `make clean`.

```
 # uname -r
 5.4.17-200.fc31.x86_64
 # make clean
 # file t/* | grep ELF | awk '{print $1,$2,$3,$4,$5}'
 t/fio-btrace2fio: ELF 64-bit LSB executable,
 t/io_uring: ELF 64-bit LSB executable,
 t/read-to-pipe-async: ELF 64-bit LSB executable,
```

The easiest way to fix this is to hard-code these conditionally
compiled binaries.
