### PR TITLE
Fix: dev-dax engine building with make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,8 @@ ifdef CONFIG_PMEMBLK
   ENGINES += pmemblk
 endif
 ifdef CONFIG_LINUX_DEVDAX
-  devdax_SRCS = engines/dev-dax.c
-  devdax_LIBS = -lpmem
+  dev-dax_SRCS = engines/dev-dax.c
+  dev-dax_LIBS = -lpmem
   ENGINES += dev-dax
 endif
 ifdef CONFIG_LIBPMEM


### PR DESCRIPTION
With recent changes to Makefile dev-dax skips building. This patch fixes that.

Signed-off-by: Harish <harish@linux.ibm.com>