### PR TITLE
engines/io_uring: update getevents max to reflect previously seen events

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -529,6 +529,7 @@ static int fio_ioring_getevents(struct thread_data *td, unsigned int min,
 		r = fio_ioring_cqring_reap(td, events, max);
 		if (r) {
 			events += r;
+			max -= r;
 			if (actual_min != 0)
 				actual_min -= r;
 			continue;


### PR DESCRIPTION
To ensure we don't return more than the requested number of events, update the max events variable after reaping events before subsequent calls to io_getevents system call.
