### PR TITLE
num2str: fix precision loss bug when the fractional part is close to 1

### DIFF
--- a/lib/num2str.c
+++ b/lib/num2str.c
@@ -112,6 +112,9 @@ done:
 	sprintf(tmp, "%.*f", (int)(maxlen - strlen(tmp) - 1),
 		(double)modulo / (double)thousand);
 
+	if (tmp[0] == '1')
+		num++;
+
 	if (asprintf(&buf, "%llu.%s%s%s", (unsigned long long) num, &tmp[2],
 		     unitprefix[post_index], unitstr[units]) < 0)
 		buf = NULL;


### PR DESCRIPTION
Fix #1117

example:
	The result of num2str(11999999999999, 4, 1, 0, N2S_NONE) should be "12.0G", but current result is "11.0G". 

Signed-off-by: Jiahao Li <gloit042@gmail.com>