### PR TITLE
Fix :<nr> suffix with random read/write causing 0 initial offset

### DIFF
--- a/init.c
+++ b/init.c
@@ -1576,7 +1576,14 @@ static int add_job(struct thread_data *td, const char *jobname, int job_add_num,
 	td->ts.sig_figs = o->sig_figs;
 
 	init_thread_stat_min_vals(&td->ts);
-	td->ddir_seq_nr = o->ddir_seq_nr;
+
+	/*
+	 * td->>ddir_seq_nr needs to be initialized to 1, NOT o->ddir_seq_nr,
+	 * so that get_next_offset gets a new random offset the first time it
+	 * is called, instead of keeping an initial offset of 0 for the first
+	 * nr-1 calls
+	 */
+	td->ddir_seq_nr = 1;
 
 	if ((o->stonewall || o->new_group) && prev_group_jobs) {
 		prev_group_jobs = 0;


### PR DESCRIPTION
When using the :<nr> suffix with random reads or writes, the initial
offset would be set to 0 for the first nr-1 operations. This happened
because td->ddir_seq_nr was initialized to the specified option value,
when it needs to always be initialized to 1, so that the first call to
get_next_offset leads to choosing a new random offset for the first nr
operations.

Signed-off-by: Nick Neumann nick@pcpartpicker.com