### PR TITLE
parse: handle comma-separated options

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -477,13 +477,17 @@ static int check_int(const char *p, int *val)
 
 static size_t opt_len(const char *str)
 {
+	char delimiter[] = {',', ':'};
 	char *postfix;
+	unsigned int i;
 
-	postfix = strchr(str, ':');
-	if (!postfix)
-		return strlen(str);
+	for (i = 0; i < FIO_ARRAY_SIZE(delimiter); i++) {
+		postfix = strchr(str, delimiter[i]);
+		if (postfix)
+			return (int)(postfix - str);
+	}
 
-	return (int)(postfix - str);
+	return strlen(str);
 }
 
 static int str_match_len(const struct value_pair *vp, const char *str)


### PR DESCRIPTION
Option parser does not properly handle 'sync_file_range' option with
multiple flags.  It was due to opt_len() only use ':' as delimiter, so
only last flag in comma-separated list have effect.

This patch adds ',' as a delimiter.  All flags are correctly ORed now.

Fixes: https://github.com/axboe/fio/issues/1234
Signed-off-by: Oleg Latin <oleglatin@yandex-team.ru>