### PR TITLE
filelock: fix wrong file trylock assertion.

### DIFF
--- a/filelock.c
+++ b/filelock.c
@@ -179,7 +179,7 @@ static bool __fio_lock_file(const char *fname, int trylock)
 	fio_sem_up(&fld->lock);
 
 	if (!ff) {
-		assert(!trylock);
+		assert(trylock);
 		return true;
 	}
 


### PR DESCRIPTION
Earlier solution to increase MAX_FILELOCKS for high parallelism might not be necessary given the wrong assertion

`> fio: filelock.c:182: __fio_lock_file: Assertion !trylock' failed. `

https://github.com/axboe/fio/commit/43661a66a8c3b9fb5ff28b463c9ab0aac91a0355

