### PR TITLE
Fix issues (assert or uninit var, hang) with check_min_rate/offloading

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1091,8 +1091,10 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 				td->rate_io_issue_bytes[__ddir] += blen;
 			}
 
-			if (should_check_rate(td))
+			if (should_check_rate(td)) {
 				td->rate_next_io_time[__ddir] = usec_for_io(td, __ddir);
+				fio_gettime(&comp_time, NULL);
+			}
 
 		} else {
 			ret = io_u_submit(td, io_u);
@@ -1172,8 +1174,11 @@ reap:
 								f->file_name);
 			}
 		}
-	} else
+	} else {
+		if (td->o.io_submit_mode == IO_MODE_OFFLOAD)
+			workqueue_flush(&td->io_wq);
 		cleanup_pending_aio(td);
+	}
 
 	/*
 	 * stop job if we failed doing any IO


### PR DESCRIPTION
Using rate_min/rate_iops_min when io_submit_mode=offload option is set
leads to intermittent asserts and doesn't work. The variable comp_time
is never set in do_io in backend.c in the offload case, and comp_time is
then used in the calls to check_min_rate. The time computations in
check_min_rate either assert and terminate fio, or return meaningless
values, so any rate checking is not correct.

This first issue is fixed by adding a call to fio_gettime in the
offloading case. Once that is done though, there is still another
problem remaining. When the min rate is not achieved (with the
offloading option), fio detects it and tries to exit but fails. It ends
up in a state where ctrl-C will not cause an exit either. This happens
because cleanup_pending_aio(td) in the error case hangs in its second
call to io_u_queued_complete. Calling workqueue_flush in the error case
(when offloading) fixes the problem by making sure nothing is left in
the work queues and cleanup can proceed as it does in the non-offload
case.

Signed-off-by: Nick Neumann <nick@pcpartpicker.com>