### PR TITLE
thinktime: Fix missing re-init thinktime when using ramptime

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -376,7 +376,7 @@ struct thread_data {
 
 	uint64_t *thinktime_blocks_counter;
 	struct timespec last_thinktime;
-	uint64_t last_thinktime_blocks;
+	int64_t last_thinktime_blocks;
 
 	/*
 	 * State for random io, a bitmap of blocks done vs not done

--- a/libfio.c
+++ b/libfio.c
@@ -131,9 +131,13 @@ void clear_io_state(struct thread_data *td, int all)
 
 void reset_all_stats(struct thread_data *td)
 {
+	unsigned long long b;
 	int i;
 
 	reset_io_counters(td, 1);
+
+	b = ddir_rw_sum(td->thinktime_blocks_counter);
+	td->last_thinktime_blocks -= b;
 
 	for (i = 0; i < DDIR_RWDIR_CNT; i++) {
 		td->io_bytes[i] = 0;
@@ -148,6 +152,8 @@ void reset_all_stats(struct thread_data *td)
 	memcpy(&td->iops_sample_time, &td->epoch, sizeof(td->epoch));
 	memcpy(&td->bw_sample_time, &td->epoch, sizeof(td->epoch));
 	memcpy(&td->ss.prev_time, &td->epoch, sizeof(td->epoch));
+
+	td->last_thinktime = td->epoch;
 
 	lat_target_reset(td);
 	clear_rusage_stat(td);


### PR DESCRIPTION
Prevent I/O bursts after `ramptime` due to thinktime.

Each thread generates a certain amount of I/O requests, configured by `thinktime_blocks`.
When `ramptime` ends, `thinktime_blocks` can't control I/O. Because `thinktime_blocks` are not reinitialized after `ramptime`.
I fixed it by reinitializing `last_thinktime` and `last_thinktime_blocks` when `ramptime` ended.

Details with figures below:
(cmd: `fio --filename=/dev/nvme0n1 --rw=read --bs=128k --iodepth=256 --size=100% --name=thinktime_test --direct=1 --ramp_time=30 --ioengine=libaio --runtime=20 --time_based --thinktime=500ms --thinktime_blocks=1000 --write_iops_log=/root/fiofix/fixed_fio --log_avg_msec=1000`)

![image](https://user-images.githubusercontent.com/38938801/229055038-bbbedcbf-2527-4018-a0e0-9f0dc6013853.png)
![image](https://user-images.githubusercontent.com/38938801/229055105-3c827fd1-259d-4594-970d-0255c938c640.png)

After debug, iops is being controlled by thinktime_blocks.