### PR TITLE
fio: Append "filecreate/filestat/filedelete" to 'readwrite=' field.

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -1149,6 +1149,12 @@ I/O type
 		**randtrimwrite**
 				Like trimwrite, but uses random offsets rather
 				than sequential writes.
+		**filecreate**
+				Create a batch of files. Must also set ``ioengine=filecreate``.
+		**filestat**
+				Stat a batch of files. Must also set ``ioengine=filestat``.
+		**filedelete**
+				Delete a batch of files. Must also set ``ioengine=filedelete``.
 
 	Fio defaults to read if the option is not specified.  For the mixed I/O
 	types, the default is to split them 50/50.  For certain types of I/O the
@@ -2155,18 +2161,21 @@ I/O engine
 			details of writing an external I/O engine.
 
 		**filecreate**
-			Simply create the files and do no I/O to them.  You still need to
-			set  `filesize` so that all the accounting still occurs, but no
-			actual I/O will be done other than creating the file.
+			Simply create the files and do no I/O to them. Must also set
+			``readwrite=filecreate``. You still need to set  `filesize` so
+			that all the accounting still occurs, but no actual I/O will
+			be done other than creating the file.
 
 		**filestat**
-			Simply do stat() and do no I/O to the file. You need to set 'filesize'
-			and 'nrfiles', so that files will be created.
+			Simply do stat() and do no I/O to the file. Must also set
+			``readwrite=filestat``. You need to set `filesize` and `nrfiles`,
+			so that files will be created.
 			This engine is to measure file lookup and meta data access.
 
 		**filedelete**
-			Simply delete the files by unlink() and do no I/O to them. You need to set 'filesize'
-			and 'nrfiles', so that the files will be created.
+			Simply delete the files by unlink() and do no I/O to them.
+			Must also set ``readwrite=filedelete``. You need to set `filesize`
+			and `nrfiles`, so that the files will be created.
 			This engine is to measure file delete.
 
 		**libpmem**

--- a/backend.c
+++ b/backend.c
@@ -1937,6 +1937,9 @@ static void *thread_main(void *data)
 			update_runtime(td, elapsed_us, DDIR_WRITE);
 		if (td_trim(td) && td->io_bytes[DDIR_TRIM])
 			update_runtime(td, elapsed_us, DDIR_TRIM);
+		if (td_fileoperate(td) && td->io_bytes[DDIR_FILE_OP])
+			update_runtime(td, elapsed_us, DDIR_FILE_OP);
+
 		fio_gettime(&td->start, NULL);
 		fio_sem_up(stat_sem);
 

--- a/engines/fileoperations.c
+++ b/engines/fileoperations.c
@@ -245,12 +245,11 @@ static int init(struct thread_data *td)
 
 	data = calloc(1, sizeof(*data));
 
-	if (td_read(td))
-		data->stat_ddir = DDIR_READ;
-	else if (td_write(td))
-		data->stat_ddir = DDIR_WRITE;
+	if (td_fileoperate(td))
+		data->stat_ddir = DDIR_FILE_OP;
 
 	td->io_ops_data = data;
+	td->file_op_flag = DDIR_FILE_OP_MASK;
 	return 0;
 }
 

--- a/examples/filecreate-ioengine.fio
+++ b/examples/filecreate-ioengine.fio
@@ -10,6 +10,7 @@
 # IO will not really be done and the write latency numbers will only reflect the
 # open times.
 [global]
+rw=filecreate
 create_on_open=1
 nrfiles=31250
 ioengine=filecreate

--- a/examples/filedelete-ioengine.fio
+++ b/examples/filedelete-ioengine.fio
@@ -5,6 +5,7 @@
 # 'unlink' is better set to 0, since the file is deleted in measurement.
 # the options disabled completion latency output such as 'disable_clat' and 'gtod_reduce' must not set.
 [global]
+rw=filedelete
 ioengine=filedelete
 filesize=4k
 nrfiles=200

