### PR TITLE
fdp cleanup and trim support for io_uring_cmd

### DIFF
--- a/engines/nvme.h
+++ b/engines/nvme.h
@@ -48,6 +48,8 @@ struct nvme_uring_cmd {
 #define NVME_ZNS_ZSA_RESET 0x4
 #define NVME_ZONE_TYPE_SEQWRITE_REQ 0x2
 
+#define NVME_ATTRIBUTE_DEALLOCATE (1 << 2)
+
 enum nvme_identify_cns {
 	NVME_IDENTIFY_CNS_NS		= 0x00,
 	NVME_IDENTIFY_CNS_CSI_NS	= 0x05,
@@ -67,6 +69,7 @@ enum nvme_admin_opcode {
 enum nvme_io_opcode {
 	nvme_cmd_write			= 0x01,
 	nvme_cmd_read			= 0x02,
+	nvme_cmd_dsm			= 0x09,
 	nvme_cmd_io_mgmt_recv		= 0x12,
 	nvme_zns_cmd_mgmt_send		= 0x79,
 	nvme_zns_cmd_mgmt_recv		= 0x7a,
@@ -206,6 +209,15 @@ struct nvme_fdp_ruh_status {
 	__le16 nruhsd;
 	struct nvme_fdp_ruh_status_desc ruhss[];
 };
+
+struct nvme_dsm_range {
+	__le32	cattr;
+	__le32	nlb;
+	__le64	slba;
+};
+
+int fio_nvme_trim(const struct thread_data *td, struct fio_file *f,
+		  unsigned long long offset, unsigned long long len);
 
 int fio_nvme_iomgmt_ruhs(struct thread_data *td, struct fio_file *f,
 			 struct nvme_fdp_ruh_status *ruhs, __u32 bytes);

--- a/fdp.c
+++ b/fdp.c
@@ -119,7 +119,10 @@ void fdp_fill_dspec_data(struct thread_data *td, struct io_u *io_u)
 		return;
 	}
 
-	dspec = ruhs->plis[ruhs->pli_loc++ % ruhs->nr_ruhs];
+	if (ruhs->pli_loc >= ruhs->nr_ruhs)
+		ruhs->pli_loc = 0;
+
+	dspec = ruhs->plis[ruhs->pli_loc++];
 	io_u->dtype = 2;
 	io_u->dspec = dspec;
 }

--- a/stat.c
+++ b/stat.c
@@ -555,7 +555,7 @@ static void show_ddir_status(struct group_run_stats *rs, struct thread_stat *ts,
 
 	iops = (1000 * (uint64_t)ts->total_io_u[ddir]) / runt;
 	iops_p = num2str(iops, ts->sig_figs, 1, 0, N2S_NONE);
-	if (ddir == DDIR_WRITE)
+	if (ddir == DDIR_WRITE || ddir == DDIR_TRIM)
 		post_st = zbd_write_status(ts);
 	else if (ddir == DDIR_READ && ts->cachehit && ts->cachemiss) {
 		uint64_t total;


### PR DESCRIPTION
This series has 2 commits:

1. For fdp remove the usage of expensive modulo operation as the same can be achieved with addition and wrapping around available reclaim unit handles.

2. Add support for trim operation to the io_uring_cmd ioengine. Print ZBD zone reset stats for trim operation.