### PR TITLE
stat: fix duplicate timestamps in iops/latency/bandwidth logs

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -2739,7 +2739,7 @@ static unsigned long add_log_sample(struct thread_data *td,
 
 	__add_stat_to_log(iolog, ddir, elapsed, td->o.log_max != 0, priority_bit);
 
-	iolog->avg_last[ddir] = elapsed - (this_window - iolog->avg_msec);
+	iolog->avg_last[ddir] = elapsed - (elapsed % iolog->avg_msec);
 	return iolog->avg_msec;
 }
 


### PR DESCRIPTION
add_log_sample() checks if the current time is greater than the last log time
plus the sampling window duration ("log_avg_msec").  If so it records the log
entry and sets the "last log time" to the current "last log time" plus
log_avg_msec.  This is incorrect in cases where more than log_avg_msec has
elapsed between calls to add_log_sample().  The effect is that the very next
time add_log_sample() is called a new log entry will be recorded, possibly with
the same timestamp as the previous log entry.

This fix sets the last log time to the current time, rounded down to the nearest
multiple of log_avg_msec (e.g. if current time is 203 and log_avg_msec is 50 the
last log time will be set to 200, so the next log entry should be recorded at
time=250).  This prevents duplicate log entries.

Fixes https://github.com/axboe/fio/issues/971