### PR TITLE
fio_generate_plots: fix scale on gnuplot graphs

### DIFF
--- a/tools/fio_generate_plots
+++ b/tools/fio_generate_plots
@@ -123,10 +123,10 @@ plot () {
 # plot <sub title> <file name tag> <y axis label> <y axis scale>
 #
 
-plot "I/O Latency" lat "Time (msec)" 1000
+plot "I/O Latency" lat "Time (msec)" 1000000
 plot "I/O Operations Per Second" iops "IOPS" 1
-plot "I/O Submission Latency" slat "Time (μsec)" 1
-plot "I/O Completion Latency" clat "Time (msec)" 1000
+plot "I/O Submission Latency" slat "Time (μsec)" 1000
+plot "I/O Completion Latency" clat "Time (msec)" 1000000
 plot "I/O Bandwidth" bw "Throughput (KB/s)" 1
 
 


### PR DESCRIPTION
Since log files for latencies have values in nanoseconds in order to get microseconds we divide by 1000
and for milliseconds by 1000000