### PR TITLE
Change log_compression option from int to bool

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -3786,18 +3786,18 @@ Measurements and reporting
 	entry as well as the other data values. Defaults to 0 meaning that
 	offsets are not present in logs. Also see `Log File Formats`_.
 
-.. option:: log_compression=int
+.. option:: log_compression=bool
 
 	If this is set, fio will compress the I/O logs as it goes, to keep the
-	memory footprint lower. When a log reaches the specified size, that chunk is
-	removed and compressed in the background. Given that I/O logs are fairly
-	highly compressible, this yields a nice memory savings for longer runs. The
-	downside is that the compression will consume some background CPU cycles, so
-	it may impact the run. This, however, is also true if the logging ends up
-	consuming most of the system memory.  So pick your poison. The I/O logs are
-	saved normally at the end of a run, by decompressing the chunks and storing
-	them in the specified log file. This feature depends on the availability of
-	zlib.
+	memory footprint lower. When a chunk of log entries is big enough, that
+	chunk is removed and compressed in the background. Given that I/O logs are
+	fairly highly compressible, this yields a nice memory savings for longer
+	runs. The downside is that the compression will consume some background CPU
+	cycles, so it may impact the run. This, however, is also true if the
+	logging ends up consuming most of the system memory.  So pick your poison.
+	The I/O logs are saved normally at the end of a run, by decompressing the
+	chunks and storing them in the specified log file. This feature depends on
+	the availability of zlib.
 
 .. option:: log_compression_cpus=str
 

--- a/fio.1
+++ b/fio.1
@@ -3490,17 +3490,16 @@ If this is set, the iolog options will include the I/O priority for the I/O
 entry as well as the other data values. Defaults to 0 meaning that
 I/O priorities are not present in logs. Also see \fBLOG FILE FORMATS\fR section.
 .TP
-.BI log_compression \fR=\fPint
-If this is set, fio will compress the I/O logs as it goes, to keep the
-memory footprint lower. When a log reaches the specified size, that chunk is
-removed and compressed in the background. Given that I/O logs are fairly
-highly compressible, this yields a nice memory savings for longer runs. The
-downside is that the compression will consume some background CPU cycles, so
-it may impact the run. This, however, is also true if the logging ends up
-consuming most of the system memory. So pick your poison. The I/O logs are
-saved normally at the end of a run, by decompressing the chunks and storing
-them in the specified log file. This feature depends on the availability of
-zlib.
+.BI log_compression \fR=\fPbool
+If this is set, fio will compress the I/O logs as it goes, to keep the memory
+footprint lower. When a chunk of log entries is big enough, that chunk is
+removed and compressed in the background. Given that I/O logs are fairly highly
+compressible, this yields a nice memory savings for longer runs. The downside
+is that the compression will consume some background CPU cycles, so it may
+impact the run. This, however, is also true if the logging ends up consuming
+most of the system memory. So pick your poison. The I/O logs are saved normally
+at the end of a run, by decompressing the chunks and storing them in the
+specified log file. This feature depends on the availability of zlib.
 .TP
 .BI log_compression_cpus \fR=\fPstr
 Define the set of CPUs that are allowed to handle online log compression for

--- a/iolog.c
+++ b/iolog.c
@@ -1168,7 +1168,7 @@ static size_t inflate_chunk(struct iolog_compress *ic, int gz_hdr, FILE *f,
  */
 static int inflate_gz_chunks(struct io_log *log, FILE *f)
 {
-	struct inflate_chunk_iter iter = { .chunk_sz = log->log_gz, };
+	struct inflate_chunk_iter iter = { .chunk_sz = 64 * 1024 * 1024, };
 	z_stream stream;
 
 	while (!flist_empty(&log->chunk_list)) {

--- a/iolog.h
+++ b/iolog.h
@@ -110,7 +110,7 @@ struct io_log {
 	unsigned int log_prio;
 
 	/*
-	 * Max size of log entries before a chunk is compressed
+	 * Compress in-memory log entries
 	 */
 	unsigned int log_gz;
 

--- a/options.c
+++ b/options.c
@@ -4459,11 +4459,9 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 	{
 		.name	= "log_compression",
 		.lname	= "Log compression",
-		.type	= FIO_OPT_INT,
+		.type	= FIO_OPT_BOOL,
 		.off1	= offsetof(struct thread_options, log_gz),
-		.help	= "Log in compressed chunks of this size",
-		.minval	= 1024ULL,
-		.maxval	= 512 * 1024 * 1024ULL,
+		.help	= "Compress in-memory logs",
 		.category = FIO_OPT_C_LOG,
 		.group	= FIO_OPT_G_INVALID,
 	},

--- a/t/log_compression.py
+++ b/t/log_compression.py
@@ -51,7 +51,7 @@ def run_fio(fio,log_store_compressed):
         '--write_bw_log=test',
         '--per_job_logs=0',
         '--log_offset=1',
-        '--log_compression=10K',
+        '--log_compression=1',
         ]
     if log_store_compressed:
         fio_args.append('--log_store_compressed=1')


### PR DESCRIPTION
The log_compression option no longer has an effect on when a chunk of log entries is compressed in the background, but instead functions as a boolean for whether or not to perform the compression. It was also used to decide decompression chunk size after a job, but we can just use a fixed chunk size as is done for the fio --inflate-log option.

As such, change the option from int to bool to avoid confusion. Note that any existing usage of this option will need to be updated to specify a bool instead of an int.

Please confirm that your commit message(s) follow these guidelines:
CONFIRMED
1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>
