### PR TITLE
Fix compile error of GCC 4

### DIFF
--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -67,6 +67,7 @@
 #endif
 
 #ifndef __has_attribute
+#define __has_attribute(x) __GCC4_has_attribute_##x
 #define __GCC4_has_attribute___fallthrough__	0
 #endif
 


### PR DESCRIPTION
gcc-4.9.3 doesn't recognize `__has_attribute(__fallthrough__)` and reports
the following error.

```
  CC crc/crc32c-arm64.o
  In file included from crc/../os/../file.h:5:0,
                   from crc/../os/os-linux.h:32,
                   from crc/../os/os.h:39,
                   from crc/crc32c-arm64.c:2:
  crc/../os/../compiler/compiler.h:74:20: error: missing binary operator before token "("
  Makefile:501: recipe for target 'crc/crc32c-arm64.o' failed
  make: *** [crc/crc32c-arm64.o] Error 1
```

Signed-off-by: Chung-Chiang Cheng <cccheng@synology.com>