### PR TITLE
Fix an error triggered by double releasing the lock

### DIFF
--- a/verify.c
+++ b/verify.c
@@ -1411,7 +1411,6 @@ static void *verify_async_thread(void *data)
 			ret = pthread_cond_wait(&td->verify_cond,
 							&td->io_u_lock);
 			if (ret) {
-				pthread_mutex_unlock(&td->io_u_lock);
 				break;
 			}
 		}


### PR DESCRIPTION
Fix an error triggered by double releasing the lock. 
Fixes: https://github.com/axboe/fio/issues/1254.

Signed-off-by: Anson Lo ycaibb@gmail.com