### PR TITLE
ci: always upload Windows MSI if smoke test passes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,15 +25,13 @@ build_script:
   - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && ./configure --disable-native --extra-cflags=\"-Werror\" ${CONFIGURE_OPTIONS} && make.exe'
 
 after_build:
-  - cd os\windows && dobuild.cmd %PLATFORM%
+  - file.exe fio.exe
+  - make.exe test
+  - 'cd os\windows && dobuild.cmd %PLATFORM% && cd ..'
+  - ps: Get-ChildItem .\os\windows\*.msi | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name -DeploymentName fio.msi }
 
 test_script:
-  - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && file.exe fio.exe && make.exe test'
   - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && [ -f fio.exe ] && python.exe t/run-fio-tests.py --artifact-root test-artifacts --debug'
-
-artifacts:
-  - path: os\windows\*.msi
-    name: msi
 
 on_finish:
   - 'bash.exe -lc "cd \"${APPVEYOR_BUILD_FOLDER}\" && [ -d test-artifacts ] && 7z a -t7z test-artifacts.7z test-artifacts -xr!foo.0.0 -xr!latency.?.0 -xr!fio_jsonplus_clat2csv.test && appveyor PushArtifact test-artifacts.7z'


### PR DESCRIPTION
When the test_script stage fails the artifacts stage isn't run. This is
problematic because the long running tests (on all platforms) can be
flaky and Windows folk are accustomed to not having to do builds
themselves when testing the tip of a project. This could lead to a
situation where no there's no pre-built Windows binaries due to a
spurious failures...

Solve the above by moving the smoke test and artifact upload to be
earlier, remove a useless use of bash during smoke Appveyor smoke
testing and change the "Deployment name" from msi to fio.msi.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>