### PR TITLE
getopt_long: avoid variable global initialization

### DIFF
--- a/oslib/getopt_long.c
+++ b/oslib/getopt_long.c
@@ -16,8 +16,8 @@
 
 #include "getopt.h"
 
-char *optarg = NULL;
-int optind = 0, opterr = 0, optopt = 0;
+char *optarg;
+int optind, opterr, optopt;
 
 static struct getopt_private_state {
 	const char *optptr;


### PR DESCRIPTION
Issue #1100 shows that an address sanitizer(ASAN) complains about a few
global variables that are initialized globally in the getopt_long.c file.
We look into these variables and found they do not need to be initialized
globally. This patch fixes the issue by cleaning up the global
initialization for these variables.

Signed-off-by: Cheng Li <chenglii@cs.rutgers.edu>