### PR TITLE
os: detect PMULL support before enabling accelerated crc32c on ARM

### DIFF
--- a/os/os-linux.h
+++ b/os/os-linux.h
@@ -20,6 +20,9 @@
 
 #ifdef ARCH_HAVE_CRC_CRYPTO
 #include <sys/auxv.h>
+#ifndef HWCAP_PMULL
+#define HWCAP_PMULL             (1 << 4)
+#endif /* HWCAP_PMULL */
 #ifndef HWCAP_CRC32
 #define HWCAP_CRC32             (1 << 7)
 #endif /* HWCAP_CRC32 */
@@ -405,7 +408,8 @@ static inline bool os_cpu_has(cpu_features feature)
 #ifdef ARCH_HAVE_CRC_CRYPTO
 	case CPU_ARM64_CRC32C:
 		hwcap = getauxval(AT_HWCAP);
-		have_feature = (hwcap & HWCAP_CRC32) != 0;
+		have_feature = (hwcap & (HWCAP_PMULL | HWCAP_CRC32)) ==
+			       (HWCAP_PMULL | HWCAP_CRC32);
 		break;
 #endif
 	default:


### PR DESCRIPTION
Issue #1239 shows a crash on a FUJITSU/A64FX ARM platform at the
following line:

crc/crc32c-arm64.c:
 64                 t1 = (uint64_t)vmull_p64(crc1, k2);

On armv8 PMULL crypto instructions like vmull_p64 are defined as
optional (see
https://github.com/google/crc32c/pull/6#issuecomment-328713398 and
https://github.com/dotnet/runtime/issues/35143#issuecomment-617263508 ).

Avoid the crash by gating use of the hardware accelerated ARM crc32c
path behind runtime detection of PMULL.

Fixes: https://github.com/axboe/fio/issues/1239

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>
Tested-by: Yi Zhang <yi.zhang@redhat.com>