### PR TITLE
Bad header rand_seed with time_based or loops with randrepeat=0 verify

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -258,6 +258,7 @@ struct thread_data {
 
 	struct frand_state bsrange_state[DDIR_RWDIR_CNT];
 	struct frand_state verify_state;
+	struct frand_state verify_state_last_do_io;
 	struct frand_state trim_state;
 	struct frand_state delay_state;
 


### PR DESCRIPTION
Verify fails with "bad header rand_seed" when multiple iterations of do_io() execute (time_based=1 or loops>0), with verify enabled and randrepeat=0

The root cause is do_verify() resetting the verify seed back to the job-init value, which works for verification of the first iteration of do_io() but fails for subsequent iterations because the seed is left in its post-do_io() state after the first do_verify(), which means different rand values for the second iteration of do_io() yet the second iteration of do_verify() will revert back again to the job-init seed value.

The fix is to revert the verify seed for randrepeat=0 back to ts state when do_io() last ran rather than to its job-init value. That will allow do_verify() to use the correct seed for each iteration while still retaining a per-iteration unique verify seed.

Link: https://github.com/axboe/fio/issues/1517#issuecomment-1430282533

Signed-off-by: Adam Horshack (horshack@live.com)