### PR TITLE
Suppress sync engine QD > 1 warning if io_submit_mode is offload

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1796,7 +1796,7 @@ static void *thread_main(void *data)
 	if (td_io_init(td))
 		goto err;
 
-	if (td_ioengine_flagged(td, FIO_SYNCIO) && td->o.iodepth > 1) {
+	if (td_ioengine_flagged(td, FIO_SYNCIO) && td->o.iodepth > 1 && td->o.io_submit_mode != IO_MODE_OFFLOAD) {
 		log_info("note: both iodepth >= 1 and synchronous I/O engine "
 			 "are selected, queue depth will be capped at 1\n");
 	}


### PR DESCRIPTION
The user is warned if iodepth > 1 when using a synchronous I/O engine, since the engine can only submit one I/O at a time. This warning is not accounting for the case of the user enabling I/O submission offload threads via io_submit_mode=offload. Modified the warning conditional to suppress the warning when this is the case.

Signed-off-by: Adam Horshack (horshack@live.com)
