### PR TITLE
engines/libaio: fix io_getevents min/max events arguments

### DIFF
--- a/engines/libaio.c
+++ b/engines/libaio.c
@@ -288,14 +288,16 @@ static int fio_libaio_getevents(struct thread_data *td, unsigned int min,
 		    && actual_min == 0
 		    && ((struct aio_ring *)(ld->aio_ctx))->magic
 				== AIO_RING_MAGIC) {
-			r = user_io_getevents(ld->aio_ctx, max,
+			r = user_io_getevents(ld->aio_ctx, max - events,
 				ld->aio_events + events);
 		} else {
 			r = io_getevents(ld->aio_ctx, actual_min,
-				max, ld->aio_events + events, lt);
+				max - events, ld->aio_events + events, lt);
 		}
-		if (r > 0)
+		if (r > 0) {
 			events += r;
+			actual_min = actual_min > events ? actual_min - events : 0;
+		}
 		else if ((min && r == 0) || r == -EAGAIN) {
 			fio_libaio_commit(td);
 			if (actual_min)


### PR DESCRIPTION
If the io_getevents system call is interrupted, it can succeed while returning less than the min_nr requested events. If this occurs during the final reaping of events, libaio will call io_getevents again wtih the same minimum events argument. Since some of the events have already been reaped, this results in a hang. To fix this, update the arguments for io_getevents based on the previously seen events.
