### PR TITLE
Fix logic determining if operating on single shared file

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2316,12 +2316,16 @@ static void run_threads(struct sk_out *sk_out)
 
 		if (!td->o.create_serialize) {
 			/*
-			 *  When operating on a single rile in parallel,
+			 *  When operating on a single file in parallel,
 			 *  perform single-threaded early setup so that
 			 *  when setup_files() does not run into issues
-			 *  later.
+			 *  later. As files are added by add_job(), a
+			 *  single shared file will end up with
+			 *  files_size==1. Jobs dynamically creating
+			 *  files will end up with files_size>=2, even
+			 *  if there is only a single file per job.
 			*/
-			if (!i && td->o.nr_files == 1) {
+			if (!i && td->files_size == 1) {
 				if (setup_shared_file(td)) {
 					exit_value++;
 					if (td->error)


### PR DESCRIPTION
nrfiles=1 is not a valid decision point to determine whether
or not fio is operating on a single shared file. If numjobs>1
and filename is NOT specified, each job will create a single
non-shared file. add_file() is called differently when filename
is specified on the command line. If filename is specified,
then add_file() is called once from an options callback and
td->files_size==1. If filename is NOT specified, and each job
creates its own file, then td->files_size>=2 as filenames are
dynamically added. Change the logic to call setup_shared_file()
so that it is only called wheen td->files_size==1.

Signed-off-by: Chris Weber <weberc@netapp.com>

This fixes #1442 


I tested using the fio.txt job options:
```
[global]
time_based=1
startdelay=5
exitall_on_error=0
create_serialize=0
directory=/home/user/fiotest
group_reporting
clocksource=gettimeofday
ioengine=posixaio
disk_util=0
iodepth=1
create_on_open=1

[nfs_load]
rw=write
bs=8k
numjobs=20
direct=0
size=1M
stonewall
```

I also verified that our use case of a single-shared file still behaves as desired.


