### PR TITLE
io_uring: Avoid needless update of completion queue head pointer

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -307,7 +307,9 @@ static int fio_ioring_cqring_reap(struct thread_data *td, unsigned int events,
 		head++;
 	} while (reaped + events < max);
 
-	atomic_store_release(ring->head, head);
+	if (reaped)
+		atomic_store_release(ring->head, head);
+
 	return reaped;
 }
 


### PR DESCRIPTION
I'm seeing a slowdown in io_uring performance on a POWER9 box when
the userspace and kernel polling threads are on two cores that
share an L2 cache.

fio_ioring_cqring_reap() always stores to the completion queue head
pointer, even if nothing was reaped and the value hasn't changed.

Changing this to only update the head pointer when it changes results
in a 95% improvement in performance on this particular test.

Signed-off-by: Anton Blanchard <anton@ozlabs.org>