### PR TITLE
Fix to prevent the status interval from creeping up by 1-2 msec over time

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -3091,13 +3091,15 @@ int calc_log_samples(void)
 			(td->bw_log && !per_unit_log(td->bw_log))) {
 			tmp = add_bw_samples(td, &now);
 
-			log_avg_msec = td->bw_log->avg_msec;
+			if (td->bw_log)
+				log_avg_msec = td->bw_log->avg_msec;
 		}
 		if (!td->iops_log ||
 			(td->iops_log && !per_unit_log(td->iops_log))) {
 			tmp = add_iops_samples(td, &now);
 
-			log_avg_msec = td->iops_log->avg_msec;
+			if (td->iops_log)
+				log_avg_msec = td->iops_log->avg_msec;
 		}
 
 		if (tmp < next)
@@ -3109,6 +3111,7 @@ int calc_log_samples(void)
 
 	next_mod = elapsed_time%log_avg_msec;
 	next = min(next, (log_avg_msec-next_mod));  /* correction to keep the time on the log avg msec boundary */
+
 	return next == ~0U ? 0 : next;
 }
 


### PR DESCRIPTION
With the current FIO version, we're seeing the status interval increase by 1 msec over time.  See an example in the stat-int-creep attached file.
[stat-int-creep.txt](https://github.com/axboe/fio/files/5476571/stat-int-creep.txt)

This issue will cause dip ( low ) in IOPS and BW plot vs time because parsing/plot tool can't get correct sum total IOPS and BW from multiple jobs when there is 1-2us increment in timestamp.

The issue was introduced in version 3.18 with the following commit - https://github.com/axboe/fio/commit/31eca641ad91634e5ffcf369cd756b0506a700c1 .   
And this commit made it slightly better - https://github.com/axboe/fio/commit/0f77d30d90b809fbf233b9474cc5d17c6bf73541
But the problem still exists.

The patch below is my attempt to correct the problem.  I'm not real familiar with the FIO code so I'm sure there could be better ways to do this.  Please review and provide any input that would make this fix better.  
