### PR TITLE
$clientuid keyword to differentiate clients in client/server mode

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -809,6 +809,8 @@ Target file/device
 
 		**$jobname**
 				The name of the worker thread or process.
+		**$clientuid**
+				IP of the fio process when using client/server mode.
 		**$jobnum**
 				The incremental number of the worker thread or process.
 		**$filenum**

--- a/fio.1
+++ b/fio.1
@@ -584,6 +584,9 @@ string:
 .B $jobname
 The name of the worker thread or process.
 .TP
+.B $clientuid
+IP of the fio process when using client/server mode.
+.TP
 .B $jobnum
 The incremental number of the worker thread or process.
 .TP

--- a/init.c
+++ b/init.c
@@ -1238,7 +1238,8 @@ enum {
 	FPRE_NONE = 0,
 	FPRE_JOBNAME,
 	FPRE_JOBNUM,
-	FPRE_FILENUM
+	FPRE_FILENUM,
+	FPRE_CLIENTUID
 };
 
 static struct fpre_keyword {
@@ -1249,6 +1250,7 @@ static struct fpre_keyword {
 	{ .keyword = "$jobname",	.key = FPRE_JOBNAME, },
 	{ .keyword = "$jobnum",		.key = FPRE_JOBNUM, },
 	{ .keyword = "$filenum",	.key = FPRE_FILENUM, },
+	{ .keyword = "$clientuid",	.key = FPRE_CLIENTUID, },
 	{ .keyword = NULL, },
 	};
 
@@ -1326,6 +1328,21 @@ static char *make_filename(char *buf, size_t buf_size,struct thread_options *o,
 				int ret;
 
 				ret = snprintf(dst, dst_left, "%d", filenum);
+				if (ret < 0)
+					break;
+				else if (ret > dst_left) {
+					log_err("fio: truncated filename\n");
+					dst += dst_left;
+					dst_left = 0;
+				} else {
+					dst += ret;
+					dst_left -= ret;
+				}
+				break;
+				}
+			case FPRE_CLIENTUID: {
+				int ret;
+				ret = snprintf(dst, dst_left, "%s", client_sockaddr_str);
 				if (ret < 0)
 					break;
 				else if (ret > dst_left) {


### PR DESCRIPTION
We been using fio heavily, but getting it to put an IP into filename was a struggle.

Previously we had to specify `directory=/` in config, which would prepend /<ip> to any filenames. Having explicit format string for this seems better :) 