### PR TITLE
Adding Fix for Indefinite run for fio

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -680,7 +680,23 @@ static enum fio_ddir rate_ddir(struct thread_data *td, enum fio_ddir ddir)
 	if (td->o.io_submit_mode == IO_MODE_INLINE)
 		io_u_quiesce(td);
 
+	if (td->o.timeout && ((usec + now) > td->o.timeout)) {
+		/*
+		 * check if the usec is capable of taking negative values
+		 * however it is unlikely, but still a possibility.
+		 */
+		if (now > td->o.timeout) {
+			ddir = DDIR_INVAL;
+			return ddir;
+		}
+		usec = td->o.timeout - now;
+	}
 	usec_sleep(td, usec);
+
+	now = utime_since_now(&td->epoch);
+	if ((td->o.timeout && (now > td->o.timeout)) || td->terminate)
+		ddir = DDIR_INVAL;
+
 	return ddir;
 }
 
@@ -896,6 +912,10 @@ static int fill_io_u(struct thread_data *td, struct io_u *io_u)
 
 	set_rw_ddir(td, io_u);
 
+	if (io_u->ddir == DDIR_INVAL) {
+		dprint(FD_IO, "Invalid Direction received ddir = %d", io_u->ddir);
+		return 1;
+	}
 	/*
 	 * fsync() or fdatasync() or trim etc, we are done
 	 */

--- a/stat.c
+++ b/stat.c
@@ -414,6 +414,18 @@ static void display_lat(const char *name, unsigned long long min,
 	free(maxp);
 }
 
+static double convert_agg_kbytes_percent(struct group_run_stats *rs, int ddir, int mean)
+{
+	double p_of_agg = 100.0;
+	if (rs->agg[ddir] < 1024) {
+		p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024.0);
+
+		if (p_of_agg > 100.0)
+			p_of_agg = 100.0;
+	}
+	return p_of_agg;
+}
+
 static void show_ddir_status(struct group_run_stats *rs, struct thread_stat *ts,
 			     int ddir, struct buf_output *out)
 {
@@ -551,11 +563,7 @@ static void show_ddir_status(struct group_run_stats *rs, struct thread_stat *ts,
 		else
 			bw_str = "kB";
 
-		if (rs->agg[ddir]) {
-			p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024);
-			if (p_of_agg > 100.0)
-				p_of_agg = 100.0;
-		}
+		p_of_agg = convert_agg_kbytes_percent(rs, ddir, mean);
 
 		if (rs->unit_base == 1) {
 			min *= 8.0;
@@ -1376,11 +1384,7 @@ static void add_ddir_status_json(struct thread_stat *ts,
 	}
 
 	if (calc_lat(&ts->bw_stat[ddir], &min, &max, &mean, &dev)) {
-		if (rs->agg[ddir]) {
-			p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024);
-			if (p_of_agg > 100.0)
-				p_of_agg = 100.0;
-		}
+		p_of_agg = convert_agg_kbytes_percent(rs, ddir, mean);
 	} else {
 		min = max = 0;
 		p_of_agg = mean = dev = 0.0;


### PR DESCRIPTION
PR to the Linked Issue:

io_u: fix asymptotically high time run in accordance with blocksize of fio when using rate with timeout
Fixes: https://github.com/axboe/fio/issues/1039
signed-off-by : Sriharsha B S sribs@microsoft.com

@sitsofe , It is almost the same change that you have proposed. However, I have added another check to check if it takes in negative values.

Thanks,
Sri