### PR TITLE
Add cpu/op and CPU usr/sys ms to json

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -4187,6 +4187,7 @@ group) the output looks like::
 	  lat (msec)   : 2=4.16%, 4=1.84%, 10=4.90%, 20=11.33%, 50=5.37%
 	  lat (msec)   : 100=0.65%
 	  cpu          : usr=0.27%, sys=0.18%, ctx=12072, majf=0, minf=21
+	  cpu/op       : 42.70 (cpu usec/op)
 	  IO depths    : 1=85.0%, 2=13.1%, 4=1.8%, 8=0.1%, 16=0.0%, 32=0.0%, >=64=0.0%
 	     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
 	     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
@@ -4260,6 +4261,11 @@ writes in the example above).  In the order listed, they denote:
 		finally the number of major and minor page faults. The CPU utilization
 		numbers are averages for the jobs in that reporting group, while the
 		context and fault counters are summed.
+**cpu/op**
+                Average CPU time per operation. The CPU time includes user and
+                system CPU times for this thread. All operations in this thread
+                are included: read, write, and trims. The unit of the metric is
+                the CPU time in microseconds per operation (usec/op).
 
 **IO depths**
 		The distribution of I/O depths over the job lifetime.  The numbers are

--- a/fio.1
+++ b/fio.1
@@ -3854,6 +3854,7 @@ group) the output looks like:
 		  lat (msec)   : 2=4.16%, 4=1.84%, 10=4.90%, 20=11.33%, 50=5.37%
 		  lat (msec)   : 100=0.65%
 		  cpu          : usr=0.27%, sys=0.18%, ctx=12072, majf=0, minf=21
+		  cpu/op       : 42.70 (cpu usec/op)
 		  IO depths    : 1=85.0%, 2=13.1%, 4=1.8%, 8=0.1%, 16=0.0%, 32=0.0%, >=64=0.0%
 		     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
 		     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
@@ -3915,6 +3916,12 @@ read/write/trim sections above, the data here and in the remaining
 sections apply to all I/Os for the reporting group. 250=0.04% means that
 0.04% of the I/Os completed in under 250us. 500=64.11% means that 64.11%
 of the I/Os required 250 to 499us for completion.
+.TP
+.B cpu/op
+Average CPU time per operation. The CPU time includes user and system CPU times
+for this thread. All operations in this thread are included: read, write, and
+trims. The unit of the metric is the CPU time in microseconds per operation
+(usec/op).
 .TP
 .B cpu
 CPU usage. User and system time, along with the number of context

--- a/stat.c
+++ b/stat.c
@@ -1732,6 +1732,8 @@ static struct json_object *show_thread_status_json(struct thread_stat *ts,
 	json_object_add_value_int(root, "job_runtime", ts->total_run_time);
 	json_object_add_value_float(root, "usr_cpu", usr_cpu);
 	json_object_add_value_float(root, "sys_cpu", sys_cpu);
+	json_object_add_value_int(root, "usr_cpu_ms", ts->usr_time);
+	json_object_add_value_int(root, "sys_cpu_ms", ts->sys_time);
 	json_object_add_value_float(root, "cpu_usec_per_op", cpu_per_op);
 	json_object_add_value_int(root, "ctx", ts->ctx);
 	json_object_add_value_int(root, "majf", ts->majf);

--- a/stat.c
+++ b/stat.c
@@ -1162,7 +1162,7 @@ static void show_thread_status_normal(struct thread_stat *ts,
 				      struct group_run_stats *rs,
 				      struct buf_output *out)
 {
-	double usr_cpu, sys_cpu;
+	double usr_cpu, sys_cpu, cpu_per_op;
 	unsigned long runtime;
 	double io_u_dist[FIO_IO_U_MAP_NR];
 	time_t time_p;
@@ -1214,11 +1214,15 @@ static void show_thread_status_normal(struct thread_stat *ts,
 		sys_cpu = 0;
 	}
 
+	cpu_per_op = (1000.0 * (ts->usr_time + ts->sys_time)) /
+			ddir_rw_sum(ts->total_io_u);
+
 	log_buf(out, "  cpu          : usr=%3.2f%%, sys=%3.2f%%, ctx=%llu,"
 		 " majf=%llu, minf=%llu\n", usr_cpu, sys_cpu,
 			(unsigned long long) ts->ctx,
 			(unsigned long long) ts->majf,
 			(unsigned long long) ts->minf);
+	log_buf(out, "  cpu/op       : %3.2f (cpu usec/op)\n", cpu_per_op);
 
 	stat_calc_dist(ts->io_u_map, ddir_rw_sum(ts->total_io_u), io_u_dist);
 	log_buf(out, "  IO depths    : 1=%3.1f%%, 2=%3.1f%%, 4=%3.1f%%, 8=%3.1f%%,"
@@ -1685,7 +1689,7 @@ static struct json_object *show_thread_status_json(struct thread_stat *ts,
 	double io_u_lat_n[FIO_IO_U_LAT_N_NR];
 	double io_u_lat_u[FIO_IO_U_LAT_U_NR];
 	double io_u_lat_m[FIO_IO_U_LAT_M_NR];
-	double usr_cpu, sys_cpu;
+	double usr_cpu, sys_cpu, cpu_per_op;
 	int i;
 	size_t size;
 
@@ -1723,9 +1727,12 @@ static struct json_object *show_thread_status_json(struct thread_stat *ts,
 		usr_cpu = 0;
 		sys_cpu = 0;
 	}
+	cpu_per_op = 1000.0 * (ts->usr_time + ts->sys_time) /
+			ddir_rw_sum(ts->total_io_u);
 	json_object_add_value_int(root, "job_runtime", ts->total_run_time);
 	json_object_add_value_float(root, "usr_cpu", usr_cpu);
 	json_object_add_value_float(root, "sys_cpu", sys_cpu);
+	json_object_add_value_float(root, "cpu_usec_per_op", cpu_per_op);
 	json_object_add_value_int(root, "ctx", ts->ctx);
 	json_object_add_value_int(root, "majf", ts->majf);
 	json_object_add_value_int(root, "minf", ts->minf);


### PR DESCRIPTION
Add cpu/op and CPU usr/sys ms to json

Having these times might be useful to calculate any events waited by the CPU time (e.g. CPU/op).

Signed-off-by: Luis Useche <useche@gmail.com>