### PR TITLE
fix: io_uring sqpoll issue_time not inited when kernel not read sqring

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -646,7 +646,7 @@ static int fio_ioring_commit(struct thread_data *td)
 	 */
 	if (o->sqpoll_thread) {
 		struct io_sq_ring *ring = &ld->sq_ring;
-		unsigned start = *ld->sq_ring.head;
+		unsigned start = *ld->sq_ring.tail - ld->queued;
 		unsigned flags;
 
 		flags = atomic_load_acquire(ring->flags);


### PR DESCRIPTION
In io_uring sqpoll mode, when kernel side thread has not yet read  the sqring before second fio_ioring_commit() called, the sq_ring.head will remain the same. The second fio_ioring_commit() will initialize the wrong io_u's issue_time. This old(in head) io_u‘s issue_time will to be initialized twice and new(in tail - 1) io_u's's issue_time will not to be initialized. This problem will cause clat is weird, sometimes larger than lat.

Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>
