### PR TITLE
Unbreak the pmemblk engine

### DIFF
--- a/engines/pmemblk.c
+++ b/engines/pmemblk.c
@@ -220,13 +220,13 @@ static fio_pmemblk_file_t pmb_open(const char *pathspec, int flags)
 		pmb->pmb_nblocks = pmemblk_nblock(pmb->pmb_pool);
 
 		fio_pmemblk_cache_insert(pmb);
+	} else {
+		free(path);
 	}
 
 	pmb->pmb_refcnt += 1;
 
 	pthread_mutex_unlock(&CacheLock);
-
-	free(path);
 
 	return pmb;
 


### PR DESCRIPTION
Reported-by: Yi Zhang <yi.zhang@redhat.com>
Tested-by: Yi Zhang <yi.zhang@redhat.com>
Fixes: e9c7be0e32e6 ("pmemblk: Fix a memory leak")
Signed-off-by: Bart Van Assche <bvanassche@acm.org>