### PR TITLE
parse: fix parse_is_percent() warning

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -131,7 +131,7 @@ static inline void *td_var(void *to, const struct fio_option *o,
 
 static inline int parse_is_percent(unsigned long long val)
 {
-	return val >= -101;
+	return val >= -101ULL;
 }
 
 #define ZONE_BASE_VAL ((-1ULL >> 1) + 1)


### PR DESCRIPTION
When compiling an out of tree ioengine, such as the SPDK fio plugin,
which has -Wextra in CFLAGS, the compiler gives the following warning:

parse.h: In function ‘parse_is_percent’:
parse.h:134:13: warning: comparison of integer expressions of different signedness: ‘long long unsigned int’ and ‘int’ [-Wsign-compare]

Since this warning was introduced recently by fio
commit b75c0fae6612 ("parse: simplify parse_is_percent()"),
and since this is the only warning seen when compiling the SPDK fio
plugin, readd the ULL prefix to parse_is_percent().

Fixes: b75c0fae6612 ("parse: simplify parse_is_percent()")
Signed-off-by: Niklas Cassel <niklas.cassel@wdc.com>