### PR TITLE
Testing improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,10 +26,10 @@ after_build:
 test_script:
   - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && file.exe fio.exe && make.exe test'
   - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && [ -f fio.exe ] && python.exe t/run-fio-tests.py --artifact-root test-artifacts --debug'
-  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && [ -d test-artifacts ] && 7z a -t7z test-artifacts.7z test-artifacts -xr!foo.0.0 -xr!latency.?.0 -xr!fio_jsonplus_clat2csv.test'
 
 artifacts:
   - path: os\windows\*.msi
     name: msi
-  - path: test-artifacts.7z
-    name: test-artifacts
+
+on_finish:
+  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && [ -d test-artifacts ] && 7z a -t7z test-artifacts.7z test-artifacts -xr!foo.0.0 -xr!latency.?.0 -xr!fio_jsonplus_clat2csv.test && appveyor PushArtifact test-artifacts.7z'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ os:
 compiler:
   - clang
   - gcc
+arch:
+  - amd64
+  - arm64
 env:
   matrix:
     - BUILD_ARCH="x86"
@@ -17,18 +20,24 @@ matrix:
     - os: osx
       compiler: clang # Workaround travis setting CC=["clang", "gcc"]
       env: BUILD_ARCH="x86_64"
+      arch: amd64
     # Latest xcode image (needs periodic updating)
     - os: osx
       compiler: clang
       osx_image: xcode11.2
       env: BUILD_ARCH="x86_64"
+      arch: amd64
   exclude:
     - os: osx
       compiler: gcc
-  exclude:
     - os: linux
       compiler: clang
+      arch: amd64
       env: BUILD_ARCH="x86" # Only do the gcc x86 build to reduce clutter
+    - os: linux
+      env: BUILD_ARCH="x86"
+      arch: arm64
+
 before_install:
   - EXTRA_CFLAGS="-Werror"
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -54,4 +63,8 @@ before_install:
 script:
   - ./configure --extra-cflags="${EXTRA_CFLAGS}" && make
   - make test
-  - sudo python3 t/run-fio-tests.py --skip 6 1007 1008 --debug
+  - if [[ "$TRAVIS_CPU_ARCH" == "arm64" ]]; then
+        sudo python3 t/run-fio-tests.py --skip 6 1007 1008 --debug -p 1010:"--skip 15 16 17 18 19 20";
+    else
+        sudo python3 t/run-fio-tests.py --skip 6 1007 1008 --debug;
+    fi;


### PR DESCRIPTION
Jens, please consider this pull request which does the following:

- upload AppVeyor test artifacts whether tests fail or pass instead of only when they all pass 
- enable TravisCI arm64 builds

arm64 builds are working for my fio fork: https://travis-ci.com/github/vincentkfu/fio/builds/168409097

TravisCI says that arm64 support is still at an [alpha](https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support) stage and there have been some issues only [recently resolved](https://travis-ci.community/t/disk-quota-exceeded-on-arm64/7619/11). So adding arm64 builds may cause some test noise, but it is useful to support an additional platform.