### PR TITLE
configure: fix vasprintf check under musl

### DIFF
--- a/configure
+++ b/configure
@@ -892,7 +892,8 @@ cat > $TMPC << EOF
 
 int main(int argc, char **argv)
 {
-  return vasprintf(NULL, "%s", NULL) == 0;
+  va_list ap;
+  return vasprintf(NULL, "%s", ap) == 0;
 }
 EOF
 if compile_prog "" "" "have_vasprintf"; then


### PR DESCRIPTION
It errors when passing NULL or 0. Passing an empty va_list works.