### PR TITLE
engines/cpu: Fix td_vmsg() call

### DIFF
--- a/engines/cpu.c
+++ b/engines/cpu.c
@@ -245,6 +245,7 @@ static int fio_cpuio_init(struct thread_data *td)
 	struct thread_options *o = &td->o;
 	struct cpu_options *co = td->eo;
 	int td_previous_state;
+	char *msg;
 
 	if (!co->cpuload) {
 		td_vmsg(td, EINVAL, "cpu thread needs rate (cpuload=)","cpuio");
@@ -281,7 +282,10 @@ static int fio_cpuio_init(struct thread_data *td)
 		qsort_init(td);
 		break;
 	default:
-		td_vmsg(td, EINVAL, "cpu engine mode bad: %d", co->cpumode);
+		if (asprintf(&msg, "bad cpu engine mode: %d", co->cpumode) < 0)
+			msg = NULL;
+		td_vmsg(td, EINVAL, msg ? : "(?)", __func__);
+		free(msg);
 		return 1;
 	}
 


### PR DESCRIPTION
Make sure that the third td_vmsg() argument is a fully expanded string and
also that the fourth argument is a string argument. This was detected by
Coverity.

Fixes: b213922390fe ("engines/cpu: style cleanups")
Signed-off-by: Bart Van Assche <bvanassche@acm.org>