### PR TITLE
Changed signedness of seqlock.sequence fixing comparison-warning

### DIFF
--- a/lib/seqlock.h
+++ b/lib/seqlock.h
@@ -5,7 +5,7 @@
 #include "../arch/arch.h"
 
 struct seqlock {
-	volatile int sequence;
+	volatile unsigned int sequence;
 };
 
 static inline void seqlock_init(struct seqlock *s)


### PR DESCRIPTION
I might be off here, but it seems like ``seqlock.sequence`` should be ``unsigned`` to avoid comparing signed with unsigned in the function ``read_seqlock_retry()``.