### PR TITLE
fix: io_uring sqpoll issue_time empty when kernel not yet read sq

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -646,7 +646,7 @@ static int fio_ioring_commit(struct thread_data *td)
 	 */
 	if (o->sqpoll_thread) {
 		struct io_sq_ring *ring = &ld->sq_ring;
-		unsigned start = *ld->sq_ring.head;
+		unsigned start = *ld->sq_ring.tail - ld->queued;
 		unsigned flags;
 
 		flags = atomic_load_acquire(ring->flags);


### PR DESCRIPTION
In io_uring sqpoll mode, when kernel side thread has not yet read  the sqring before second fio_ioring_commit() called, the  sq_ring.head will remain the same. The second 
fio_ioring_commit() will initialize the wrong io_u's issue_time.  The old(in head) io_u‘s issue_time will to be initialized twice and  new(in tail - 1) io_u's issue_time will not to be initialized. This problem will cause clat is weird, sometimes larger than lat.

Situation:
1. fio_ioring_queue(td, io_u_a) // head -> io_u_a;  tail -> io_u_a + 1
2. fio_ioring_commit(td)   // initial io_u_a.issue_time
3. fio_ioring_queue(td, io_u_b) // head -> io_u_a; tail -> io_u_b + 1
4. fio_ioring_commit(td)  // initial io_u_a.issue_time again
5. kernel thread read sq_ring, // head += 2

io_u_b.issue_time is never initilized.