### PR TITLE
hack buffer_pattern option to provide large sample file

### DIFF
--- a/cconv.c
+++ b/cconv.c
@@ -170,7 +170,7 @@ void convert_thread_options_to_cpu(struct thread_options *o,
 	o->verify_offset = le32_to_cpu(top->verify_offset);
 
 	memcpy(o->verify_pattern, top->verify_pattern, MAX_PATTERN_SIZE);
-	memcpy(o->buffer_pattern, top->buffer_pattern, MAX_PATTERN_SIZE);
+	//	memcpy(o->buffer_pattern, top->buffer_pattern, MAX_PATTERN_SIZE);
 
 	o->verify_pattern_bytes = le32_to_cpu(top->verify_pattern_bytes);
 	o->verify_fatal = le32_to_cpu(top->verify_fatal);
@@ -553,7 +553,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 	}
 
 	memcpy(top->verify_pattern, o->verify_pattern, MAX_PATTERN_SIZE);
-	memcpy(top->buffer_pattern, o->buffer_pattern, MAX_PATTERN_SIZE);
+	//	memcpy(top->buffer_pattern, o->buffer_pattern, MAX_PATTERN_SIZE);
 
 	top->size = __cpu_to_le64(o->size);
 	top->io_size = __cpu_to_le64(o->io_size);

--- a/lib/pattern.c
+++ b/lib/pattern.c
@@ -370,6 +370,33 @@ int parse_and_fill_pattern(const char *in, unsigned int in_len,
 	return total;
 }
 
+int load_pattern(const char *filename, char** data)
+{
+  off_t size;
+  int fd;
+  ssize_t rsize;
+  fd = open(filename, O_RDONLY);
+  if (fd < 0)
+    return 0;
+
+  size = lseek(fd, 0, SEEK_END);
+  if (size < 0)
+  {
+    close(fd);
+    return 0;
+  }
+  lseek(fd, 0, SEEK_SET);
+
+  if (size > 128 * 1024 * 1024)
+    size = 128 * 1024 * 1024;
+
+  *data = malloc(size);  
+  rsize = read(fd, *data, size);
+  close(fd);
+  return rsize;
+}
+
+
 /**
  * dup_pattern() - Duplicates part of the pattern all over the buffer.
  *

--- a/lib/pattern.h
+++ b/lib/pattern.h
@@ -27,6 +27,8 @@ int parse_and_fill_pattern(const char *in, unsigned int in_len,
 			   struct pattern_fmt *fmt,
 			   unsigned int *fmt_sz_out);
 
+int load_pattern(const char *filename, char** data);
+
 int paste_format_inplace(char *pattern, unsigned int pattern_len,
 			 struct pattern_fmt *fmt, unsigned int fmt_sz,
 			 void *priv);

--- a/options.c
+++ b/options.c
@@ -1374,8 +1374,12 @@ static int str_buffer_pattern_cb(void *data, const char *input)
 	int ret;
 
 	/* FIXME: for now buffer pattern does not support formats */
-	ret = parse_and_fill_pattern(input, strlen(input), td->o.buffer_pattern,
+	ret = load_pattern(input, &td->o.buffer_pattern);
+	#if 0
+	td->o.buffer_pattern = malloc(MAX_PATTERN_SIZE);
+	ret = parse_and_fill_pattern(input, strlen(input), &td->o.buffer_pattern,
 				     MAX_PATTERN_SIZE, NULL, NULL, NULL);
+	#endif
 	if (ret < 0)
 		return 1;
 

--- a/thread_options.h
+++ b/thread_options.h
@@ -234,8 +234,10 @@ struct thread_options {
 	unsigned int zero_buffers;
 	unsigned int refill_buffers;
 	unsigned int scramble_buffers;
-	char buffer_pattern[MAX_PATTERN_SIZE];
+	char *buffer_pattern;//[MAX_PATTERN_SIZE];
 	unsigned int buffer_pattern_bytes;
+	unsigned int buffer_pattern_ofs;
+	unsigned int buffer_pattern_ofs_dummy;
 	unsigned int compress_percentage;
 	unsigned int compress_chunk;
 	unsigned int dedupe_percentage;
@@ -536,8 +538,10 @@ struct thread_options_pack {
 	uint32_t zero_buffers;
 	uint32_t refill_buffers;
 	uint32_t scramble_buffers;
-	uint8_t buffer_pattern[MAX_PATTERN_SIZE];
+	uint8_t *buffer_pattern;//[MAX_PATTERN_SIZE];
 	uint32_t buffer_pattern_bytes;
+	uint32_t buffer_pattern_ofs;
+	uint32_t buffer_pattern_ofs_dummy;
 	uint32_t compress_percentage;
 	uint32_t compress_chunk;
 	uint32_t dedupe_percentage;

--- a/verify.c
+++ b/verify.c
@@ -38,7 +38,18 @@ static void __fill_hdr(struct thread_data *td, struct io_u *io_u,
 
 void fill_buffer_pattern(struct thread_data *td, void *p, unsigned int len)
 {
-	(void)cpy_pattern(td->o.buffer_pattern, td->o.buffer_pattern_bytes, p, len);
+  unsigned int l;
+  while (len > 0) {
+    l = len;
+    if (l > td->o.buffer_pattern_bytes - td->o.buffer_pattern_ofs)
+      l = td->o.buffer_pattern_bytes - td->o.buffer_pattern_ofs;
+    memcpy(p, td->o.buffer_pattern + td->o.buffer_pattern_ofs, l);
+
+    len -= l;
+    td->o.buffer_pattern_ofs += l;
+    if (td->o.buffer_pattern_ofs == td->o.buffer_pattern_bytes)
+      td->o.buffer_pattern_ofs = 0;
+  }
 }
 
 static void __fill_buffer(struct thread_options *o, uint64_t seed, void *p,


### PR DESCRIPTION
*This is not actual PR*

Background:
This thing allows to provide large file as source of data for IO operations.
It allowed me to test different compression algorithms and different options.

When testing balance between compression gained and CPU power invested it is necessary to provide actual data
that can be compressed differently by different algorithms.

Data provided in --buffer-pattern is here considered to be a sample of customer data.

Request:
Can I please get some hints how to implement above feature properly, so it could be passed via client-server path?
Or can it be a feature that cannot be used in client - server mode?

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>