### PR TITLE
add signal handlers for Windows SIGBREAK

### DIFF
--- a/server.c
+++ b/server.c
@@ -2457,6 +2457,11 @@ static void set_sig_handlers(void)
 	};
 
 	sigaction(SIGINT, &act, NULL);
+
+	/* Windows uses SIGBREAK as a quit signal from other applications */
+#ifdef WIN32
+	sigaction(SIGBREAK, &act, NULL);
+#endif
 }
 
 void fio_server_destroy_sk_key(void)

--- a/t/io_uring.c
+++ b/t/io_uring.c
@@ -684,6 +684,11 @@ static void arm_sig_int(void)
 	act.sa_handler = sig_int;
 	act.sa_flags = SA_RESTART;
 	sigaction(SIGINT, &act, NULL);
+
+	/* Windows uses SIGBREAK as a quit signal from other applications */
+#ifdef WIN32
+	sigaction(SIGBREAK, &act, NULL);
+#endif
 }
 
 static int setup_ring(struct submitter *s)


### PR DESCRIPTION
Handle Windows-specific signal SIGBREAK the same as SIGINT (Ctrl+c) in the few places that don't already behave that way.

Signed-off-by: Brandon Paupore <brandon.paupore@wdc.com>