### PR TITLE
fix configure probe for libcufile

### DIFF
--- a/configure
+++ b/configure
@@ -2723,9 +2723,9 @@ int main(int argc, char* argv[]) {
    return 0;
 }
 EOF
-  if compile_prog "" "-lcuda -lcudart -lcufile" "libcufile"; then
+  if compile_prog "" "-lcuda -lcudart -lcufile -ldl" "libcufile"; then
     libcufile="yes"
-    LIBS="-lcuda -lcudart -lcufile $LIBS"
+    LIBS="-lcuda -lcudart -lcufile -ldl $LIBS"
   else
     if test "$libcufile" = "yes" ; then
       feature_not_found "libcufile" ""


### PR DESCRIPTION
configure's libcufile probe now requires -ldl passed to the linker.

Signed-off-by: Brian T. Smith <bsmith@systemfabricworks.com>
