### PR TITLE
io_u: produce bad offsets for some time_based jobs

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -355,7 +355,7 @@ static int get_next_seq_offset(struct thread_data *td, struct fio_file *f,
 	 * and invalidate the cache, if we need to.
 	 */
 	if (f->last_pos[ddir] >= f->io_size + get_start_offset(td, f) &&
-	    o->time_based) {
+	    o->time_based && o->nr_files == 1) {
 		f->last_pos[ddir] = f->file_offset;
 		loop_cache_invalidate(td, f);
 	}


### PR DESCRIPTION
Allow get_next_seq_offset to produce bad offsets for time_based jobs
when fio is accessing more than one file. Otherwise fio will not skip to
the next file once the current one is done.

Fixes: https://github.com/axboe/fio/issues/1372

Signed-off-by: Vincent Fu <vincent.fu@samsung.com>

I've run all of our automated tests and this patch introduces no issues. So I think this fix is unlikely to cause any regressions.