### PR TITLE
fixed memory leak detected by ASAN when running FIO jobs from within parent process

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2441,6 +2441,8 @@ reap:
 					_exit(ret);
 				} else if (i == fio_debug_jobno)
 					*fio_debug_jobp = pid;
+				free(fd);
+				fd = NULL;
 			}
 			dprint(FD_MUTEX, "wait on startup_sem\n");
 			if (fio_sem_down_timeout(startup_sem, 10000)) {


### PR DESCRIPTION
- fixed memory leak in parent process detected by ASAN when forking and not freeing memory in the parent process allocated for fork_data

Signed-off-by: Denis Pronin <dannftk@yandex.ru>