### PR TITLE
Fixed misplaced goto in http.c

### DIFF
--- a/engines/http.c
+++ b/engines/http.c
@@ -526,8 +526,8 @@ static enum fio_q_status fio_http_queue(struct thread_data *td,
 			if (status == 100 || (status >= 200 && status <= 204))
 				goto out;
 			log_err("DDIR_WRITE failed with HTTP status code %ld\n", status);
-			goto err;
 		}
+		goto err;
 	} else if (io_u->ddir == DDIR_READ) {
 		curl_easy_setopt(http->curl, CURLOPT_READDATA, NULL);
 		curl_easy_setopt(http->curl, CURLOPT_WRITEDATA, &_curl_stream);


### PR DESCRIPTION
In http.c:fio_http_queue function, when the user specifies rw=write and if curl_easy_perform fails then the control reaches line 565 and incorrectly prints: "WARNING: Only DDIR_READ/DDIR_WRITE/DDIR_TRIM are supported!".
Fix to this consists in moving statement: "goto err" at the end of the block as already has been done for trim/read blocks.

Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>