### PR TITLE
[WIP] server.c: fix missing le64_to_cpu for union io_sample_data

### DIFF
--- a/server.c
+++ b/server.c
@@ -1791,7 +1791,7 @@ static int __fio_append_iolog_gz_hist(struct sk_entry *first, struct io_log *log
 		/* Do the subtraction on server side so that client doesn't have to
 		 * reconstruct our linked list from packets.
 		 */
-		cur_plat_entry  = s->data.plat_entry;
+		cur_plat_entry  = le64_to_cpu(s->data.plat_entry);
 		prev_plat_entry = flist_first_entry(&cur_plat_entry->list, struct io_u_plat_entry, list);
 		cur_plat  = cur_plat_entry->io_u_plat;
 		prev_plat = prev_plat_entry->io_u_plat;


### PR DESCRIPTION
Hi,

This is not a final patch, just WIP because I'm not sure if we should fix here or in `get_sample()` or other callers. Please advise.

Without this I see this error with valgrind.

```
==743369== Invalid read of size 8
==743369==    at 0x1060444: __fio_append_iolog_gz_hist (server.c:1795)
==743369==    by 0x1060444: __fio_append_iolog_gz (server.c:1825)
==743369==    by 0x1060444: fio_append_iolog_gz (server.c:1881)
==743369==    by 0x1060444: fio_send_iolog (server.c:2040)
==743369==    by 0x106A5C7: finish_log (iolog.c:1246)
==743369==    by 0x106A7A7: __write_log (iolog.c:1581)
==743369==    by 0x106A7A7: write_clat_hist_log (iolog.c:1635)
==743369==    by 0x106A7A7: write_clat_hist_log (iolog.c:1628)
==743369==    by 0x106AD4F: td_writeout_logs (iolog.c:1731)
==743369==    by 0x106DBD5: thread_main (backend.c:1941)
==743369==    by 0x1070A21: run_threads (backend.c:2426)
==743369==    by 0x1070B2B: fio_backend (backend.c:2563)
==743369==    by 0x10627F1: handle_run_cmd (server.c:782)
==743369==    by 0x10627F1: handle_command (server.c:1018)
==743369==    by 0x10627F1: handle_connection (server.c:1247)
==743369==    by 0x10627F1: accept_loop (server.c:1394)
==743369==    by 0x10627F1: fio_server (server.c:2493)
==743369==    by 0x10240F1: parse_cmd_line (init.c:2961)
==743369==    by 0x1025267: parse_options (init.c:3012)
==743369==    by 0x100EFBB: main (fio.c:42)
==743369==  Address 0x50a4ce0e00000000 is not stack'd, malloc'd or (recently) free'd
==743369== 
==743369== 
==743369== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==743369==  Access not within mapped region at address 0x50A4CE0E00000000
==743369==    at 0x1060444: __fio_append_iolog_gz_hist (server.c:1795)
==743369==    by 0x1060444: __fio_append_iolog_gz (server.c:1825)
==743369==    by 0x1060444: fio_append_iolog_gz (server.c:1881)
==743369==    by 0x1060444: fio_send_iolog (server.c:2040)
==743369==    by 0x106A5C7: finish_log (iolog.c:1246)
==743369==    by 0x106A7A7: __write_log (iolog.c:1581)
==743369==    by 0x106A7A7: write_clat_hist_log (iolog.c:1635)
==743369==    by 0x106A7A7: write_clat_hist_log (iolog.c:1628)
==743369==    by 0x106AD4F: td_writeout_logs (iolog.c:1731)
==743369==    by 0x106DBD5: thread_main (backend.c:1941)
==743369==    by 0x1070A21: run_threads (backend.c:2426)
==743369==    by 0x1070B2B: fio_backend (backend.c:2563)
==743369==    by 0x10627F1: handle_run_cmd (server.c:782)
==743369==    by 0x10627F1: handle_command (server.c:1018)
==743369==    by 0x10627F1: handle_connection (server.c:1247)
==743369==    by 0x10627F1: accept_loop (server.c:1394)
==743369==    by 0x10627F1: fio_server (server.c:2493)
==743369==    by 0x10240F1: parse_cmd_line (init.c:2961)
==743369==    by 0x1025267: parse_options (init.c:3012)
==743369==    by 0x100EFBB: main (fio.c:42)

```