### PR TITLE
engines/dfs: add support for 1.3 DAOS API

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2561,11 +2561,11 @@ with the caveat that when used on the command line, they must come after the
 
 .. option:: pool=str : [dfs]
 
-	Specify the UUID of the DAOS pool to connect to.
+	Specify the label or UUID of the DAOS pool to connect to.
 
 .. option:: cont=str : [dfs]
 
-	Specify the UUID of the DAOS container to open.
+	Specify the label or UUID of the DAOS container to open.
 
 .. option:: chunk_size=int : [dfs]
 

--- a/fio.1
+++ b/fio.1
@@ -2326,10 +2326,10 @@ the use of cudaMemcpy.
 .RE
 .TP
 .BI (dfs)pool
-Specify the UUID of the DAOS pool to connect to.
+Specify the label or UUID of the DAOS pool to connect to.
 .TP
 .BI (dfs)cont
-Specify the UUID of the DAOS DAOS container to open.
+Specify the label or UUID of the DAOS container to open.
 .TP
 .BI (dfs)chunk_size
 Specificy a different chunk size (in bytes) for the dfs file.


### PR DESCRIPTION
A few changes were done to the pool connect and container open API
in DAOS 1.3+. UUID string or label are now passed via the API
instead of uuid_t structures. Change the dfs engine accordingly.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>