### PR TITLE
oslib: fix asprintf build failure

### DIFF
--- a/oslib/asprintf.c
+++ b/oslib/asprintf.c
@@ -1,4 +1,3 @@
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "oslib/asprintf.h"

--- a/oslib/asprintf.h
+++ b/oslib/asprintf.h
@@ -1,6 +1,8 @@
 #ifndef FIO_ASPRINTF_H
 #define FIO_ASPRINTF_H
 
+#include <stdarg.h>
+
 #ifndef CONFIG_HAVE_VASPRINTF
 int vasprintf(char **strp, const char *fmt, va_list ap);
 #endif


### PR DESCRIPTION
```oslib/asprintf.h``` needs to include ```<stdarg.h>``` for ```va_list```.
This started to appear on NetBSD since
38b00241e3("num2str(): Use asprintf() instead of malloc()").

```
In file included from lib/num2str.c:7:0:
lib/../oslib/asprintf.h:5:45: error: unknown type name 'va_list'; did you mean '__va_list'?
 int vasprintf(char **strp, const char *fmt, va_list ap);
                                             ^~~~~~~
                                             __va_list
    CC lib/pattern.o
gmake: *** [Makefile:447: lib/num2str.o] Error 1
```