### PR TITLE
genfio: use /bin/bash hashbang

### DIFF
--- a/tools/genfio
+++ b/tools/genfio
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 #
 #  Copyright (C) 2013 eNovance SAS <licensing@enovance.com>
 #  Author: Erwan Velu  <erwan@enovance.com>


### PR DESCRIPTION
Not all distros have done usrmerge - Debian
https://salsa.debian.org/debian/fio/-/blob/5a608e04b947aed0d3b49d7ca9a85ed9afe9ec56/debian/patches/genfio-interpreter
and SUSE (https://build.opensuse.org/request/show/541207 ) have been
carrying a patch changing the interpreter for genfio back to /bin/bash
and that's before you get to other OSes such as macOS...

Since /bin/bash works everywhere let's do this upstream too.

Fixes: https://github.com/axboe/fio/pull/883
Inspired-by: Changcheng Liu <changcheng.liu@aliyun.com>
Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>