--- a/examples/filestat-ioengine.fio
+++ b/examples/filestat-ioengine.fio
@@ -4,6 +4,7 @@
 # 'filesize' must be set, then files will be created at setup stage.
 
 [global]
+rw=filestat
 ioengine=filestat
 numjobs=1
 filesize=4k

--- a/fio.1
+++ b/fio.1
@@ -919,6 +919,16 @@ other Fio options limiting the total bytes or number of I/O's.
 Like
 .B trimwrite ,
 but uses random offsets rather than sequential writes.
+.TP
+.B filecreate
+Create a batch of files. Must also set `ioengine=filecreate`.
+.TP
+.B filestat
+Stat a batch of files. Must also set `ioengine=filestat`.
+.TP
+.B filedelete
+Delete a batch of files. Must also set `ioengine=filedelete`.
+.TP
 .RE
 .P
 Fio defaults to read if the option is not specified. For the mixed I/O
@@ -1968,18 +1978,18 @@ absolute or relative. See `engines/skeleton_external.c' in the fio source for
 details of writing an external I/O engine.
 .TP
 .B filecreate
-Simply create the files and do no I/O to them.  You still need to set
-\fBfilesize\fR so that all the accounting still occurs, but no actual I/O will be
-done other than creating the file.
+Simply create the files and do no I/O to them. Must also set `readwrite=filecreate`.
+You still need to set \fBfilesize\fR so that all the accounting still occurs,
+but no actual I/O will be done other than creating the file.
 .TP
 .B filestat
-Simply do stat() and do no I/O to the file. You need to set 'filesize'
-and 'nrfiles', so that files will be created.
+Simply do stat() and do no I/O to the file. Must also set `readwrite=filestat`.
+You need to set \fBfilesize\fR and \fBnrfiles\fR, so that files will be created.
 This engine is to measure file lookup and meta data access.
 .TP
 .B filedelete
-Simply delete files by unlink() and do no I/O to the file. You need to set 'filesize'
-and 'nrfiles', so that files will be created.
+Simply delete files by unlink() and do no I/O to the file. Must also set `readwrite=filedelete`.
+You need to set \fBfilesize\fR and \fBnrfiles\fR, so that files will be created.
 This engine is to measure file delete.
 .TP
 .B libpmem

--- a/fio.h
+++ b/fio.h
@@ -191,6 +191,7 @@ struct thread_data {
 	unsigned int thread_number;
 	unsigned int subjob_number;
 	unsigned int groupid;
+	uint32_t file_op_flag;
 	struct thread_stat ts __attribute__ ((aligned(8)));
 
 	int client_type;

--- a/io_u.c
+++ b/io_u.c
@@ -674,7 +674,6 @@ static enum fio_ddir rate_ddir(struct thread_data *td, enum fio_ddir ddir)
 	enum fio_ddir odir = ddir ^ 1;
 	uint64_t usec;
 	uint64_t now;
-
 	assert(ddir_rw(ddir));
 	now = utime_since_now(&td->epoch);
 
@@ -782,6 +781,8 @@ static enum fio_ddir get_rw_ddir(struct thread_data *td)
 		ddir = DDIR_WRITE;
 	else if (td_trim(td))
 		ddir = DDIR_TRIM;
+	else if (td_fileoperate(td))
+		ddir = DDIR_FILE_OP;
 	else
 		ddir = DDIR_INVAL;
 
@@ -1439,7 +1440,7 @@ static void lat_fatal(struct thread_data *td, struct io_u *io_u, struct io_compl
 		log_err("fio: latency of %llu nsec exceeds specified max (%llu nsec): %s %s %llu %llu\n",
 					tnsec, max_nsec,
 					io_u->file->file_name,
-					io_ddir_name(io_u->ddir),
+					io_ddir_name(io_u->ddir | td->file_op_flag),
 					io_u->offset, io_u->buflen);
 	}
 	td_verror(td, ETIMEDOUT, "max latency exceeded");
@@ -1875,7 +1876,7 @@ static void __io_u_log_error(struct thread_data *td, struct io_u *io_u)
 		io_u->file ? " on file " : "",
 		io_u->file ? io_u->file->file_name : "",
 		strerror(io_u->error),
-		io_ddir_name(io_u->ddir),
+		io_ddir_name(io_u->ddir | td->file_op_flag),
 		io_u->offset, io_u->xfer_buflen);
 
 	if (td->io_ops->errdetails) {

--- a/iolog.c
+++ b/iolog.c
@@ -49,7 +49,7 @@ void log_io_u(const struct thread_data *td, const struct io_u *io_u)
 	fio_gettime(&now, NULL);
 	fprintf(td->iolog_f, "%llu %s %s %llu %llu\n",
 		(unsigned long long) utime_since_now(&td->io_log_start_time),
-		io_u->file->file_name, io_ddir_name(io_u->ddir), io_u->offset,
+		io_u->file->file_name, io_ddir_name(io_u->ddir | td->file_op_flag), io_u->offset,
 		io_u->buflen);
 
 }

--- a/options.c
+++ b/options.c
@@ -1979,6 +1979,18 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 			    .oval = TD_DDIR_RANDTRIMWRITE,
 			    .help = "Randomly trim and write mix, trims preceding writes"
 			  },
+			  { .ival = "filecreate",
+			    .oval = TD_DDIR_FILECREATE,
+			    .help = "Create file with file size zero"
+			  },
+			  { .ival = "filestat",
+			    .oval = TD_DDIR_FILESTAT,
+			    .help = "Stat files"
+			  },
+			  { .ival = "filedelete",
+			    .oval = TD_DDIR_FILEDELETE,
+			    .help = "Delete files"
+			  },
 		},
 	},
 	{

--- a/stat.h
+++ b/stat.h
@@ -174,6 +174,7 @@ struct thread_stat {
 	uint32_t members;
 	uint32_t unified_rw_rep;
 	uint32_t disable_prio_stat;
+	uint32_t file_op_flag;
 
 	/*
 	 * bandwidth and latency stats


### PR DESCRIPTION
Specify exact file operation strings for 'readwrite' field in job file, Show correct file operation strings in log.

For file operation measurement, 'rw' field is set to 'read' in job file. The corresponding 'rw' in log is also 'read'. This makes user confused since file operation and IO read are totally different things. In this commit, add 3 new file operations to 'rw' field.

For implementation, TD_DDIR_FILECREATE/TD_DDIR_FILESTAT/TD_DDIR_FILEDELETE are added. Meanwhile, DDIR_FILE_OP is added to identify the file operation and IO operation. DDIR_FILE_OP is same value as DDIR_READ, then clat_stat[DDIR_FILE_READ] can be 'borrowed' for file operation statistics. Just set DDIR_FILE_OP_MASK when get io_ddir_name(). This avoid big code change if add a new index to enum fio_ddir.

With this commit, user can explicitly specify the exact file operation in job file 'rw' field. 'rw' and 'ioengine' must set to same value if anyone is file operation string. 'rw' and 'ddir' string in log are also file operation's.

Example:

$ fio   filestat-ioengine.fio
t0: (g=0): rw=filestat, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=filestat, iodepth=1
t1: (g=0): rw=filestat, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=filestat, iodepth=1
fio-3.33
Starting 2 threads

t0: (groupid=0, jobs=1): err= 0: pid=4744: Thu Nov 10 18:24:00 2022
  file_operation: IOPS=20.0k, BW=78.1MiB/s (81.9MB/s)(80.0KiB/1msec)
    clat (nsec): min=12645, max=29394, avg=13751.35, stdev=3690.55
    clat percentiles (nsec):
     |  1.00th=[12608],  5.00th=[12608], 10.00th=[12736], 20.00th=[12736],
     | 30.00th=[12736], 40.00th=[12736], 50.00th=[12864], 60.00th=[12992],
     | 70.00th=[12992], 80.00th=[13120], 90.00th=[13120], 95.00th=[13760],
     | 99.00th=[29312], 99.50th=[29312], 99.90th=[29312], 99.95th=[29312],
     | 99.99th=[29312]

Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>
