### PR TITLE
Android: Add io_uring support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ endif
 endif
 ifeq ($(CONFIG_TARGET_OS), Android)
   SOURCE += diskutil.c fifo.c blktrace.c cgroup.c trim.c profiles/tiobench.c \
-		oslib/linux-dev-lookup.c
+		oslib/linux-dev-lookup.c engines/io_uring.c
 ifdef CONFIG_HAS_BLKZONED
   SOURCE += oslib/linux-blkzoned.c
 endif

--- a/os/os-android.h
+++ b/os/os-android.h
@@ -309,4 +309,8 @@ static inline int fio_set_sched_idle(void)
 }
 #endif
 
+#ifndef RWF_UNCACHED
+#define RWF_UNCACHED	0x00000040
+#endif
+
 #endif


### PR DESCRIPTION
This patch has been tested on a recent Android phone. Compilation of this
patch has been verified as follows:

    NDK=/usr/lib/android-ndk
    export LIBS="-landroid"
    export UNAME=Android
    for ((i=23;i<=30;i++)); do
        echo "==== i = $i ===="
        export CC=$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${i}-clang
        [ -e "$CC" ] || continue
        ./configure && make -j$(nproc) fio || break
    done

Signed-off-by: Bart Van Assche <bvanassche@acm.org>