### PR TITLE
Refactor for_each_td() to catch inappropriate td ptr reuse

### DIFF
--- a/dedupe.c
+++ b/dedupe.c
@@ -7,16 +7,13 @@
  */
 int init_global_dedupe_working_set_seeds(void)
 {
-	int i;
-	struct thread_data *td;
-
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if (!td->o.dedupe_global)
 			continue;
 
 		if (init_dedupe_working_set_seeds(td, 1))
 			return 1;
-	}
+	} end_for_each();
 
 	return 0;
 }

--- a/engines/libblkio.c
+++ b/engines/libblkio.c
@@ -283,16 +283,14 @@ static bool possibly_null_strs_equal(const char *a, const char *b)
  */
 static int total_threaded_subjobs(bool hipri)
 {
-	struct thread_data *td;
-	unsigned int i;
 	int count = 0;
 
-	for_each_td(td, i) {
+	for_each_td(td) {
 		const struct fio_blkio_options *options = td->eo;
 		if (strcmp(td->o.ioengine, "libblkio") == 0 &&
 		    td->o.use_thread && (bool)options->hipri == hipri)
 			++count;
-	}
+	} end_for_each();
 
 	return count;
 }

--- a/eta.c
+++ b/eta.c
@@ -381,8 +381,7 @@ bool eta_time_within_slack(unsigned int time)
  */
 bool calc_thread_status(struct jobs_eta *je, int force)
 {
-	struct thread_data *td;
-	int i, unified_rw_rep;
+	int unified_rw_rep;
 	uint64_t rate_time, disp_time, bw_avg_time, *eta_secs;
 	unsigned long long io_bytes[DDIR_RWDIR_CNT] = {};
 	unsigned long long io_iops[DDIR_RWDIR_CNT] = {};
@@ -416,7 +415,7 @@ bool calc_thread_status(struct jobs_eta *je, int force)
 
 	bw_avg_time = ULONG_MAX;
 	unified_rw_rep = 0;
-	for_each_td(td, i) {
+	for_each_td(td) {
 		unified_rw_rep += td->o.unified_rw_rep;
 		if (is_power_of_2(td->o.kb_base))
 			je->is_pow2 = 1;
@@ -458,9 +457,9 @@ bool calc_thread_status(struct jobs_eta *je, int force)
 			je->nr_pending++;
 
 		if (je->elapsed_sec >= 3)
-			eta_secs[i] = thread_eta(td);
+			eta_secs[__td_index] = thread_eta(td);
 		else
-			eta_secs[i] = INT_MAX;
+			eta_secs[__td_index] = INT_MAX;
 
 		check_str_update(td);
 
@@ -477,26 +476,26 @@ bool calc_thread_status(struct jobs_eta *je, int force)
 				}
 			}
 		}
-	}
+	} end_for_each();
 
 	if (exitall_on_terminate) {
 		je->eta_sec = INT_MAX;
-		for_each_td(td, i) {
-			if (eta_secs[i] < je->eta_sec)
-				je->eta_sec = eta_secs[i];
-		}
+		for_each_td_index() {
+			if (eta_secs[__td_index] < je->eta_sec)
+				je->eta_sec = eta_secs[__td_index];
+		} end_for_each();
 	} else {
 		unsigned long eta_stone = 0;
 
 		je->eta_sec = 0;
-		for_each_td(td, i) {
+		for_each_td(td) {
 			if ((td->runstate == TD_NOT_CREATED) && td->o.stonewall)
-				eta_stone += eta_secs[i];
+				eta_stone += eta_secs[__td_index];
 			else {
-				if (eta_secs[i] > je->eta_sec)
-					je->eta_sec = eta_secs[i];
+				if (eta_secs[__td_index] > je->eta_sec)
+					je->eta_sec = eta_secs[__td_index];
 			}
-		}
+		} end_for_each();
 		je->eta_sec += eta_stone;
 	}
 
@@ -505,7 +504,7 @@ bool calc_thread_status(struct jobs_eta *je, int force)
 	fio_gettime(&now, NULL);
 	rate_time = mtime_since(&rate_prev_time, &now);
 
