### PR TITLE
Fix travis libiscsi

### DIFF
--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -7,7 +7,6 @@ case "$TRAVIS_OS_NAME" in
 	# Architecture-dependent packages.
 	pkgs=(
 	    libaio-dev
-	    libcunit1
 	    libcunit1-dev
 	    libfl-dev
 	    libgoogle-perftools-dev

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -20,7 +20,10 @@ case "$TRAVIS_OS_NAME" in
 	case "$CI_TARGET_ARCH" in
 	    "x86")
 		pkgs=("${pkgs[@]/%/:i386}")
-		pkgs+=(gcc-multilib)
+		pkgs+=(
+		    gcc-multilib
+		    pkg-config:i386
+	        )
 		;;
 	    "amd64")
 		pkgs+=(nvidia-cuda-dev)


### PR DESCRIPTION
cf6d8924684125b927e55471e58bad5a246e859d ("travis: enable libiscsi and cuda ioengines") made the travis x86 cross compile builds fail because pkg-config was still looking for 64 bit libraries. This patchset brute forces it way around the problem by making travis install a 32 bit pkg-config for that build.