### PR TITLE
stat: fix integer overflow in convert_agg_kbytes_percent

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -462,7 +462,7 @@ static double convert_agg_kbytes_percent(struct group_run_stats *rs, int ddir, i
 {
 	double p_of_agg = 100.0;
 	if (rs && rs->agg[ddir] > 1024) {
-		p_of_agg = mean * 100 / (double) (rs->agg[ddir] / 1024.0);
+		p_of_agg = mean * 100.0 / (double) (rs->agg[ddir] / 1024.0);
 
 		if (p_of_agg > 100.0)
 			p_of_agg = 100.0;


### PR DESCRIPTION
Assuming that "int" is 32-bit, for high bandwidth values (> 21.5 GB/s)
the expression "mean * 100" will cause an integer overflow before the
conversion to "double" happens.

Tested on the latest commit on `master`: 30bec59eab3908b681cbc2866179f7166a849c83
I was using a config with 8 jobs reading sequentially from a RAID 0 of multiple NVMe SSDs, reaching an aggregate bandwidth of 40+ GB/s (the config has `group_reporting=1`). Using a JSON output, I saw the following:
```
         "bw_agg" : -2.289580,
```
And after investigating I saw this was caused by the integer overflow mentioned above.