### PR TITLE
Avoid stpcpy issue when building with clang 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ ifdef CONFIG_PDB
   LDFLAGS += -fuse-ld=lld $(LINK_PDBFILE)
 endif
 
+# If clang, do not use builtin stpcpy as it breaks the build
+ifeq ($(CC),clang)
+  FIO_CFLAGS += -fno-builtin-stpcpy
+endif
+
 ifdef CONFIG_GFIO
   PROGS += gfio
 endif

--- a/ci/appveyor-install.sh
+++ b/ci/appveyor-install.sh
@@ -31,6 +31,7 @@ case "${DISTRO}" in
         pacman.exe --noconfirm -S \
             mingw-w64-${PACKAGE_ARCH}-clang \
             mingw-w64-${PACKAGE_ARCH}-cunit \
+            mingw-w64-${PACKAGE_ARCH}-toolchain \
             mingw-w64-${PACKAGE_ARCH}-lld
         ;;
 esac

--- a/ci/appveyor-install.sh
+++ b/ci/appveyor-install.sh
@@ -33,6 +33,7 @@ case "${DISTRO}" in
             mingw-w64-${PACKAGE_ARCH}-cunit \
             mingw-w64-${PACKAGE_ARCH}-toolchain \
             mingw-w64-${PACKAGE_ARCH}-lld
+        pacman.exe -Q # List installed packages
         ;;
 esac
 


### PR DESCRIPTION
Signed-off-by: Erwan Velu <e.velu@criteo.com>