### PR TITLE
Add LoongArch64 support

### DIFF
--- a/arch/arch-loongarch64.h
+++ b/arch/arch-loongarch64.h
@@ -1,0 +1,10 @@
+#ifndef ARCH_LOONGARCH64_H
+#define ARCH_LOONGARCH64_H
+
+#define FIO_ARCH	(arch_loongarch64)
+
+#define read_barrier()		__asm__ __volatile__("dbar 0": : :"memory")
+#define write_barrier()		__asm__ __volatile__("dbar 0": : :"memory")
+#define nop			__asm__ __volatile__("dbar 0": : :"memory")
+
+#endif

--- a/arch/arch.h
+++ b/arch/arch.h
@@ -23,6 +23,7 @@ enum {
 	arch_hppa,
 	arch_mips,
 	arch_aarch64,
+	arch_loongarch64,
 
 	arch_generic,
 
@@ -97,6 +98,8 @@ extern unsigned long arch_flags;
 #include "arch-hppa.h"
 #elif defined(__aarch64__)
 #include "arch-aarch64.h"
+#elif defined(__loongarch64)
+#include "arch-loongarch64.h"
 #else
 #warning "Unknown architecture, attempting to use generic model."
 #include "arch-generic.h"

--- a/configure
+++ b/configure
@@ -499,13 +499,15 @@ elif check_define __aarch64__ ; then
   cpu="aarch64"
 elif check_define __hppa__ ; then
   cpu="hppa"
+elif check_define __loongarch64 ; then
+  cpu="loongarch64"
 else
   cpu=`uname -m`
 fi
 
 # Normalise host CPU name and set ARCH.
 case "$cpu" in
-  ia64|ppc|ppc64|s390|s390x|sparc64)
+  ia64|ppc|ppc64|s390|s390x|sparc64|loongarch64)
     cpu="$cpu"
   ;;
   i386|i486|i586|i686|i86pc|BePC)

--- a/libfio.c
+++ b/libfio.c
@@ -74,6 +74,7 @@ static const char *fio_arch_strings[arch_nr] = {
 	"hppa",
 	"mips",
 	"aarch64",
+	"loongarch64",
 	"generic"
 };
 

--- a/os/os-linux-syscall.h
+++ b/os/os-linux-syscall.h
@@ -270,6 +270,22 @@
 #define __NR_ioprio_get		31
 #endif
 
+/* Linux syscalls for loongarch64 */
+#elif defined(ARCH_LOONGARCH64_H)
+#ifndef __NR_ioprio_set
+#define __NR_ioprio_set         30
+#define __NR_ioprio_get         31
+#endif
+
+#ifndef __NR_fadvise64
+#define __NR_fadvise64          223
+#endif
+
+#ifndef __NR_sys_splice
+#define __NR_sys_splice         76
+#define __NR_sys_tee          	77
+#define __NR_sys_vmsplice       75
+#endif
 #else
 #warning "Unknown architecture"
 #endif


### PR DESCRIPTION
Hi,There are many warnings when compiling on the LoongArch64 architecture, for example：
> crc/../arch/arch.h:101:2: warning: #warning "Unknown architecture, attempting to use generic model." [-Wcpp]
  101 | #warning "Unknown architecture, attempting to use generic model."
      |  ^~~~~~~
In file included from crc/../os/os-linux.h:40,
                 from crc/../os/os.h:37,
                 from crc/crc32c-arm64.c:2:
crc/../os/./os-linux-syscall.h:274:2: warning: #warning "Unknown architecture" [-Wcpp]
  274 | #warning "Unknown architecture"

So I submitted this pr to add LoongArch64 port.

About LoongArch:
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:https://loongson.github.io/LoongArch-Documentation/README-EN.html

thanks.
