### PR TITLE
fio: fix detecting libpmem

### DIFF
--- a/configure
+++ b/configure
@@ -2055,7 +2055,7 @@ cat > $TMPC << EOF
 int main(int argc, char **argv)
 {
   int rc;
-  rc = pmem_is_pmem(NULL, NULL);
+  rc = pmem_is_pmem(NULL, 0);
   return 0;
 }
 EOF


### PR DESCRIPTION
The current test for libpmem in 'configure' fails
in the following way:
```
$ gcc test.c -lpmem
test.c: In function ‘main’:
test.c:6:27: warning: passing argument 2 of ‘pmem_is_pmem’ \
             makes integer from pointer \
             without a cast [-Wint-conversion]
    6 |   rc = pmem_is_pmem(NULL, NULL);
      |                           ^~~~
      |                           |
      |                           void *
In file included from test.c:1:
/usr/include/libpmem.h:92:43: note: expected ‘size_t’ \
             {aka ‘long unsigned int’} but argument \
             is of type ‘void *’
   92 | int pmem_is_pmem(const void *addr, size_t len);
      |                                    ~~~~~~~^~~
```
Fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axboe/fio/1174)
<!-- Reviewable:end -->
