### PR TITLE
freeing job_sections array to avoid wasting memory and possible indirect memory leak

### DIFF
--- a/init.c
+++ b/init.c
@@ -2185,6 +2185,10 @@ static int __parse_jobs_ini(struct thread_data *td,
 		i++;
 	}
 
+	free(job_sections);
+	job_sections = NULL;
+	nr_job_sections = 0;
+
 	free(opts);
 out:
 	free(string);


### PR DESCRIPTION
- freeing job_sections array of strings upon freeing each its item in init.c

Signed-off-by: Denis Pronin <dannftk@yandex.ru>