### PR TITLE
Avoid refilling io buffers if applicable to reduce CPU utilization

### DIFF
--- a/init.c
+++ b/init.c
@@ -900,6 +900,8 @@ static int fixup_options(struct thread_data *td)
 		}
 	}
 
+	o->io_buffer_filled = 0;
+	
 	/*
 	 * Using a non-uniform random distribution excludes usage of
 	 * a random map

--- a/init.c
+++ b/init.c
@@ -887,16 +887,21 @@ static int fixup_options(struct thread_data *td)
 	/*
 	 * For fully compressible data, just zero them at init time.
 	 * It's faster than repeatedly filling it. For non-zero
-	 * compression, we should have refill_buffers set. Set it, unless
-	 * the job file already changed it.
+	 * compression, we will have refill_buffers set if either
+	 * data dedupe or verify is set. Set it, unless the job file
+	 * already changed it.
 	 */
 	if (o->compress_percentage) {
 		if (o->compress_percentage == 100) {
 			o->zero_buffers = 1;
 			o->compress_percentage = 0;
 		} else if (!fio_option_is_set(o, refill_buffers)) {
-			o->refill_buffers = 1;
-			td->flags |= TD_F_REFILL_BUFFERS;
+			if (td_read(td) || o->dedupe_percentage != 100) {
+				o->refill_buffers = 1;
+				td->flags |= TD_F_REFILL_BUFFERS;
+			} else {
+				o->refill_buffers = 0;
+			}
 		}
 	}
 

--- a/init.c
+++ b/init.c
@@ -900,8 +900,6 @@ static int fixup_options(struct thread_data *td)
 		}
 	}
 
-	o->io_buffer_filled = 0;
-
 	/*
 	 * Using a non-uniform random distribution excludes usage of
 	 * a random map

--- a/init.c
+++ b/init.c
@@ -887,21 +887,16 @@ static int fixup_options(struct thread_data *td)
 	/*
 	 * For fully compressible data, just zero them at init time.
 	 * It's faster than repeatedly filling it. For non-zero
-	 * compression, we will have refill_buffers set if either
-	 * data dedupe or verify is set. Set it, unless the job file
-	 * already changed it.
+	 * compression, we should have refill_buffers set. Set it, unless
+	 * the job file already changed it.
 	 */
 	if (o->compress_percentage) {
 		if (o->compress_percentage == 100) {
 			o->zero_buffers = 1;
 			o->compress_percentage = 0;
 		} else if (!fio_option_is_set(o, refill_buffers)) {
-			if (td_read(td) || o->dedupe_percentage != 100) {
-				o->refill_buffers = 1;
-				td->flags |= TD_F_REFILL_BUFFERS;
-			} else {
-				o->refill_buffers = 0;
-			}
+			o->refill_buffers = 1;
+			td->flags |= TD_F_REFILL_BUFFERS;
 		}
 	}
 

--- a/init.c
+++ b/init.c
@@ -900,6 +900,8 @@ static int fixup_options(struct thread_data *td)
 		}
 	}
 
+	o->io_buffer_filled = 0;
+
 	/*
 	 * Using a non-uniform random distribution excludes usage of
 	 * a random map

--- a/io_u.c
+++ b/io_u.c
@@ -2235,7 +2235,8 @@ void fill_io_buffer(struct thread_data *td, void *buf, unsigned long long min_wr
 		unsigned long long left = max_bs;
 		unsigned long long this_write;
 
-		if (!o->refill_buffers) {
+		if (td_write(td) && o->dedupe_percentage == 100 &&
+		    o->verify == VERIFY_NONE) {
 			if (o->io_buffer_filled >= o->iodepth) {
 				return;
 			}

--- a/io_u.c
+++ b/io_u.c
@@ -2235,14 +2235,6 @@ void fill_io_buffer(struct thread_data *td, void *buf, unsigned long long min_wr
 		unsigned long long left = max_bs;
 		unsigned long long this_write;
 
-		if (td_write(td) && o->dedupe_percentage == 100 &&
-		    o->verify == VERIFY_NONE) {
-			if (o->io_buffer_filled >= o->iodepth) {
-				return;
-			}
-			o->io_buffer_filled++;
-		}	
-
 		do {
 			/*
 			 * Buffers are either entirely dedupe-able or not.

--- a/io_u.c
+++ b/io_u.c
@@ -2235,8 +2235,7 @@ void fill_io_buffer(struct thread_data *td, void *buf, unsigned long long min_wr
 		unsigned long long left = max_bs;
 		unsigned long long this_write;
 
-		if (td_write(td) && o->dedupe_percentage == 100 &&
-		    o->verify == VERIFY_NONE) {
+		if (!o->refill_buffers) {
 			if (o->io_buffer_filled >= o->iodepth) {
 				return;
 			}

--- a/io_u.c
+++ b/io_u.c
@@ -2235,6 +2235,14 @@ void fill_io_buffer(struct thread_data *td, void *buf, unsigned long long min_wr
 		unsigned long long left = max_bs;
 		unsigned long long this_write;
 
+		if (td_write(td) && o->dedupe_percentage == 100 &&
+		    o->verify == VERIFY_NONE) {
+			if (o->io_buffer_filled >= o->iodepth) {
+				return;
+			}
+			o->io_buffer_filled++;
+		}	
+
 		do {
 			/*
 			 * Buffers are either entirely dedupe-able or not.

--- a/io_u.h
+++ b/io_u.h
@@ -12,6 +12,8 @@
 #include <libaio.h>
 #endif
 
+#define IO_BUFFER_FILL_INTERVAL (128)
+
 enum {
 	IO_U_F_FREE		= 1 << 0,
 	IO_U_F_FLIGHT		= 1 << 1,

--- a/options.c
+++ b/options.c
@@ -1503,6 +1503,9 @@ static int str_buffer_pattern_cb(void *data, const char *input)
 	 */
 	if (!td->o.compress_percentage && !td_read(td))
 		td->o.refill_buffers = 0;
