### PR TITLE
SIGSEGV / Exit 139 when write_iolog used with io_submit_mode=offload

### DIFF
--- a/rate-submit.c
+++ b/rate-submit.c
@@ -154,6 +154,7 @@ static int io_workqueue_init_worker_fn(struct submit_worker *sw)
 	dup_files(td, parent);
 	td->eo = parent->eo;
 	fio_options_mem_dupe(td);
+	td->iolog_f = parent->iolog_f;
 
 	if (ioengine_load(td))
 		goto err;


### PR DESCRIPTION
Segmentation fault when log_io_u() attempts to write an entry to a user-specified write_iolog file, if the I/O is issued from an offload thread created by io_submit_mode=offload. Call path:

rate-submit.c::io_workqueue_fn() -> td_io_queue() -> log_io_u(td, io_u)

The log file handle in thread_data->iolog_f opened by init_iolog() is not being copied to the offload thread's private copy of thread_data, causing a NULL deference when fprintf() is called to write to the log file.

Fix is to copy the main thread's td->iolog_f to the offload thread's td at creation time. Seems a bit disjointed to be copying individual fields between these two structures on an as-needed basis rather than having a mechanism to replicate the entire structure, or at least replicating the I/O submission specific fields by moving them into a nested structure that's copied wholesale in io_workqueue_init_worker_fn() - that way future code changes to the I/O submission path wont cause the same bug for fields needed by both the inline and offline submission paths.

Signed-off-by: Adam Horshack (horshack@live.com)
