### PR TITLE
helper_thread: better handle select() return value

### DIFF
--- a/helper_thread.c
+++ b/helper_thread.c
@@ -194,10 +194,11 @@ static void *helper_thread_main(void *data)
 			FD_SET(hd->pipe[0], &rfds);
 			FD_ZERO(&efds);
 			FD_SET(hd->pipe[0], &efds);
-			ret = select(1, &rfds, NULL, &efds, &timeout);
-			if (ret < 0)
+			if (select(1, &rfds, NULL, &efds, &timeout) < 0) {
 				log_err("fio: select() call in helper thread failed: %s",
 					strerror(errno));
+				ret = 1;
+			}
 			if (read_from_pipe(hd->pipe[0], &action, sizeof(action)) <
 			    0)
 				action = 0;


### PR DESCRIPTION
On Windows, the ETA is not updated after ramp_time expires. For example:

```
C:\fio-dev>fio\fio --name=test --runtime=5s --time_based --ramp_time=5 --size=1M --ioengine=null --thread
test: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=null, iodepth=1
fio-3.19-54-g9bc8
Starting 1 thread
Jobs: 1 (f=0): [/(1)][-.-%][eta 00m:05s]
test: (groupid=0, jobs=1): err= 0: pid=5344: Tue May 12 10:40:49 2020
  read: IOPS=2535k, BW=9903MiB/s (10.4GB/s)(48.4GiB/5001msec)
    clat (nsec): min=38, max=10680, avg=40.94, stdev= 4.20
     lat (nsec): min=107, max=10751, avg=110.78, stdev= 6.13
...
```

Notice that the last ETA update line indicates that there are still 5s
of runtime left even though the job has finished. This occurs because
the while loop in helper_thread_main() finishes soon after ramp_time
expires instead of continuing to run until the last job has completed.
The while loop ends because the return value for select() is stored in
ret. select() can return positive values in non-error conditions. The
while loop should not end when select() returns a positive value.

Fixes: 700ad386aa88 ("helper_thread: Complain if select() fails")