### PR TITLE
Hang when ioengine=net and verify_backlog

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1070,7 +1070,8 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 		if (td_write(td) && io_u->ddir == DDIR_WRITE &&
 		    td->o.do_verify &&
 		    td->o.verify != VERIFY_NONE &&
-		    !td->o.experimental_verify)
+		    !td->o.experimental_verify &&
+		    !td_ioengine_flagged(td, FIO_UNIDIR))
 			log_io_piece(td, io_u);
 
 		if (td->o.io_submit_mode == IO_MODE_OFFLOAD) {


### PR DESCRIPTION
The net engine only supports uni-direction workloads. This means verify operations for write workloads aren't supported. There is already logic to prevent post-workload verifies but no logic to prevent the in-workload verifies performed when verify_backlog is enabled.

The fix is to prevent in-workload verifies for FIO_UNIDIR engines. There are several options on where to place this conditional but I found an existing conditional that prevents the logging of writes to log_io_piece() when verify is disabled, and check_get_verify() already depends on this behavior to not perform in-workload verifies for other cases (it doesn't check if verify is disabled - it relies on the absence of entries in log_io_piece). So I placed the check for FIO_UNIDIR there.

My grasp of these distributed, interdependent state checks across modules is tenuous so please review this fix carefully.

Signed-off-by: Adam Horshack (horshack@live.com)
