### PR TITLE
dedupe: fixing bug with subsequent dedupe buffer generation

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -259,6 +259,7 @@ struct thread_data {
 
 	struct frand_state buf_state;
 	struct frand_state buf_state_prev;
+	struct frand_state buf_state_ret;
 	struct frand_state dedupe_state;
 	struct frand_state zone_state;
 	struct frand_state prio_state;

--- a/io_u.c
+++ b/io_u.c
@@ -2182,8 +2182,16 @@ static struct frand_state *get_buf_state(struct thread_data *td)
 
 	v = rand_between(&td->dedupe_state, 1, 100);
 
-	if (v <= td->o.dedupe_percentage)
-		return &td->buf_state_prev;
+	if (v <= td->o.dedupe_percentage) {
+		/*
+		 * The caller advances the returned frand_state.
+		 * A copy of prev should be returned instead since
+		 * a subsequent intention to generate a deduped buffer
+		 * might result in generating a unique one
+		 */
+		frand_copy(&td->buf_state_ret, &td->buf_state_prev);
+		return &td->buf_state_ret;
+	}
 
 	return &td->buf_state;
 }


### PR DESCRIPTION
from testing we can see that on small file sizes with high dedup percentage requested the actual dedup percentage resulted is much lower than expected.

for example:
`./fio --name=bar -rw=randwrite --bs=4096 --size=1mb --dedupe_percentage=99 --direct=1`

when checking the actual percentage received -  we got 34% instead of 99%:
`./t/fio-dedupe -o 1 bar.0.0 `

```
Will check <bar.0.0>, size <1048576>, using 15 threads
Threads(15): 256 items processed
Extents=256, Unique extents=169
De-dupe ratio: 1:0.51
Fio setting: dedupe_percentage=34
```

the reason to that is since in high dedup percentage the buf_state_prev would likely be chosen:
```
static struct frand_state *get_buf_state(struct thread_data *td)
{
...
        if (v <= td->o.dedupe_percentage)
                return &td->buf_state_prev;
...
}
```
however, after generating that buffer the `buf_state_prev` internal seed is advanced and we forget about the seed that used to generate the previous one.

so essentially in the example above we most likely choose `buf_state_prev` as the seed to generate our buffers, but it will usually generate unique buffers instead of repeating the previous ones.


you may ask - why this does not happen with large sizes? :
if we'll examine  `save_buf_state` that is called after the buffer is generated we can see that the buf_state_prev is overridden only if dedup was not intended to be generated:
```
static void save_buf_state(struct thread_data *td, struct frand_state *rs)
{
        if (td->o.dedupe_percentage == 100)
                frand_copy(rs, &td->buf_state_prev);
        else if (rs == &td->buf_state)
                frand_copy(&td->buf_state_prev, rs);
}
```

so consider the case of high dedup ratio combined with large size. most buffers will choose `buf_state_prev` to generate, however note that `buf_state_prev` and `buf_state` are both initialized to the same seed.
then let's consider seed starts at 1 and progresses to 2 and 3, etc'..
now, the starting point is:
`buf_state = buf_state_prev = 1`
then dedup is generated 50 times using buf_state_prev... :
```
buf_state = 1
buf state_prev = 50
```

here's the interesting part - while fio thinks it has by now generated 50 deduped buffers, actually 50 unique pages have been written. but since `dedupe_percentage` is not 100% then the next time fio will decide to generate a **unique** buffer, what will happen is `buf_state` will be used (actually a deduped buffer) and `buf_state_prev` will be overridden with an old seed. 
resulting in the following state:
```
buf_state = 2
buf_state_prev = 2
```

since it is likely for `buf_state_prev` to be used, the written buffers will be regenerated again, **by mistake**.
to conclude, in high dedup_percentage along with larger sizes, the likelihood of **intending** to generate unique buffers once in a while increases, and then fio will keep on to re-use old seeds and actually achieve some level of dedup accuracy.



unless i'm missing something, i don't think this was the author's initial thinking as it seems odd to me to generate the deduped buffers that way.

in any way, with some testing i've done it seems to improve the obtained dedup's accuracy and IMO a trivial change:

(with my fix)
`./fio --name=bar -rw=randwrite --bs=4096 --size=1mb --dedupe_percentage=99 --direct=1`

``` 
./t/fio-dedupe -o 1 bar.0.0 
Will check <bar.0.0>, size <1048576>, using 15 threads
Threads(15): 256 items processed
Extents=256, Unique extents=2
De-dupe ratio: 1:127.00
Fio setting: dedupe_percentage=99
```

and with larger size
` ./fio --name=bar -rw=randwrite --bs=4096 --size=10gb --dedupe_percentage=99`

```
 ./t/fio-dedupe -o 1 bar.0.0 
Will check <bar.0.0>, size <10737418240>, using 15 threads
Threads(15): 2621440 items processed
Extents=2621440, Unique extents=26332
De-dupe ratio: 1:98.55
Fio setting: dedupe_percentage=99
```

50% dedup
` ./fio --name=bar2 -rw=randwrite --bs=4096 --size=10gb --dedupe_percentage=50`

```
./t/fio-dedupe -o 1 bar2.0.0 
Will check <bar2.0.0>, size <10737418240>, using 15 threads
Threads(15): 2621440 items processed
Extents=2621440, Unique extents=1310409
De-dupe ratio: 1:1.00
Fio setting: dedupe_percentage=50
```