### PR TITLE
b/t/one-core-peak: Improving check_sysblock_value error handling

### DIFF
--- a/t/one-core-peak.sh
+++ b/t/one-core-peak.sh
@@ -153,10 +153,9 @@ check_sysblock_value() {
   target_file="${sys_block_dir}/$2"
   value=$3
   [ -f "${target_file}" ] || return
-  content=$(cat ${target_file})
+  content=$(cat ${target_file} 2>/dev/null)
   if [ "${content}" != "${value}" ]; then
-    info "${device_name}" "${target_file} set to ${value}."
-    echo ${value} > ${target_file} 2>/dev/null || hint "${device_name}: Cannot set ${value} on ${target_file}"
+    echo ${value} > ${target_file} 2>/dev/null && info "${device_name}" "${target_file} set to ${value}." || hint "${device_name}: Cannot set ${value} on ${target_file}"
   fi
 }
 


### PR DESCRIPTION
The current code was reporting the following output:
	cat: /sys/block/nvme0n1/queue/wbt_lat_usec: Argument invalide
	nvme0n1: /sys/block/nvme0n1/queue/wbt_lat_usec set to 0.
	Warning: nvme0n1: Cannot set 0 on /sys/block/nvme0n1/queue/wbt_lat_usec

This is problematic for several reasons:
- cat reports an error at reading wbt_lat_usec
- a message says it set wbt_lat_usec to 0
- a warning reports it cannot set wbt_lat_usec to 0

This commit:
- prevents the first error to be printed
- only report wbt_lat_usec is set to 0 if succeed unles it print the Warning message.

Signed-off-by: Erwan Velu <erwanaliasr1@gmail.com>