### PR TITLE
init: exiting with fio_show_ioengine_help return code

### DIFF
--- a/init.c
+++ b/init.c
@@ -2543,7 +2543,7 @@ int parse_cmd_line(int argc, char *argv[], int client_type)
 		case 'i':
 			did_arg = true;
 			if (!cur_client) {
-				fio_show_ioengine_help(optarg);
+				exit_val = fio_show_ioengine_help(optarg);
 				do_exit++;
 			}
 			break;


### PR DESCRIPTION
In the current code, calling --enghelp=<engine> always return 0.
But fio_show_ioengine_help() implemented a return code to inform when an engine is present or not.

This commit makes fio returning fio_show_ioengine_help() value when calling --enghelp=<engine>

A typical use case is detecting which engine is available on a given fio build.
It is possible to use the return code to determine if a given engine is available or not :

	[user@host]# fio --enghelp=libaio
	userspace_reap          : Use alternative user-space reap implementation
	[user@host]# echo $?
	0

	[user@host]#fio --enghelp=io_uring
	fio: engine io_uring not loadable
	IO engine io_uring not found
	[user@host]# echo $?
	1

Signed-off-by: Erwan Velu <e.velu@criteo.com>