### PR TITLE
fix man page and example for latency_window

### DIFF
--- a/examples/latency-profile.fio
+++ b/examples/latency-profile.fio
@@ -13,7 +13,7 @@ iodepth=128
 # Set max acceptable latency to 500msec
 latency_target=500000
 # profile over a 5s window
-latency_window=5000000
+latency_window=5000
 # 99.9% of IOs must be below the target
 latency_percentile=99.9
 

--- a/fio.1
+++ b/fio.1
@@ -2267,7 +2267,7 @@ the unit is omitted, the value is interpreted in microseconds. See
 .BI latency_window \fR=\fPtime
 Used with \fBlatency_target\fR to specify the sample window that the job
 is run at varying queue depths to test the performance. When the unit is
-omitted, the value is interpreted in microseconds.
+omitted, the value is interpreted in milliseconds.
 .TP
 .BI latency_percentile \fR=\fPfloat
 The percentage of I/Os that must fall within the criteria specified by


### PR DESCRIPTION
The code uses latency_window as millisecond, but the man page says it is
microsecond. Fix the man page and the example.

Signed-off-by: Song Liu <songliubraving@fb.com>