### PR TITLE
filesetup: add option to prepopulate file with data

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -1208,6 +1208,15 @@ I/O type
 	write to the end of an extended file will stall until the entire
 	file has been filled with zeroes.
 
+.. option:: prepopulate=bool
+
+	After laying down files it might be expected to fill them with some data.
+	It makes sense only for read jobs (not preceded by a write job).
+	It works on regular files and fills them up block by block. It may take
+	some time to complete (especially with big file and small block size).
+	It makes no sense with fill_device, so don't use these two together.
+	Default: false.
+
 .. option:: fadvise_hint=str
 
 	Use :manpage:`posix_fadvise(2)` or :manpage:`posix_fadvise(2)` to

--- a/cconv.c
+++ b/cconv.c
@@ -255,6 +255,7 @@ void convert_thread_options_to_cpu(struct thread_options *o,
 	o->stats = le32_to_cpu(top->stats);
 	o->fadvise_hint = le32_to_cpu(top->fadvise_hint);
 	o->fallocate_mode = le32_to_cpu(top->fallocate_mode);
+	o->prepopulate = le32_to_cpu(top->prepopulate);
 	o->zero_buffers = le32_to_cpu(top->zero_buffers);
 	o->refill_buffers = le32_to_cpu(top->refill_buffers);
 	o->scramble_buffers = le32_to_cpu(top->scramble_buffers);
@@ -456,6 +457,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 	top->stats = cpu_to_le32(o->stats);
 	top->fadvise_hint = cpu_to_le32(o->fadvise_hint);
 	top->fallocate_mode = cpu_to_le32(o->fallocate_mode);
+	top->prepopulate = cpu_to_le32(o->prepopulate);
 	top->zero_buffers = cpu_to_le32(o->zero_buffers);
 	top->refill_buffers = cpu_to_le32(o->refill_buffers);
 	top->scramble_buffers = cpu_to_le32(o->scramble_buffers);

--- a/examples/libpmem.fio
+++ b/examples/libpmem.fio
@@ -10,6 +10,7 @@ disable_lat=1
 disable_slat=1
 disable_clat=1
 clat_percentiles=0
+prepopulate=1
 
 iodepth=1
 iodepth_batch=1

--- a/fio.1
+++ b/fio.1
@@ -981,6 +981,14 @@ write to the end of an extended file will stall until the entire
 file has been filled with zeroes.
 .RE
 .TP
+.BI prepopulate \fR=\fPbool
+After laying down files it might be expected to fill them with some data.
+It makes sense only for read jobs (not preceded by a write job).
+It works on regular files and fills them up block by block. It may take
+some time to complete (especially with big file and small block size).
+It makes no sense with fill_device, so don\(aqt use these two together.
+Default: false.
+.TP
 .BI fadvise_hint \fR=\fPstr
 Use \fBposix_fadvise\fR\|(2) or \fBposix_madvise\fR\|(2) to advise the kernel
 what I/O patterns are likely to be issued. Accepted values are:

--- a/options.c
+++ b/options.c
@@ -2525,6 +2525,16 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		},
 	},
 	{
+		.name	= "prepopulate",
+		.lname	= "Prepopulate",
+		.type	= FIO_OPT_BOOL,
+		.off1	= offsetof(struct thread_options, prepopulate),
+		.help	= "Prepopulate files with some data",
+		.def	= "0",
+		.category = FIO_OPT_C_FILE,
+		.group	= FIO_OPT_G_INVALID,
+	},
+	{
 		.name	= "fadvise_hint",
 		.lname	= "Fadvise hint",
 		.type	= FIO_OPT_STR,

--- a/thread_options.h
+++ b/thread_options.h
@@ -230,6 +230,7 @@ struct thread_options {
 	unsigned int stats;
 	unsigned int fadvise_hint;
 	enum fio_fallocate_mode fallocate_mode;
+	unsigned int prepopulate;
 	unsigned int zero_buffers;
 	unsigned int refill_buffers;
 	unsigned int scramble_buffers;
@@ -619,6 +620,9 @@ struct thread_options_pack {
 	uint64_t max_latency;
 	fio_fp64_t latency_percentile;
 	uint32_t latency_run;
+
+
+	uint32_t prepopulate;
 
 	/*
 	 * flow support


### PR DESCRIPTION
When read job is executed and file is zero'ed, results are
higher than expected (because reading zero page).

Signed-off-by: Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>

**note:**
I've done this for the libpmem engine purpose (where it makes a difference), but I believe it may be useful for other engines as well. I've tested it also with mmap, but performance difference there was just minimal (if any).