### PR TITLE
fix: assign NULL after free (Use-After-Free at parse.c:1508)

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2485,6 +2485,7 @@ reap:
 				} else if (__td_index == fio_debug_jobno)
 					*fio_debug_jobp = pid;
 				free(eo);
+				eo = NULL;
 				free(fd);
 				fd = NULL;
 			}


### PR DESCRIPTION
**Description: Address Sanitizer detected use-after-free at parse.c:1508. it frees if a dereference of the ptr is not NULL, but eo had freed and not assigned with NULL at backend.c:2487.**

`options_free` in parse.c:1496 automatically frees objects if the target pointer of the target object is not NULL.
![image](https://github.com/axboe/fio/assets/17183234/77d0f85a-29d7-4fe0-8501-71bbdc470abc)

However, at backend.c:2487, eo did not be assigned by NULL although it was freed.
![image](https://github.com/axboe/fio/assets/17183234/a5013008-c484-4d74-8150-e7d7a5eae615)


```
=================================================================
==1712810==ERROR: AddressSanitizer: heap-use-after-free on address 0x6040000002b8 at pc 0x000000583871 bp 0x7ffe93e61400 sp 0x7ffe93e613e8
READ of size 8 at 0x6040000002b8 thread T0
    #0 0x583870 in options_free /home/qbit/testing-2023/fio/parse.c:1508:7
    #1 0x58b858 in fio_options_free /home/qbit/testing-2023/fio/options.c:5786:3
    #2 0x5bb400 in fio_backend /home/qbit/testing-2023/fio/backend.c:2647:3
    #3 0x60b44b in main /home/qbit/testing-2023/fio/fio.c:60:9
    #4 0x7fe832a81d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #5 0x7fe832a81e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #6 0x42ce24 in _start (/home/qbit/testing-2023/fio/fio+0x42ce24)

0x6040000002b8 is located 40 bytes inside of 48-byte region [0x604000000290,0x6040000002c0)
freed by thread T0 here:
    #0 0x4d7a97 in free /home/qbit/D-CMA/LLVM/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cpp:123:3
    #1 0x5babd9 in run_threads /home/qbit/testing-2023/fio/backend.c:2487:5
    #2 0x5babd9 in fio_backend /home/qbit/testing-2023/fio/backend.c:2626:2
    #3 0x60b44b in main /home/qbit/testing-2023/fio/fio.c:60:9

previously allocated by thread T0 here:
    #0 0x4d7d8f in malloc /home/qbit/D-CMA/LLVM/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x530cb6 in ioengine_load /home/qbit/testing-2023/fio/init.c:1177:12

SUMMARY: AddressSanitizer: heap-use-after-free /home/qbit/testing-2023/fio/parse.c:1508:7 in options_free
Shadow bytes around the buggy address:
  0x0c087fff8000: fa fa fd fd fd fd fd fa fa fa 00 00 00 00 00 01
  0x0c087fff8010: fa fa 00 00 00 00 01 fa fa fa 00 00 00 00 02 fa
  0x0c087fff8020: fa fa 00 00 00 00 02 fa fa fa 00 00 00 00 01 fa
  0x0c087fff8030: fa fa 00 00 00 00 00 04 fa fa fd fd fd fd fd fa
  0x0c087fff8040: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fd
=>0x0c087fff8050: fa fa fd fd fd fd fd[fd]fa fa fd fd fd fd fd fa
  0x0c087fff8060: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x0c087fff8070: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff8080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff8090: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c087fff80a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==1712810==ABORTING
```