### PR TITLE
Read stats for backlog verifies not reported for time-expired work…

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1919,7 +1919,8 @@ static void *thread_main(void *data)
 			}
 		} while (1);
 
-		if (td_read(td) && td->io_bytes[DDIR_READ])
+		if (td->io_bytes[DDIR_READ] && (td_read(td) ||
+			((td->flags & TD_F_VER_BACKLOG) && td_write(td))))
 			update_runtime(td, elapsed_us, DDIR_READ);
 		if (td_write(td) && td->io_bytes[DDIR_WRITE])
 			update_runtime(td, elapsed_us, DDIR_WRITE);


### PR DESCRIPTION
…loads

When verify_backlog is used on a write-only workload with a runtime= value and the runtime expires before the workload has written its full dataset, the read stats for the backlog verifies are not reported, resulting in a stat result showing only the workload writes (ie, the "read:" results section is completely missing from fio's stats output)

The logic in thread_main() fails to call update_runtime() for DDIR_READ because the existing call to update_runtime() for DDIR_READ on write-only workloads is currently only done after do_verify() is complete, which wont be called in this scenario because td->terminate is true due to the expiration of the runtime.

I'm not up to speed on fio's stats logic so please review this fix carefully. For example, it appears to be ok to call update_runtime() multiple times for a given DDIR_* value, as this is already done for mix read-write workloads that have verify_backlog enabled - once for the backlog reads and again for any remaining verify reads performed by do_verify().

Issue link: https://github.com/axboe/fio/issues/1515

Signed-off-by: Adam Horshack (horshack@live.com)