+	else if (!td_read(td) && (td->o.dedupe_percentage == 100) &&
+		 (td->o.verify == VERIFY_NONE))
+		td->o.refill_buffers = 0;
 	else
 		td->o.refill_buffers = 1;
 
@@ -1527,7 +1530,11 @@ static int str_dedupe_cb(void *data, unsigned long long *il)
 
 	td->flags |= TD_F_COMPRESS;
 	td->o.dedupe_percentage = *il;
-	td->o.refill_buffers = 1;
+	if (!td_read(td) && (td->o.dedupe_percentage == 100) &&
+	    (td->o.verify == VERIFY_NONE))
+	    	td->o.refill_buffers = 0;
+	else
+		td->o.refill_buffers = 1;
 	return 0;
 }
 

--- a/options.c
+++ b/options.c
@@ -1503,9 +1503,6 @@ static int str_buffer_pattern_cb(void *data, const char *input)
 	 */
 	if (!td->o.compress_percentage && !td_read(td))
 		td->o.refill_buffers = 0;
-	else if (!td_read(td) && (td->o.dedupe_percentage == 100) &&
-		 (td->o.verify == VERIFY_NONE))
-		td->o.refill_buffers = 0;
 	else
 		td->o.refill_buffers = 1;
 
@@ -1530,11 +1527,7 @@ static int str_dedupe_cb(void *data, unsigned long long *il)
 
 	td->flags |= TD_F_COMPRESS;
 	td->o.dedupe_percentage = *il;
-	if (!td_read(td) && (td->o.dedupe_percentage == 100) &&
-	    (td->o.verify == VERIFY_NONE))
-	    	td->o.refill_buffers = 0;
-	else
-		td->o.refill_buffers = 1;
+	td->o.refill_buffers = 1;
 	return 0;
 }
 

--- a/options.c
+++ b/options.c
@@ -4666,7 +4666,6 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		.maxval	= 100,
 		.minval	= 0,
 		.help	= "Percentage of buffers that are dedupable",
-		.def    = "100",
 		.interval = 1,
 		.category = FIO_OPT_C_IO,
 		.group	= FIO_OPT_G_IO_BUF,

--- a/options.c
+++ b/options.c
@@ -4666,6 +4666,7 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		.maxval	= 100,
 		.minval	= 0,
 		.help	= "Percentage of buffers that are dedupable",
+		.def    = "100",
 		.interval = 1,
 		.category = FIO_OPT_C_IO,
 		.group	= FIO_OPT_G_IO_BUF,

--- a/thread_options.h
+++ b/thread_options.h
@@ -91,6 +91,7 @@ struct thread_options {
 	unsigned int unit_base;
 	unsigned int ddir_seq_nr;
 	long long ddir_seq_add;
+	unsigned int io_buffer_filled;
 	unsigned int iodepth;
 	unsigned int iodepth_low;
 	unsigned int iodepth_batch;

--- a/thread_options.h
+++ b/thread_options.h
@@ -97,7 +97,7 @@ struct thread_options {
 	unsigned int iodepth_batch_complete_min;
 	unsigned int iodepth_batch_complete_max;
 	unsigned int serialize_overlap;
-
+	unsigned long long io_buffer_filled;
 	unsigned int unique_filename;
 
 	unsigned long long size;

--- a/thread_options.h
+++ b/thread_options.h
@@ -91,7 +91,6 @@ struct thread_options {
 	unsigned int unit_base;
 	unsigned int ddir_seq_nr;
 	long long ddir_seq_add;
-	unsigned int io_buffer_filled;
 	unsigned int iodepth;
 	unsigned int iodepth_low;
 	unsigned int iodepth_batch;


### PR DESCRIPTION
This commit is aimed to avoid refilling io buffers in write scenarios by setting existing
parameter refill_buffers properly to reduce CPU utilization if applicable.

In a non-read case, there is no need to refill io buffers every time when data dedupe or
data verify is not set. We only need to refill io buffers for the 1st time, and reuse these
buffers in the following rounds. By doing this, we can significantly reduce the CPU
utilization, which could avoid CPU being the bottleneck when testing multiple SSDs
in one single server. This is of more importance when we turn to PCIe Gen4 or Gen5
interface and set a specific compression ratio.

Ning Zheng <ningzhengrpi@163.com>
