### PR TITLE
Quick cite this repository - APA/BibTeX

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+preferred-citation:
+  type: software
+  authors:
+  - family-names: "Axboe"
+    given-names: "Jens"
+    email: axboe@kernel.dk
+  title: "Flexible I/O Tester"
+  year: 2022
+  url: "https://github.com/axboe/fio"
+licence: GNU GPL v2.0


### PR DESCRIPTION
Hi there this is a github repo specific enhancement.

Have been referencing FIO recently and was generating bibtex for this repo. I came across a Github way of adding a CITATION.cff file which adds a nice little menu button for others to easy cite it in APA/Bibtex. Thought I may add it, see added file/pictures. More information on the CITATION.cff feature here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files (unfortunately APA only available currently but BibTeX was what I was after).

![image](https://user-images.githubusercontent.com/30672425/159146133-fb8b5627-b6cc-483e-87d3-51cd600bcca5.png)

Thanks
Jono