### PR TITLE
client: only do le64_to_cpu() on io_sample_data member if iolog is histogram

### DIFF
--- a/client.c
+++ b/client.c
@@ -1702,7 +1702,8 @@ static struct cmd_iolog_pdu *convert_iolog(struct fio_net_cmd *cmd,
 			s = (struct io_sample *)((char *)s + sizeof(struct io_u_plat_entry) * i);
 
 		s->time		= le64_to_cpu(s->time);
-		s->data.val	= le64_to_cpu(s->data.val);
+		if (ret->log_type != IO_LOG_TYPE_HIST)
+			s->data.val	= le64_to_cpu(s->data.val);
 		s->__ddir	= __le32_to_cpu(s->__ddir);
 		s->bs		= le64_to_cpu(s->bs);
 		s->priority	= le16_to_cpu(s->priority);


### PR DESCRIPTION
In the case of histogram iolog, the union io_sample_data member is a
pointer of struct io_u_plat_entry, while in the case of normal iolog, it
is an uint64_t. Thus only need to do the byteswap in case it is an
uint64_t.

This has been done similarly in server code.

Signed-off-by: Ulrich Weigand <ulrich.weigand@de.ibm.com>
Signed-off-by: Tuan Hoang <tuan.hoang1@ibm.com>