### PR TITLE
fixed jobs eta memory leak

### DIFF
--- a/eta.c
+++ b/eta.c
@@ -3,6 +3,7 @@
  */
 #include <unistd.h>
 #include <string.h>
+#include <stdlib.h>
 #ifdef CONFIG_VALGRIND_DEV
 #include <valgrind/drd.h>
 #else
@@ -707,10 +708,10 @@ void print_thread_status(void)
 	size_t size;
 
 	je = get_jobs_eta(false, &size);
-	if (je)
+	if (je) {
 		display_thread_status(je);
-
-	free(je);
+		free(je);
+	}
 }
 
 void print_status_init(int thr_number)

--- a/server.c
+++ b/server.c
@@ -1323,7 +1323,7 @@ static int handle_xmits(struct sk_out *sk_out)
 	sk_unlock(sk_out);
 
 	while (!flist_empty(&list)) {
-		entry = flist_entry(list.next, struct sk_entry, list);
+		entry = flist_first_entry(&list, struct sk_entry, list);
 		flist_del(&entry->list);
 		ret += handle_sk_entry(sk_out, entry);
 	}

--- a/stat.c
+++ b/stat.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <math.h>
@@ -1698,6 +1699,7 @@ static struct json_object *show_thread_status_json(struct thread_stat *ts,
 	if (je) {
 		json_object_add_value_int(root, "eta", je->eta_sec);
 		json_object_add_value_int(root, "elapsed", je->elapsed_sec);
+		free(je);
 	}
 
 	if (opt_list)


### PR DESCRIPTION
Launch fio built with ASAN enabled, for example, by this way:
```
./fio --max-jobs=4 --output=fio-output.json --output-format=json+ --filename=fio_jsonplus_clat2csv.test --ioengine=libaio --time_based --runtime=3s --size=1M --slat_percentiles=1 --clat_percentiles=1 --lat_percentiles=1 --thread=1 --name=test1 --rw=randrw --name=test2 --rw=read --name=test3 --rw=write --thread=1
```

Borrowed from one tests the project has got

We can see many memory leaks, in particular:

```
Direct leak of 573 byte(s) in 3 object(s) allocated from:
    #0 0x345e0d in malloc (/home/dpronin/Development/workspace/fio/fio+0x345e0d)
    #1 0x414499 in get_jobs_eta /home/dpronin/Development/workspace/fio/eta.c:690:7
```

This PR fixes this leak