### PR TITLE
Prevent that fio hangs when using io_submit_mode=offload

### DIFF
--- a/rate-submit.c
+++ b/rate-submit.c
@@ -97,8 +97,11 @@ static int io_workqueue_fn(struct submit_worker *sw,
 			td->cur_depth -= ret;
 	}
 
-	if (error || td->error)
+	if (error || td->error) {
+		pthread_mutex_lock(&td->io_u_lock);
 		pthread_cond_signal(&td->parent->free_cond);
+		pthread_mutex_unlock(&td->io_u_lock);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This patch has been tested by running the following shell command:

for ((i=0;i<1000;i++)); do echo $i; python3 t/run-fio-tests.py -o 10; done

Fixes: d28174f0189c ("workqueue: ensure we see deferred error for IOs")
Signed-off-by: Bart Van Assche <bvanassche@acm.org>