### PR TITLE
bug: ESX does not have timerfd support

### DIFF
--- a/configure
+++ b/configure
@@ -2695,6 +2695,7 @@ print_config "Windows PDB generation" "$pdb"
 ##########################################
 # check for timerfd support
 timerfd_create="no"
+if test "$esx" != "yes" ; then
 cat > $TMPC << EOF
 #include <sys/time.h>
 #include <sys/timerfd.h>
@@ -2704,8 +2705,9 @@ int main(int argc, char **argv)
 	return timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
 }
 EOF
-if compile_prog "" "" "timerfd_create"; then
-  timerfd_create="yes"
+  if compile_prog "" "" "timerfd_create"; then
+    timerfd_create="yes"
+  fi
 fi
 print_config "timerfd_create" "$timerfd_create"
 


### PR DESCRIPTION
Running fio on an ESX host fails due to the lack of support for file
descriptor based notifications of timer expiration.  This change
bypasses patch 696378af added to increase timer accuracy.

Signed-off-by: Brian 'Redbeard' Harrington <redbeard@redhat.com>