### PR TITLE
Uniform examples usage

### DIFF
--- a/examples/cpp_null.fio
+++ b/examples/cpp_null.fio
@@ -7,4 +7,4 @@ ioengine=cpp_null
 size=100g
 rw=randread
 norandommap
-time_based=0
+time_based

--- a/examples/cross-stripe-verify.fio
+++ b/examples/cross-stripe-verify.fio
@@ -17,7 +17,7 @@ verify_backlog=1
 offset_increment=124g
 io_size=120g
 offset=120k
-group_reporting=1
+group_reporting
 verify_dump=1
 loops=2
 

--- a/examples/dev-dax.fio
+++ b/examples/dev-dax.fio
@@ -18,7 +18,7 @@ cpus_allowed_policy=split
 #
 iodepth=1
 direct=0
-thread=1
+thread
 numjobs=16
 #
 # The dev-dax engine does IO to DAX device that are special character

--- a/examples/dev-dax.fio
+++ b/examples/dev-dax.fio
@@ -2,7 +2,7 @@
 bs=2m
 ioengine=dev-dax
 norandommap
-time_based=1
+time_based
 runtime=30
 group_reporting
 disable_lat=1

--- a/examples/e4defrag.fio
+++ b/examples/e4defrag.fio
@@ -18,7 +18,7 @@ rw=write
 # Run e4defrag and aio-dio workers in parallel
 [e4defrag]
 stonewall
-time_based=30
+time_based
 runtime=30
 ioengine=e4defrag
 buffered=0

--- a/examples/e4defrag2.fio
+++ b/examples/e4defrag2.fio
@@ -55,7 +55,7 @@ inplace=1
 bs=4k
 donorname=file3.def
 filename=file3
-time_based=30
+time_based
 rw=randwrite
 
 [buffered-aio-32k]
@@ -68,7 +68,7 @@ bs=32k
 filename=file3
 rw=randrw
 runtime=30
-time_based=30
+time_based
 numjobs=4
 
 [direct-aio-32k]
@@ -82,7 +82,6 @@ bs=32k
 filename=file3
 rw=randrw
 runtime=30
-time_based=30
 numjobs=4
 
 

--- a/examples/exitwhat.fio
+++ b/examples/exitwhat.fio
@@ -11,7 +11,7 @@
 filename=/tmp/test
 filesize=1G
 blocksize=4096
-group_reporting=1
+group_reporting
 exitall=1
 
 [slow1]

--- a/examples/falloc.fio
+++ b/examples/falloc.fio
@@ -15,7 +15,7 @@ group_reporting
 [falloc-fuzzer]
 stonewall
 runtime=10
-time_based=10
+time_based
 bssplit=4k/10:64k/50:32k/40
 rw=randwrite
 numjobs=1
@@ -24,7 +24,7 @@ filename=fragmented_file
 [punch hole-fuzzer]
 bs=4k
 runtime=10
-time_based=10
+time_based
 rw=randtrim
 numjobs=2
 filename=fragmented_file

--- a/examples/fio-rand-RW.fio
+++ b/examples/fio-rand-RW.fio
@@ -9,7 +9,7 @@ rwmixwrite=40
 bs=4K
 direct=0
 numjobs=4
-time_based=1
+time_based
 runtime=900
 
 [file1]

--- a/examples/fio-rand-read.fio
+++ b/examples/fio-rand-read.fio
@@ -7,7 +7,7 @@ rw=randread
 bs=4K
 direct=0
 numjobs=1
-time_based=1
+time_based
 runtime=900
 
 [file1]

--- a/examples/fio-rand-write.fio
+++ b/examples/fio-rand-write.fio
@@ -7,7 +7,7 @@ rw=randwrite
 bs=4K
 direct=0
 numjobs=4
-time_based=1
+time_based
 runtime=900
 
 [file1]

--- a/examples/fio-seq-RW.fio
+++ b/examples/fio-seq-RW.fio
@@ -9,7 +9,7 @@ rwmixwrite=40
 bs=256K
 direct=0
 numjobs=4
