### PR TITLE
fixed possible and actual memory leaks

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2433,8 +2433,10 @@ reap:
 			} else {
 				pid_t pid;
 				struct fio_file **files;
+				void *eo;
 				dprint(FD_PROCESS, "will fork\n");
 				files = td->files;
+				eo = td->eo;
 				read_barrier();
 				pid = fork();
 				if (!pid) {
@@ -2447,6 +2449,7 @@ reap:
 				// freeing previously allocated memory for files
 				// this memory freed MUST NOT be shared between processes, only the pointer itself may be shared within TD
 				free(files);
+				free(eo);
 				free(fd);
 				fd = NULL;
 			}

--- a/ioengines.c
+++ b/ioengines.c
@@ -223,6 +223,8 @@ struct ioengine_ops *load_ioengine(struct thread_data *td)
  */
 void free_ioengine(struct thread_data *td)
 {
+	assert(td != NULL && td->io_ops != NULL);
+
 	dprint(FD_IO, "free ioengine %s\n", td->io_ops->name);
 
 	if (td->eo && td->io_ops->options) {


### PR DESCRIPTION
backend.c: release memory occupied by the parent process for options
ioengines.c: free_ioengine entry point is protected by 'assert' call
upon td and td->io_ops

Signed-off-by: Denis Pronin <dannftk@yandex.ru>