### PR TITLE
zipf/pareto: Fix unpredictable location of most probable selection.

### DIFF
--- a/lib/zipf.c
+++ b/lib/zipf.c
@@ -29,7 +29,7 @@ static void shared_rand_init(struct zipf_state *zs, uint64_t nranges,
 	zs->nranges = nranges;
 
 	init_rand_seed(&zs->rand, seed, 0);
-	zs->rand_off = __rand(&zs->rand);
+	zs->rand_off = 0;
 }
 
 void zipf_init(struct zipf_state *zs, uint64_t nranges, double theta,


### PR DESCRIPTION
Using "--file_service_type=zipf:0.6" is impractical when run with changing seeds.
Consider:
fio --randseed=1 --ioengine=libaio --rw=randwrite --nrfiles=16 \
    --bs=4k --size=128m --loops=10 --allow_file_create=1 \
    --write_iolog=log.txt --file_service_type=zipf:0.6 \
    --filename_format=object.\$filenum --name=x
This generates iolog that shows object.1 accessed the most and object.15 the least.
cat log.txt |grep write |cut -f 1 -d " " |sort |uniq -c | sort -n \
| sed "s/[.]/ /" | while read a b c; do echo $c $b $a; done |sort -n
0 object 50225
1 object 67564
2 object 33355
3 object 24978
4 object 20177
5 object 17426
6 object 15504
7 object 13948
8 object 12862
9 object 12021
10 object 11371
11 object 10740
12 object 10144
13 object 9475
14 object 9164
15 object 8726

But when --randseed=2 it changes and object.10 is accessed most and object.8 least:
0 object 14140
1 object 12936
2 object 12122
3 object 11151
4 object 10551
5 object 10249
6 object 9596
7 object 9310
8 object 8748
9 object 47175
10 object 69704
11 object 33575
12 object 24941
13 object 20252
14 object 17622
15 object 15608

This change also affects --random_distribution, making offset selection
for zipf and pareto always having 0 as most probable selection.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>