### PR TITLE
backend: increase waiting time for the started threads from 100ms to 300ms

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2510,7 +2510,7 @@ reap:
 			if (mtime_since_now(&this_start) > JOB_START_TIMEOUT)
 				break;
 
-			do_usleep(100000);
+			do_usleep(300000);
 
 			for (i = 0; i < this_jobs; i++) {
 				td = map[i];


### PR DESCRIPTION
backend: increase waiting time for the started threads from 100ms to 300ms

When the device's Identify CMD takes mor than 100ms, Random Read Performance is dropped. Increasing waiting time is helpful for this issue.

Signed-off-by: Chanhyun Park <chanhyun0708@gmail.com>