### PR TITLE
io_uring: dereference pthread_t value from pthread_self

### DIFF
--- a/t/io_uring.c
+++ b/t/io_uring.c
@@ -799,15 +799,14 @@ static int submitter_init(struct submitter *s)
 	int i, nr_batch, err;
 	static int init_printed;
 	char buf[80];
-
 	s->tid = gettid();
 	printf("submitter=%d, tid=%d, file=%s, node=%d\n", s->index, s->tid,
 							s->filename, s->numa_node);
 
 	set_affinity(s);
 
-	__init_rand64(&s->rand_state, pthread_self());
-	srand48(pthread_self());
+	__init_rand64(&s->rand_state, s->tid);
+	srand48(s->tid);
 
 	for (i = 0; i < MAX_FDS; i++)
 		s->files[i].fileno = i;


### PR DESCRIPTION
__init_rand64 takes 64bit value and srand48 takes unsigned 32bit value,
pthread_t is opaque type and some libcs ( e.g. musl ) do not define them
in plain old data types and ends up with errors

| t/io_uring.c:809:32: error: incompatible pointer to integer conversion passing 'pthread_t' (aka 'struct __pthread *') to parameter of type 'uint64_t' (aka 'unsigned long') [-Wint-conver
sion]
|         __init_rand64(&s->rand_state, pthread_self());
|                                       ^~~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>

Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>