-	if (write_bw_log && rate_time > bw_avg_time && !in_ramp_time(td)) {
+	if (write_bw_log && rate_time > bw_avg_time /* && !in_ramp_time(td) fixme: td isn't valid here */) {
 		calc_rate(unified_rw_rep, rate_time, io_bytes, rate_io_bytes,
 				je->rate);
 		memcpy(&rate_prev_time, &now, sizeof(now));

--- a/fio.h
+++ b/fio.h
@@ -753,9 +753,24 @@ extern void lat_target_reset(struct thread_data *);
 
 /*
  * Iterates all threads/processes within all the defined jobs
+ * Usage:
+ *		for_each_td(var_name_for_td) {
+ *			<< bodoy of your loop >>
+ *			 Note: internally-scoped loop index availble as __td_index
+ *		} end_for_each_td()
  */
-#define for_each_td(td, i)	\
-	for ((i) = 0, (td) = &segments[0].threads[0]; (i) < (int) thread_number; (i)++, (td) = tnumber_to_td((i)))
+#define for_each_td(td)			\
+{								\
+	int __td_index;				\
+	struct thread_data *(td);	\
+	for (__td_index = 0, (td) = &segments[0].threads[0];\
+		__td_index < (int) thread_number; __td_index++, (td) = tnumber_to_td(__td_index))
+#define for_each_td_index()	    \
+{								\
+	int __td_index;				\
+	for (__td_index = 0; __td_index < (int) thread_number; __td_index++)
+#define	end_for_each()	}
+
 #define for_each_file(td, f, i)	\
 	if ((td)->files_index)						\
 		for ((i) = 0, (f) = (td)->files[0];			\

--- a/init.c
+++ b/init.c
@@ -1405,15 +1405,14 @@ static void gen_log_name(char *name, size_t size, const char *logtype,
 
 static int check_waitees(char *waitee)
 {
-	struct thread_data *td;
-	int i, ret = 0;
+	int ret = 0;
 
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if (td->subjob_number)
 			continue;
 
 		ret += !strcmp(td->o.name, waitee);
-	}
+	} end_for_each();
 
 	return ret;
 }
@@ -1448,10 +1447,7 @@ static bool wait_for_ok(const char *jobname, struct thread_options *o)
 
 static int verify_per_group_options(struct thread_data *td, const char *jobname)
 {
-	struct thread_data *td2;
-	int i;
-
-	for_each_td(td2, i) {
+	for_each_td(td2) {
 		if (td->groupid != td2->groupid)
 			continue;
 
@@ -1461,7 +1457,7 @@ static int verify_per_group_options(struct thread_data *td, const char *jobname)
 				jobname);
 			return 1;
 		}
-	}
+	} end_for_each();
 
 	return 0;
 }

--- a/iolog.c
+++ b/iolog.c
@@ -1875,9 +1875,7 @@ void td_writeout_logs(struct thread_data *td, bool unit_logs)
 
 void fio_writeout_logs(bool unit_logs)
 {
-	struct thread_data *td;
-	int i;
-
-	for_each_td(td, i)
+	for_each_td(td) {
 		td_writeout_logs(td, unit_logs);
+	} end_for_each();
 }

--- a/libfio.c
+++ b/libfio.c
@@ -240,13 +240,11 @@ void fio_mark_td_terminate(struct thread_data *td)
 
 void fio_terminate_threads(unsigned int group_id, unsigned int terminate)
 {
-	struct thread_data *td;
 	pid_t pid = getpid();
-	int i;
 
 	dprint(FD_PROCESS, "terminate group_id=%d\n", group_id);
 
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if ((terminate == TERMINATE_GROUP && group_id == TERMINATE_ALL) ||
 		    (terminate == TERMINATE_GROUP && group_id == td->groupid) ||
 		    (terminate == TERMINATE_STONEWALL && td->runstate >= TD_RUNNING) ||
@@ -274,22 +272,20 @@ void fio_terminate_threads(unsigned int group_id, unsigned int terminate)
 					ops->terminate(td);
 			}
 		}
-	}
+	} end_for_each();
 }
 
 int fio_running_or_pending_io_threads(void)
 {
-	struct thread_data *td;
-	int i;
 	int nr_io_threads = 0;
 
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if (td->io_ops_init && td_ioengine_flagged(td, FIO_NOIO))
 			continue;
 		nr_io_threads++;
 		if (td->runstate < TD_EXITED)
 			return 1;
-	}
+	} end_for_each();
 
 	if (!nr_io_threads)
 		return -1; /* we only had cpuio threads to begin with */

--- a/rate-submit.c
+++ b/rate-submit.c
@@ -12,8 +12,7 @@
 
 static void check_overlap(struct io_u *io_u)
 {
-	int i, res;
-	struct thread_data *td;
+	int res;
 
 	/*
 	 * Allow only one thread to check for overlap at a time to prevent two
@@ -31,7 +30,7 @@ static void check_overlap(struct io_u *io_u)
 	assert(res == 0);
 
 retry:
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if (td->runstate <= TD_SETTING_UP ||
 		    td->runstate >= TD_FINISHING ||
 		    !td->o.serialize_overlap ||
@@ -46,7 +45,7 @@ retry:
 		res = pthread_mutex_lock(&overlap_check);
 		assert(res == 0);
 		goto retry;
-	}
+	} end_for_each();
 }
 
 static int io_workqueue_fn(struct submit_worker *sw,

--- a/zbd.c
+++ b/zbd.c
@@ -524,11 +524,10 @@ out:
 /* Verify whether direct I/O is used for all host-managed zoned block drives. */
 static bool zbd_using_direct_io(void)
 {
-	struct thread_data *td;
 	struct fio_file *f;
-	int i, j;
+	int j;
 
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if (td->o.odirect || !(td->o.td_ddir & TD_DDIR_WRITE))
 			continue;
 		for_each_file(td, f, j) {
@@ -536,7 +535,7 @@ static bool zbd_using_direct_io(void)
 			    f->zbd_info->model == ZBD_HOST_MANAGED)
 				return false;
 		}
-	}
+	} end_for_each();
 
 	return true;
 }
