### PR TITLE
Added IPv6 option at client side

### DIFF
--- a/fio.1
+++ b/fio.1
@@ -4547,6 +4547,12 @@ Fio can connect to multiple servers this way:
 $ fio \-\-client=<server1> <job file(s)> \-\-client=<server2> <job file(s)>
 .RE
 .P
+In an IPv6 network, use prefix "ip6:" before the IP address.
+.RS
+.P
+$ fio \-\-client=ip6:<server1 Ipv6 address> <job file(s)> \-\-client=ip6:<server2 IPv6 address> <job file(s)>
+.RE
+.P
 If the job file is located on the fio server, then you can tell the server to
 load a local file as well. This is done by using \fB\-\-remote\-config\fR:
 .RS


### PR DESCRIPTION
Added IPv6 option at client side

Documentation lacked the information of how fio handles IPv6 in client/server environment.
server side option is present but it is quite unclear about how to implement in client end.

Signed-off-by: Abhishek Bose <abose@redhat.com>