### PR TITLE
io_u: Fix bad interaction with --openfiles and non-sequential file selection policy

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -1326,8 +1326,10 @@ static struct fio_file *__get_next_file(struct thread_data *td)
 	if (f && fio_file_open(f) && !fio_file_closing(f)) {
 		if (td->o.file_service_type == FIO_FSERVICE_SEQ)
 			goto out;
-		if (td->file_service_left--)
-			goto out;
+		if (td->file_service_left) {
+		  td->file_service_left--;
+		  goto out;
+		}
 	}
 
 	if (td->o.file_service_type == FIO_FSERVICE_RR ||


### PR DESCRIPTION

Problem happens when --openfiles is set and file_service_type != FIO_FSERVICE_SEQ.
In function `__get_next_file`, we decrement file_service_left and if 0, we select
next file to operate on.
However, `get_next_file_rand` can return -EBUSY if too many files are already opened,
and `__get_next_file` exits with error.

In next invocation of `__get_next_file`, we decrement file_service_left again (from 0),
wrapping around to 2^32-1, effectively locking `__get_next_file` to always select the same.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>