### PR TITLE
Fix for Issue 1213

### DIFF
--- a/configure
+++ b/configure
@@ -2723,9 +2723,9 @@ int main(int argc, char* argv[]) {
    return 0;
 }
 EOF
-  if compile_prog "" "-lcuda -lcudart -lcufile" "libcufile"; then
+  if compile_prog "" "-lcuda -lcudart -lcufile -ldl" "libcufile"; then
     libcufile="yes"
-    LIBS="-lcuda -lcudart -lcufile $LIBS"
+    LIBS="-lcuda -lcudart -lcufile -ldl $LIBS"
   else
     if test "$libcufile" = "yes" ; then
       feature_not_found "libcufile" ""

--- a/engines/libcufile.c
+++ b/engines/libcufile.c
@@ -606,6 +606,7 @@ FIO_STATIC struct ioengine_ops ioengine = {
 	.version             = FIO_IOOPS_VERSION,
 	.init                = fio_libcufile_init,
 	.queue               = fio_libcufile_queue,
+	.get_file_size       = generic_get_file_size,
 	.open_file           = fio_libcufile_open_file,
 	.close_file          = fio_libcufile_close_file,
 	.iomem_alloc         = fio_libcufile_iomem_alloc,


### PR DESCRIPTION
libcufile: use generic_get_file_size

In libcufile ioengine_ops, set get_file_size to generic_get_file_size.

Fixes #1213.

Signed-off-by: Brian T. Smith <bsmith@systemfabricworks.com>