### PR TITLE
Init file_cache to invalid (maj, min)

### DIFF
--- a/blktrace.c
+++ b/blktrace.c
@@ -442,7 +442,10 @@ err:
 bool read_blktrace(struct thread_data* td)
 {
 	struct blk_io_trace t;
-	struct file_cache cache = { };
+	struct file_cache cache = {
+		.maj = ~0U,
+		.min = ~0U,
+	};
 	unsigned long ios[DDIR_RWDIR_SYNC_CNT] = { };
 	unsigned long long rw_bs[DDIR_RWDIR_CNT] = { };
 	unsigned long skipped_writes;


### PR DESCRIPTION
In the very unlikely case that the trace was taken from a device with
major and minor zeroes, the cache will wrongly hit the first time. We
are hitting this problem when trying to replay generated traces with
major and minor zeroes. Initializing with ~0U fixes this problem.

Signed-off-by: Luis Useche useche@gmail.com