### PR TITLE
configure: remove unused CLOCK_MONOTONIC_* symbols

### DIFF
--- a/configure
+++ b/configure
@@ -2794,12 +2794,6 @@ fi
 if test "$clock_monotonic" = "yes" ; then
   output_sym "CONFIG_CLOCK_MONOTONIC"
 fi
-if test "$clock_monotonic_raw" = "yes" ; then
-  output_sym "CONFIG_CLOCK_MONOTONIC_RAW"
-fi
-if test "$clock_monotonic_precise" = "yes" ; then
-  output_sym "CONFIG_CLOCK_MONOTONIC_PRECISE"
-fi
 if test "$clockid_t" = "yes"; then
   output_sym "CONFIG_CLOCKID_T"
 fi


### PR DESCRIPTION
This removes the symbol definitions for CLOCK_MONOTONIC_PRECISE and CLOCK_MONOTONIC_RAW.
Those are no longer used in the code and the respective probes were removed in commits 187f39063e1b0a7baeda20a9f4f2406327ec0d41 and 69212fc41c0420f8caf272a0cc270194edbddfe7.

I just stumbled upon this. In case these definitions are there for a reason, please feel free to close this PR.