### PR TITLE
Improve IOPs 50% by avoiding clock sampling when rate options not used

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -785,7 +785,15 @@ static enum fio_ddir get_rw_ddir(struct thread_data *td)
 	else
 		ddir = DDIR_INVAL;
 
-	td->rwmix_ddir = rate_ddir(td, ddir);
+	if (!should_check_rate(td)) {
+		/*
+		 * avoid time-consuming call to utime_since_now() if rate checking
+		 * isn't being used. this imrpoves IOPs 50%. See:
+		 * https://github.com/axboe/fio/issues/1501#issuecomment-1418327049
+		 */
+		td->rwmix_ddir = ddir;
+	} else
+		td->rwmix_ddir = rate_ddir(td, ddir);
 	return td->rwmix_ddir;
 }
 


### PR DESCRIPTION
Profiling revealed thread_main() is spending 50% of its time in calls to utime_since_now() from rate_ddir(). This call is only necessary if the user specified a rate option for the job. A conditional was added to avoid the call if !should_check_rate(). See this link for details and profiling data:

https://github.com/axboe/fio/issues/1501#issuecomment-1418327049

Signed-off-by: Adam Horshack (horshack@live.com)