### PR TITLE
Grow bandwidth log stats to MAX_LOG_ENTRIES

### DIFF
--- a/eta.c
+++ b/eta.c
@@ -507,6 +507,7 @@ bool calc_thread_status(struct jobs_eta *je, int force)
 		calc_rate(unified_rw_rep, rate_time, io_bytes, rate_io_bytes,
 				je->rate);
 		memcpy(&rate_prev_time, &now, sizeof(now));
+		regrow_agg_logs();
 		for_each_rw_ddir(ddir) {
 			add_agg_sample(sample_val(je->rate[ddir]), ddir, 0, 0);
 		}

--- a/iolog.h
+++ b/iolog.h
@@ -182,6 +182,7 @@ static inline struct io_sample *__get_sample(void *samples, int log_offset,
 struct io_logs *iolog_cur_log(struct io_log *);
 uint64_t iolog_nr_samples(struct io_log *);
 void regrow_logs(struct thread_data *);
+void regrow_agg_logs(void);
 
 static inline struct io_sample *get_sample(struct io_log *iolog,
 					   struct io_logs *cur_log,

--- a/stat.c
+++ b/stat.c
@@ -2536,6 +2536,14 @@ void regrow_logs(struct thread_data *td)
 	td->flags &= ~TD_F_REGROW_LOGS;
 }
 
+void regrow_agg_logs(void)
+{
+	enum fio_ddir ddir;
+
+	for (ddir = 0; ddir < DDIR_RWDIR_CNT; ddir++)
+		regrow_log(agg_io_log[ddir]);
+}
+
 static struct io_logs *get_cur_log(struct io_log *iolog)
 {
 	struct io_logs *cur_log;


### PR DESCRIPTION
This commit enables agg logs to grow to MAX_LOG_ENTRIES, like any thread logs.

Fixes: https://github.com/axboe/fio/issues/1113
Co-authored-by: Sitsofe Wheeler <sitsofe@yahoo.com>
Tested-by: Panagiotis Moustafellos <pmoust@elastic.co>
Signed-off-by: Panagiotis Moustafellos <pmoust@elastic.co>