### PR TITLE
fix fiologparser.py to work with new logging format

### DIFF
--- a/tools/fiologparser.py
+++ b/tools/fiologparser.py
@@ -166,7 +166,7 @@ class TimeSeries(object):
         f = open(fn, 'r')
         p_time = 0
         for line in f:
-            (time, value, foo, bar) = line.rstrip('\r\n').rsplit(', ')
+            (time, value) = line.rstrip('\r\n').rsplit(', ')[:2]
             self.add_sample(p_time, int(time), int(value))
             p_time = int(time)
  


### PR DESCRIPTION
The logging format updates documented in 1a953d97 were never propagated to fiologparser.py, which since then has been failing with a ValueError exception.

This commit explicitly limits fiologparser.py to only reading the first 2 columns in the log file, because they are the only columns used.

This is similar to issue #928.