### PR TITLE
stat: fix bandwidth log maximum log entry count

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -2435,7 +2435,7 @@ static struct io_logs *get_new_log(struct io_log *iolog)
 	 * forever
 	 */
 	if (!iolog->cur_log_max)
-		new_samples = DEF_LOG_ENTRIES;
+		new_samples = MAX_LOG_ENTRIES;
 	else {
 		new_samples = iolog->cur_log_max * 2;
 		if (new_samples > MAX_LOG_ENTRIES)


### PR DESCRIPTION
When using `--bandwidth-log`, resulting aggregated logs will
contain only 1024 lines, which do not contain enough information
when fio is running for a longer period of time. This commit
changes size cap to the value of MAX_LOG_ENTRIES (instead of
DEF_LOG_ENTRIES)