### PR TITLE
pshared: fix comment on supported platforms

### DIFF
--- a/pshared.c
+++ b/pshared.c
@@ -51,7 +51,7 @@ int mutex_init_pshared_with_type(pthread_mutex_t *mutex, int type)
 	}
 
 	/*
-	 * Not all platforms support process shared mutexes (FreeBSD)
+	 * Not all platforms support process shared mutexes (NetBSD/OpenBSD)
 	 */
 #ifdef CONFIG_PSHARED
 	ret = pthread_mutexattr_setpshared(&mattr, PTHREAD_PROCESS_SHARED);


### PR DESCRIPTION
FreeBSD supports it, but NetBSD/OpenBSD don't.

```
 # uname
 FreeBSD
 # ./configure | grep "POSIX pshared"
 POSIX pshared support         yes
```

```
 # uname
 NetBSD
 # ./configure | grep "POSIX pshared"
 POSIX pshared support         no
```
