### PR TITLE
json: Fix compile error on RHEL6

### DIFF
--- a/json.h
+++ b/json.h
@@ -92,9 +92,9 @@ static inline int json_object_add_value_object(struct json_object *obj,
 {
 	struct json_value arg = {
 		.type = JSON_TYPE_OBJECT,
-		.object = val,
 	};
 
+	arg.object = val;
 	return json_object_add_value_type(obj, name, &arg);
 }
 


### PR DESCRIPTION
eb2f29b7fd("Make the JSON code easier to analyze") doesn't compile
on RHEL6 using gcc4.x.

Using `{.object = val,},` for an union field seems to fix the issue,
but just use `arg.object = val;` instead as this is guaranteed to
compile on supported platforms.

```
    CC gettime.o
In file included from stat.h:7,
                 from thread_options.h:7,
                 from fio.h:18,
                 from gettime.c:7:
json.h: In function 'json_object_add_value_object':
json.h:95: error: unknown field 'object' specified in initializer
json.h:95: warning: missing braces around initializer
json.h:95: warning: (near initialization for 'arg.<anonymous>')
json.h:95: warning: initialization makes integer from pointer without a cast
make: *** [gettime.o] Error 1
```