### PR TITLE
engine/rados: Remove mandatory creation

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2294,6 +2294,12 @@ with the caveat that when used on the command line, they must come after the
         Poll store instead of waiting for completion. Usually this provides better
         throughput at cost of higher(up to 100%) CPU utilization.
 
+.. option:: touch_objects=bool : [rados]
+
+        During initialization, touch (create if do not exist) all objects (files).
+        Touching all objects affects ceph caches and likely impacts test results.
+        Enabled by default.
+
 .. option:: skip_bad=bool : [mtd]
 
 	Skip operations against known bad blocks.

--- a/fio.1
+++ b/fio.1
@@ -2049,6 +2049,11 @@ by default.
 Poll store instead of waiting for completion. Usually this provides better
 throughput at cost of higher(up to 100%) CPU utilization.
 .TP
+.BI (rados)touch_objects \fR=\fPbool
+During initialization, touch (create if do not exist) all objects (files).
+Touching all objects affects ceph caches and likely impacts test results.
+Enabled by default.
+.TP
 .BI (http)http_host \fR=\fPstr
 Hostname to connect to. For S3, this could be the bucket name. Default
 is \fBlocalhost\fR


### PR DESCRIPTION
Changed connection procedure so it no longer attempts to create objects.
This change will affect tests that read objects without creating them first.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>