### PR TITLE
avoid division by zero in t/latency_percentiles.py

### DIFF
--- a/t/latency_percentiles.py
+++ b/t/latency_percentiles.py
@@ -395,6 +395,11 @@ class FioLatTest():
         approximation   value of the bin used by fio to store a given latency
         actual          actual latency value
         """
+
+        # Avoid a division by zero. The smallest latency values have no error.
+        if actual == 0:
+            return approximation == 0
+
         delta = abs(approximation - actual) / actual
         return delta <= 1/128
 


### PR DESCRIPTION
There was a division by zero error which led to a false failure report in an [AppVeyor run](https://ci.appveyor.com/project/axboe/fio/builds/30996510/job/osc8qdqhl6jmx03h) for https://github.com/axboe/fio/pull/932. This patch eliminates the possibility of the division by zero.