### PR TITLE
Simplify and optimize __fill_random_buf

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -97,29 +97,18 @@ void init_rand_seed(struct frand_state *state, uint64_t seed, bool use64)
 
 void __fill_random_buf(void *buf, unsigned int len, uint64_t seed)
 {
-	void *ptr = buf;
+	uint64_t *b = buf;
+	uint64_t *e = b  + len / sizeof(*b);
+	unsigned int rest = len % sizeof(*b);
 
-	while (len) {
-		int this_len;
-
-		if (len >= sizeof(int64_t)) {
-			*((int64_t *) ptr) = seed;
-			this_len = sizeof(int64_t);
-		} else if (len >= sizeof(int32_t)) {
-			*((int32_t *) ptr) = seed;
-			this_len = sizeof(int32_t);
-		} else if (len >= sizeof(int16_t)) {
-			*((int16_t *) ptr) = seed;
-			this_len = sizeof(int16_t);
-		} else {
-			*((int8_t *) ptr) = seed;
-			this_len = sizeof(int8_t);
-		}
-		ptr += this_len;
-		len -= this_len;
+	for (; b != e; ++b) {
+		*b = seed;
 		seed *= GOLDEN_RATIO_PRIME;
 		seed >>= 3;
 	}
+
+	if (fio_unlikely(rest))
+		__builtin_memcpy(e, &seed, rest);
 }
 
 uint64_t fill_random_buf(struct frand_state *fs, void *buf,


### PR DESCRIPTION
This reduces the number of source lines and the code size.

For example, when compiling with GCC 12.1 (-O3 -march=skylake), the
resulting assembly shrinks from 33 to 27 instructions and the number of
jump instructions is reduced from 4 to 3.

NB: GCC is able to eliminate the memcpy() call.

NB: Even if a compiler doesn't eliminate the memcpy() call, it's very
unlikely to ever get called since the buffer sizes are expected to be
powers of two [greater than 8], usually.

---

Motivation: On a somewhat underpowered CPU I noticed that fio was CPU bound (when running with `refill_buffers`) and profiling showed that most of the time was spent in `__fill_random_buf()`.

I thus optimized it a bit and observed an improvement of 20 % or so in the fio throughput.

See also: https://godbolt.org/z/57fGGYqsM