### PR TITLE
fixed bunch of memory leaks in json constructor

### DIFF
--- a/json.h
+++ b/json.h
@@ -81,8 +81,13 @@ static inline int json_object_add_value_string(struct json_object *obj,
 	struct json_value arg = {
 		.type = JSON_TYPE_STRING,
 	};
+	union {
+		const char *a;
+		char *b;
+	} string;
 
-	arg.string = strdup(val ? : "");
+	string.a = val ? val : "";
+	arg.string = string.b;
 	return json_object_add_value_type(obj, name, &arg);
 }
 

--- a/t/run-fio-tests.py
+++ b/t/run-fio-tests.py
@@ -546,9 +546,10 @@ class FioJobTest_iops_rate(FioJobTest):
             return
 
         iops1 = self.json_data['jobs'][0]['read']['iops']
-        iops2 = self.json_data['jobs'][1]['read']['iops']
-        ratio = iops2 / iops1
         logging.debug("Test %d: iops1: %f", self.testnum, iops1)
+        iops2 = self.json_data['jobs'][1]['read']['iops']
+        logging.debug("Test %d: iops2: %f", self.testnum, iops2)
+        ratio = iops2 / iops1
         logging.debug("Test %d: ratio: %f", self.testnum, ratio)
 
         if iops1 < 950 or iops1 > 1050:


### PR DESCRIPTION
fixed memory leak produced by not freed string given by 'strdup' in
'json_object_add_value_string' function. Just removed 'strdup' and made
string in 'json_value' as immutable

Signed-off-by: Denis Pronin <dannftk@yandex.ru>