### PR TITLE
appveyor: make test artifacts available for inspection

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,8 +25,11 @@ after_build:
 
 test_script:
   - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && file.exe fio.exe && make.exe test'
-  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && python.exe t/run-fio-tests.py --debug'
+  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && [ -f fio.exe ] && python.exe t/run-fio-tests.py --artifact-root test-artifacts --debug'
+  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && [ -d test-artifacts ] && 7z a -t7z test-artifacts.7z test-artifacts -xr!foo.0.0 -xr!latency.?.0 -xr!fio_jsonplus_clat2csv.test'
 
 artifacts:
   - path: os\windows\*.msi
     name: msi
+  - path: test-artifacts.7z
+    name: test-artifacts


### PR DESCRIPTION
For debugging test failures, package test artifacts and make them
available for download. Exclude certain files to reduce size of the
compressed archive.

Suggested-by: Sitsofe Wheeler <sitsofe@gmail.com>
Signed-off-by: Vincent Fu <vincent.fu@wdc.com>