### PR TITLE
ioengines: increment FIO_IOOPS_VERSION

### DIFF
--- a/ioengines.h
+++ b/ioengines.h
@@ -8,7 +8,7 @@
 #include "io_u.h"
 #include "zbd_types.h"
 
-#define FIO_IOOPS_VERSION	26
+#define FIO_IOOPS_VERSION	27
 
 #ifndef CONFIG_DYNAMIC_ENGINES
 #define FIO_STATIC	static


### PR DESCRIPTION
increment FIO_IOOPS_VERSION to reflect changes made to struct io_u in versions 3.22+