### PR TITLE
zbd: Add a missing pthread_mutex_unlock() call

### DIFF
--- a/zbd.c
+++ b/zbd.c
@@ -1546,6 +1546,7 @@ enum io_u_action zbd_adjust_block(struct thread_data *td, struct io_u *io_u)
 	case DDIR_READ:
 		if (td->runstate == TD_VERIFYING && td_write(td)) {
 			zb = zbd_replay_write_order(td, io_u, zb);
+			pthread_mutex_unlock(&zb->mutex);
 			goto accept;
 		}
 		/*


### PR DESCRIPTION
This patch fixes the following Coverity complaint:

CID 292491 (#1 of 1): Missing unlock (LOCK)
missing_unlock: Returning without unlocking zb->mutex.

Fixes: bfbdd35b3e8f ("Add support for zoned block devices")
Signed-off-by: Bart Van Assche <bvanassche@acm.org>