### PR TITLE
Unbreak zbd.c build on NetBSD and OpenBSD

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -1268,7 +1268,12 @@ done:
 	td_restore_runstate(td, old_state);
 
 	if (td->o.zone_mode == ZONE_MODE_ZBD) {
+#if defined(FIO_OS_NETBSD_H) || defined(FIO_OS_OPENBSD_H)
+		log_err("%s: zbd unsupported\n", o->name);
+		err = 1; /* unsupported due to unimplemented pthread function */
+#else
 		err = zbd_setup_files(td);
+#endif
 		if (err)
 			goto err_out;
 	}

--- a/os/os-netbsd.h
+++ b/os/os-netbsd.h
@@ -35,6 +35,12 @@
 #define fio_swap32(x)	bswap32(x)
 #define fio_swap64(x)	bswap64(x)
 
+/*
+ * XXX Define NOP pthread_mutexattr_setpshared(3) to unbreak build.
+ * pthread_mutexattr_setpshared(3) won't be implemented any time soon.
+ */
+#define pthread_mutexattr_setpshared(attr, pshared) do{}while(0)
+
 static inline int blockdev_size(struct fio_file *f, unsigned long long *bytes)
 {
 	struct disklabel dl;

--- a/os/os-openbsd.h
+++ b/os/os-openbsd.h
@@ -35,6 +35,12 @@
 #define fio_swap32(x)	swap32(x)
 #define fio_swap64(x)	swap64(x)
 
+/*
+ * XXX Define NOP pthread_mutexattr_setpshared(3) to unbreak build.
+ * pthread_mutexattr_setpshared(3) won't be implemented any time soon.
+ */
+#define pthread_mutexattr_setpshared(attr, pshared) do{}while(0)
+
 static inline int blockdev_size(struct fio_file *f, unsigned long long *bytes)
 {
 	struct disklabel dl;


### PR DESCRIPTION
Neither platform has `pthread_mutexattr_setpshared(3)`,
so NetBSD and OpenBSD can't support (and have never supported)
`zonemode=zbd` unless pthread part in zbd.c gets implemented without
using it.

Since it's their pthread issue that they haven't implemented
`pthread_mutexattr_setpshared(3)`, just define an NOP macro and fail
on runtime, rather than bringing back compile time detection.

Fixes: b76949618d55 ("fio: Generalize zonemode=zbd")