@@ -639,27 +638,25 @@ static bool zbd_zone_align_file_sizes(struct thread_data *td,
  */
 static bool zbd_verify_sizes(void)
 {
-	struct thread_data *td;
 	struct fio_file *f;
-	int i, j;
+	int j;
 
-	for_each_td(td, i) {
+	for_each_td(td) {
 		for_each_file(td, f, j) {
 			if (!zbd_zone_align_file_sizes(td, f))
 				return false;
 		}
-	}
+	} end_for_each();
 
 	return true;
 }
 
 static bool zbd_verify_bs(void)
 {
-	struct thread_data *td;
 	struct fio_file *f;
-	int i, j;
+	int j;
 
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if (td_trim(td) &&
 		    (td->o.min_bs[DDIR_TRIM] != td->o.max_bs[DDIR_TRIM] ||
 		     td->o.bssplit_nr[DDIR_TRIM])) {
@@ -680,7 +677,7 @@ static bool zbd_verify_bs(void)
 				return false;
 			}
 		}
-	}
+	} end_for_each();
 	return true;
 }
 
@@ -1010,11 +1007,10 @@ void zbd_free_zone_info(struct fio_file *f)
  */
 static int zbd_init_zone_info(struct thread_data *td, struct fio_file *file)
 {
-	struct thread_data *td2;
 	struct fio_file *f2;
-	int i, j, ret;
+	int j, ret;
 
-	for_each_td(td2, i) {
+	for_each_td(td2) {
 		for_each_file(td2, f2, j) {
 			if (td2 == td && f2 == file)
 				continue;
@@ -1025,7 +1021,7 @@ static int zbd_init_zone_info(struct thread_data *td, struct fio_file *file)
 			file->zbd_info->refcount++;
 			return 0;
 		}
-	}
+	} end_for_each();
 
 	ret = zbd_create_zone_info(td, file);
 	if (ret < 0)
@@ -1289,13 +1285,10 @@ static uint32_t pick_random_zone_idx(const struct fio_file *f,
 
 static bool any_io_in_flight(void)
 {
-	struct thread_data *td;
-	int i;
-
-	for_each_td(td, i) {
+	for_each_td(td) {
 		if (td->io_u_in_flight)
 			return true;
-	}
+	} end_for_each();
 
 	return false;
 }


### PR DESCRIPTION
I recently introduced a bug caused by reusing a struct thread_data *td after the end of a for_each_td() loop construct.

Link: https://github.com/axboe/fio/pull/1521#issuecomment-1448591102

To prevent others from making this same mistake, this commit refactors for_each_td() so that both the struct thread_data * and the loop index variable are placed inside their own scope for the loop. This will cause any reference to those variables outside the for_each_td() to produce an undeclared identifier error, provided the outer scope doesn't already reuse those same variable names for other code within the routine (which is fine because the scopes are separate).

Because C/C++ doesn't let you declare two different variable types within the scope of a for() loop initializer, creating a scope for both struct thread_data * and the loop index required explicitly declaring a scope with a curly brace. This means for_each_td() includes an opening curly brace to create the scope, which means all uses of for_each_td() must now end with an invocation of a new macro named end_for_each_td() to emit an ending curly brace to match the scope brace created by for_each_td():

	for_each_td(td, i) {
		while (td->runstate < TD_EXITED)
			sleep(1);
	}
	end_for_each_td()

The alternative is to end every for_each_td() construct with an inline curly brace, which is off-putting since the implementation of an extra opening curly brace is abstracted in for_each_td():

	for_each_td(td, i) {
		while (td->runstate < TD_EXITED)
			sleep(1);
	}}

Most fio logic only declares "struct thread_data *td" and "int i" for use in for_each_td(), which means those declarations will now cause -Wunused-variable warnings since they're not used outside the scope the refactored for_each_td(). Those declarations have been removed.

Implementing this change caught a latent bug in eta.c::calc_thread_status() that accesses the ending value of struct thread_data *td after the end of for_each_td(), now manifesting as a compile error, so working as designed :) That bug is corrected as part of this commit.

Signed-off-by: Adam Horshack (horshack@live.com)
