### PR TITLE
Fix libaio engine with nowait option

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -2069,6 +2069,10 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 				icd->error = ret;
 		}
 	} else if (io_u->error) {
+		if (io_u->error == EAGAIN) {
+			requeue_io_u(td, io_u_ptr);
+			return;
+		}
 		icd->error = io_u->error;
 		io_u_log_error(td, io_u);
 	}


### PR DESCRIPTION
This PR fixed an issue when `nowait` option is used for the libaio engine.
Specifically, the completion events can contain an EAGAIN error, which
will fail fio in the current implementation.  This change requeues the I/O
request.
