### PR TITLE
Fix inconsistent status-interval intervals

### DIFF
--- a/helper_thread.c
+++ b/helper_thread.c
@@ -164,12 +164,10 @@ static void *helper_thread_main(void *data)
 	while (!ret && !hd->exit) {
 		uint64_t since_du, since_ss = 0;
 		struct timeval timeout = {
-			.tv_sec  = DISK_UTIL_MSEC / 1000,
-			.tv_usec = (DISK_UTIL_MSEC % 1000) * 1000,
+			.tv_sec  = msec_to_next_event / 1000,
+			.tv_usec = (msec_to_next_event % 1000) * 1000,
 		};
 		fd_set rfds, efds;
-
-		timespec_add_msec(&ts, msec_to_next_event);
 
 		if (read_from_pipe(hd->pipe[0], &action, sizeof(action)) < 0) {
 			FD_ZERO(&rfds);

--- a/stat.c
+++ b/stat.c
@@ -2354,8 +2354,6 @@ void __show_running_run_stats(void)
 	fio_sem_up(stat_sem);
 }
 
-static bool status_interval_init;
-static struct timespec status_time;
 static bool status_file_disabled;
 
 #define FIO_STATUS_FILE		"fio-dump-status"
@@ -2398,16 +2396,6 @@ static int check_status_file(void)
 
 void check_for_running_stats(void)
 {
-	if (status_interval) {
-		if (!status_interval_init) {
-			fio_gettime(&status_time, NULL);
-			status_interval_init = true;
-		} else if (mtime_since_now(&status_time) >= status_interval) {
-			show_running_run_stats();
-			fio_gettime(&status_time, NULL);
-			return;
-		}
-	}
 	if (check_status_file()) {
 		show_running_run_stats();
 		return;


### PR DESCRIPTION
Jens, please consider these changes.

We observed inconsistent status intervals after the signal handler safety changes to the helper thread. Changing the select() timeout did not resolve the issue. Moving the status-interval trigger from the main fio thread to the helper thread did the trick, however.