### PR TITLE
fix unit of latency_window

### DIFF
--- a/init.c
+++ b/init.c
@@ -956,7 +956,6 @@ static int fixup_options(struct thread_data *td)
 	 */
 	o->max_latency *= 1000ULL;
 	o->latency_target *= 1000ULL;
-	o->latency_window *= 1000ULL;
 
 	return ret;
 }


### PR DESCRIPTION
latency_window has unit of microseconds, and is compared against
usec_window. Therefore, there is no need to fix it up to nanoseconds.

Signed-off-by: Song Liu <songliubraving@fb.com>