### PR TITLE
Lintian manpage fixes

### DIFF
--- a/fio.1
+++ b/fio.1
@@ -830,7 +830,7 @@ so. Default: false.
 .BI max_open_zones \fR=\fPint
 When running a random write test across an entire drive many more zones will be
 open than in a typical application workload. Hence this command line option
-that allows to limit the number of open zones. The number of open zones is
+that allows one to limit the number of open zones. The number of open zones is
 defined as the number of zones to which write commands are issued by all
 threads/processes.
 .TP
@@ -1224,7 +1224,7 @@ map. For the \fBnormal\fR distribution, a normal (Gaussian) deviation is
 supplied as a value between 0 and 100.
 .P
 The second, optional float is allowed for \fBpareto\fR, \fBzipf\fR and \fBnormal\fR
-distributions. It allows to set base of distribution in non-default place, giving
+distributions. It allows one to set base of distribution in non-default place, giving
 more control over most probable outcome. This value is in range [0-1] which maps linearly to
 range of possible random values.
 Defaults are: random for \fBpareto\fR and \fBzipf\fR, and 0.5 for \fBnormal\fR.
@@ -4213,7 +4213,7 @@ This format is not supported in fio versions >= 1.20\-rc3.
 .TP
 .B Trace file format v2
 The second version of the trace file format was added in fio version 1.17. It
-allows to access more then one file per trace and has a bigger set of possible
+allows one to access more then one file per trace and has a bigger set of possible
 file actions.
 .RS
 .P

--- a/fio.1
+++ b/fio.1
@@ -569,7 +569,7 @@ by this option will be \fBsize\fR divided by number of files unless an
 explicit size is specified by \fBfilesize\fR.
 .RS
 .P
-Each colon in the wanted path must be escaped with a '\\'
+Each colon in the wanted path must be escaped with a '\e'
 character. For instance, if the path is `/dev/dsk/foo@3,0:c' then you
 would use `filename=/dev/dsk/foo@3,0\\:c' and if the path is
 `F:\\filename' then you would use `filename=F\\:\\filename'.


### PR DESCRIPTION
Spelling and markup fixes for man 1 fio reported by lintian (a Debian package linter) while reviewing the package.