-time_based=1
+time_based
 runtime=900
 
 [file1]

--- a/examples/fio-seq-read.fio
+++ b/examples/fio-seq-read.fio
@@ -5,7 +5,7 @@ rw=read
 bs=256K
 direct=1
 numjobs=1
-time_based=1
+time_based
 runtime=900
 
 [file1]

--- a/examples/fio-seq-write.fio
+++ b/examples/fio-seq-write.fio
@@ -7,7 +7,7 @@ rw=write
 bs=256K
 direct=0
 numjobs=1
-time_based=1
+time_based
 runtime=900
 
 [file1]

--- a/examples/fsx.fio
+++ b/examples/fsx.fio
@@ -9,4 +9,3 @@ bs=4k
 norandommap
 direct=1
 loops=500000
-rwmixcycle=40

--- a/examples/jesd219.fio
+++ b/examples/jesd219.fio
@@ -17,4 +17,4 @@ bssplit=512/4:1024/1:1536/1:2048/1:2560/1:3072/1:3584/1:4k/67:8k/10:16k/7:32k/3:
 blockalign=4k
 random_distribution=zoned:50/5:30/15:20/80
 filename=/dev/nvme0n1
-group_reporting=1
+group_reporting

--- a/examples/libpmem.fio
+++ b/examples/libpmem.fio
@@ -3,7 +3,7 @@ bs=4k
 size=8g
 ioengine=libpmem
 norandommap
-time_based=1
+time_based
 group_reporting
 invalidate=1
 disable_lat=1

--- a/examples/libpmem.fio
+++ b/examples/libpmem.fio
@@ -13,7 +13,7 @@ clat_percentiles=0
 
 iodepth=1
 iodepth_batch=1
-thread=1
+thread
 numjobs=1
 runtime=300
 

--- a/examples/libzbc-rand-write.fio
+++ b/examples/libzbc-rand-write.fio
@@ -12,7 +12,7 @@ max_open_zones=32
 bs=512K
 direct=1
 numjobs=16
-time_based=1
+time_based
 runtime=300
 
 [dev1]

--- a/examples/null.fio
+++ b/examples/null.fio
@@ -7,4 +7,3 @@ ioengine=null
 size=100g
 rw=randread
 norandommap
-time_based=0

--- a/examples/pmemblk.fio
+++ b/examples/pmemblk.fio
@@ -2,7 +2,7 @@
 bs=1m
 ioengine=pmemblk
 norandommap
-time_based=1
+time_based
 runtime=30
 group_reporting
 disable_lat=1

--- a/examples/pmemblk.fio
+++ b/examples/pmemblk.fio
@@ -19,7 +19,7 @@ cpus_allowed_policy=split
 #
 iodepth=1
 direct=1
-thread=1
+thread
 numjobs=16
 #
 # Unlink can be used to remove the files when done, but if you are

--- a/examples/steadystate.fio
+++ b/examples/steadystate.fio
@@ -7,7 +7,7 @@
 
 [global]
 threads=1
-group_reporting=1
+group_reporting
 time_based
 size=128m
 

--- a/examples/surface-scan.fio
+++ b/examples/surface-scan.fio
@@ -1,7 +1,7 @@
 ; writes 512 byte verification blocks until the disk is full,
 ; then verifies written data
 [global]
-thread=1
+thread
 bs=64k
 direct=1
 ioengine=sync

--- a/examples/waitfor.fio
+++ b/examples/waitfor.fio
@@ -1,6 +1,6 @@
 [global]
 threads=1
-group_reporting=1
+group_reporting
 filename=/tmp/data
 filesize=128m
 

--- a/examples/zbd-rand-write.fio
+++ b/examples/zbd-rand-write.fio
@@ -12,7 +12,7 @@ max_open_zones=32
 bs=512K
 direct=1
 numjobs=16
-time_based=1
+time_based
 runtime=180
 
 [dev1]


### PR DESCRIPTION
The examples/ directory is often used as a starting point for new jobs or tests but many has incorrect/useless syntax which could confuse users.
Let's get all examples using the same syntax.