### PR TITLE
fix fio2gnuplot to work with new logging format

### DIFF
--- a/tools/plot/fio2gnuplot
+++ b/tools/plot/fio2gnuplot
@@ -198,7 +198,7 @@ def compute_temp_file(fio_data_file,disk_perf,gnuplot_output_dir, min_time, max_
 			# Index will be used to remember what file was featuring what value
 			index=index+1
 
-			time, perf, x, block_size = line[1]
+			time, perf, x, block_size = line[1][:4]
 			if (blk_size == 0):
 				try:
 					blk_size=int(block_size)


### PR DESCRIPTION
The logging format updates documented in 1a953d97 were never
propagated to fio2gnuplot, which since then has been failing with a
ValueError exception.

This commit explicits limits fio2gnuplot to only reading the first
4 columns in the log file.
