### PR TITLE
introducing low memory mode

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -1845,6 +1845,9 @@ Buffers and memory
 	Pin the specified amount of memory with :manpage:`mlock(2)`. Can be used to
 	simulate a smaller amount of memory.  The amount specified is per worker.
 
+.. option:: low_memory=bool
+
+	Hints fio to reduce memory usage.
 
 I/O size
 ~~~~~~~~

--- a/cconv.c
+++ b/cconv.c
@@ -201,6 +201,7 @@ void convert_thread_options_to_cpu(struct thread_options *o,
 	o->bs_unaligned = le32_to_cpu(top->bs_unaligned);
 	o->fsync_on_close = le32_to_cpu(top->fsync_on_close);
 	o->bs_is_seq_rand = le32_to_cpu(top->bs_is_seq_rand);
+	o->low_memory = le32_to_cpu(top->low_memory);
 	o->random_distribution = le32_to_cpu(top->random_distribution);
 	o->exitall_error = le32_to_cpu(top->exitall_error);
 	o->zipf_theta.u.f = fio_uint64_to_double(le64_to_cpu(top->zipf_theta.u.i));
@@ -428,6 +429,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 	top->bs_unaligned = cpu_to_le32(o->bs_unaligned);
 	top->fsync_on_close = cpu_to_le32(o->fsync_on_close);
 	top->bs_is_seq_rand = cpu_to_le32(o->bs_is_seq_rand);
+	top->low_memory = cpu_to_le32(o->low_memory);
 	top->random_distribution = cpu_to_le32(o->random_distribution);
 	top->exitall_error = cpu_to_le32(o->exitall_error);
 	top->zipf_theta.u.i = __cpu_to_le64(fio_double_to_uint64(o->zipf_theta.u.f));

--- a/dedupe.h
+++ b/dedupe.h
@@ -1,6 +1,12 @@
 #ifndef DEDUPE_H
 #define DEDUPE_H
 
+/*
+ * Defines the ratio of seeds we maintain in memory opposed to seeds we calculate in runtime
+ * E.g. a ratio of 1k means we maintain 1 seed per 1k pages we expect in the dedupe_workset
+ */
+#define LOW_MEMORY_DEDUPE_WORKSET_RATIO 1024
+
 int init_dedupe_working_set_seeds(struct thread_data *td);
 
 #endif

--- a/fio.1
+++ b/fio.1
@@ -1654,6 +1654,9 @@ preferred way to set this to avoid setting a non-pow-2 bad value.
 .BI lockmem \fR=\fPint
 Pin the specified amount of memory with \fBmlock\fR\|(2). Can be used to
 simulate a smaller amount of memory. The amount specified is per worker.
+.TP
+.BI low_memory \fR=\fPbool
+Hints fio to reduce memory usage.
 .SS "I/O size"
 .TP
 .BI size \fR=\fPint[%|z]

--- a/optgroup.h
+++ b/optgroup.h
@@ -71,6 +71,7 @@ enum opt_category_group {
 	__FIO_OPT_G_LIBCUFILE,
 	__FIO_OPT_G_DFS,
 	__FIO_OPT_G_NFS,
+	__FIO_OPT_G_MEMORY,
 
 	FIO_OPT_G_RATE		= (1ULL << __FIO_OPT_G_RATE),
 	FIO_OPT_G_ZONE		= (1ULL << __FIO_OPT_G_ZONE),
@@ -116,6 +117,7 @@ enum opt_category_group {
 	FIO_OPT_G_FILESTAT	= (1ULL << __FIO_OPT_G_FILESTAT),
 	FIO_OPT_G_LIBCUFILE	= (1ULL << __FIO_OPT_G_LIBCUFILE),
 	FIO_OPT_G_DFS		= (1ULL << __FIO_OPT_G_DFS),
+	FIO_OPT_G_MEMORY	= (1ULL << __FIO_OPT_G_MEMORY),
 };
 
 extern const struct opt_group *opt_group_from_mask(uint64_t *mask);

--- a/options.c
+++ b/options.c
@@ -5015,6 +5015,16 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		.group  = FIO_OPT_G_RUNTIME,
 	},
 	{
+		.name	= "low_memory",
+		.lname	= "Low memory mode",
+		.type	= FIO_OPT_BOOL,
+		.off1	= offsetof(struct thread_options, low_memory),
+		.def	= "0",
+		.help	= "Make an effort to conserve memory",
+		.category = FIO_OPT_C_GENERAL,
+		.group	= FIO_OPT_G_MEMORY,
+	},
+	{
 		.name = NULL,
 	},
 };

--- a/thread_options.h
+++ b/thread_options.h
@@ -171,6 +171,7 @@ struct thread_options {
 	unsigned int bs_unaligned;
 	unsigned int fsync_on_close;
 	unsigned int bs_is_seq_rand;
+	unsigned int low_memory;
 
 	unsigned int verify_only;
 
@@ -486,6 +487,8 @@ struct thread_options_pack {
 	uint32_t bs_unaligned;
 	uint32_t fsync_on_close;
 	uint32_t bs_is_seq_rand;
+	uint32_t low_memory;
+	uint32_t pad5;
 
 	uint32_t random_distribution;
 	uint32_t exitall_error;


### PR DESCRIPTION
fio will make an effort to reduce memory usage.

with this patch also integrating low memory mode for
recent dedupe_working_set which maintains pregenerated
random generator seeds in-memory.

Signed-off-by: Bar David <bardavvid@gmail.com>



example run:

baseline:
```
$ /usr/bin/time -v ./fio --minimal --name=bar3 --rw=randwrite --size=1000g --dedupe_mode=working_set --dedupe_percentage=50 --direct=1 --ioengine=libaio --iodepth=256 --bs=8k --runtime=10 --time_based=1 
```

mem usage:
```
	Maximum resident set size (kbytes): 328776
```

with low memory mode:
```
$ /usr/bin/time -v ./fio --minimal --name=bar3 --rw=randwrite --size=1000g --dedupe_mode=working_set --dedupe_percentage=50 --direct=1 --ioengine=libaio --iodepth=256 --bs=8k --runtime=10 --time_based=1 --low_memory=1
```
mem usage:
```
	Maximum resident set size (kbytes): 21884
```
