### PR TITLE
Fix Windows UNC path parsing

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -928,7 +928,17 @@ int longest_existing_path(char *path) {
 	sprintf(buf, "%s", path);
 	done = false;
 	while (!done) {
-		buf_pos = strrchr(buf, FIO_OS_PATH_SEPARATOR);
+#if WIN32
+		// Support for Windows UNC paths (i.e. '\\server1\...').
+		if ((buf[0] == FIO_OS_PATH_SEPARATOR) && (buf[1] == FIO_OS_PATH_SEPARATOR)) {
+			buf_pos = strrchr(buf + 2, FIO_OS_PATH_SEPARATOR);
+		}
+		else
+#endif
+		{
+			buf_pos = strrchr(buf, FIO_OS_PATH_SEPARATOR);
+		}
+
 		if (!buf_pos) {
 			done = true;
 			offset = 0;


### PR DESCRIPTION
This is a fix for #1130 by adding support for Windows UNC path. The issue is the logic for parsing the path was previously early exiting when encountering leading '\\' and stopping before it parsed the full server name, resulting in error message "fio: failed to create dir (\\): No such file or directory".

Unfortunately, I don't have access to a Windows SMB share to fully test the changes. So I isolated the path parsing changes and verified them independently for correctness.