### PR TITLE
engines/rados: fix build issue with thread_cond_t vs pthread_cond_t

### DIFF
--- a/engines/rados.c
+++ b/engines/rados.c
@@ -17,7 +17,7 @@ struct rados_data {
 	struct io_u **aio_events;
 	bool connected;
 	pthread_mutex_t completed_lock;
-	thread_cond_t completed_more_io;
+	pthread_cond_t completed_more_io;
 	struct flist_head completed_operations;
 	uint64_t ops_scheduled;
 	uint64_t ops_completed;


### PR DESCRIPTION
The Travis-CI Ubuntu 18.04 build fails because the type for `completed_more_io`
was changed from `pthread_cond_t` to `thread_cond_t`:

https://travis-ci.org/github/axboe/fio/jobs/687073515

Change it back to `pthread_cond_t`.

The original code actually builds without error in my local Ubuntu 18.04 build environment but it fails in Travis-CI's Ubuntu 18.04 build environment.

Fixes: 1e30d8d005a568169c0749f5fc6fb2d5f09dcc97 ("engines/rados: Added
waiting for completion on cleanup.")
Signed-off-by: Vincent Fu <vincent.fu@wdc.com>