### PR TITLE
filesetup: fix win raw disk access and improve dir creation failure msg

### DIFF
--- a/os/os-windows.h
+++ b/os/os-windows.h
@@ -203,7 +203,11 @@ static inline int fio_mkdir(const char *path, mode_t mode) {
 	}
 
 	if (CreateDirectoryA(path, NULL) == 0) {
-		log_err("CreateDirectoryA = %d\n", GetLastError());
+		/* Ignore errors if path is a device namespace */
+		if (strcmp(path, "\\\\.") == 0) {
+			errno = EEXIST;
+			return -1;
+		}
 		errno = win_to_posix_error(GetLastError());
 		return -1;
 	}


### PR DESCRIPTION
The commit df18600fd06258b96ae6f6b530ecdff541c2a82d ("filesetup: fix
directory creation issues") broke Windows raw/physical disk access
because Windows doesn't consider a path that only consists of a
namespace (such as the device namespace "\\.\" - see
https://docs.microsoft.com/en-gb/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#namespaces
for information on Windows' namespaces) to exist as a directory(!).

Workaround the issue for raw devices by explicitly considering the
device namespace subcomponent to always be valid. Further, intermediate
path components in UNC paths or paths starting with a namespace might
also not "exist" so introduce backwards scanning for the longest
pre-existing directory to sidestep this. The function doing this is made
available for non-windows platforms so a similar code path is used
everywhere.

Tests done:

Windows:
> ./fio.exe --name=dtest --thread --size=16k --rw=write `
  --filename 'fio.tmp'
> ./fio.exe --name=dtest --thread --size=16k --rw=write `
  --filename '\\?\C\:\Windows\Temp\fio\fio.tmp'
> Clear-Disk 1 -RemoveData -Confirm:$false # Destroys partition data!
> ./fio.exe --name=dtest --thread --size=16k --rw=write `
   --filename '\\.\PhysicalDrive1'
> ./fio.exe --name=dtest --thread --size=16k --rw=write `
  --filename '\fio.tmp'
> ./fio.exe --name=dtest --thread --size=16k --rw=write `
  --filename '\\LOCALHOST\Users\User\fio\fio.tmp'

macOS:
$ rm -rf /tmp/fio
$ ./fio --name=dtest --size=16k --filename /tmp/fio/fio.tmp \
  --rw=write

Finally, change the directory creation error message to give a human
error message rather than just an errno.

Fixes: https://github.com/axboe/fio/issues/916
Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>