### PR TITLE
Improvements in dup_files function

### DIFF
--- a/filesetup.c
+++ b/filesetup.c
@@ -2031,11 +2031,12 @@ void dup_files(struct thread_data *td, struct thread_data *org)
 	if (!org->files)
 		return;
 
-	td->files = malloc(org->files_index * sizeof(f));
+	td->files = calloc(org->files_index, sizeof(f));
 
 	if (td->o.file_lock_mode != FILE_LOCK_NONE)
 		td->file_locks = malloc(org->files_index);
 
+	assert(org->files_index >= org->o.nr_files);
 	for_each_file(org, f, i) {
 		struct fio_file *__f;
 


### PR DESCRIPTION
- cleared allocation of td->files when duplicating files
- call 'assert', before iterating over original thread_data, that prevents possible segmentation fault when duplicating files

Signed-off-by: Denis Pronin <dannftk@yandex.ru>