### PR TITLE
helper_thread.h: fix missing header and types forward declaration

### DIFF
--- a/helper_thread.h
+++ b/helper_thread.h
@@ -3,6 +3,9 @@
 
 #include <stdbool.h>
 
+struct fio_sem;
+struct sk_out;
+
 extern void helper_reset(void);
 extern void helper_do_stat(void);
 extern bool helper_should_exit(void);

--- a/helper_thread.h
+++ b/helper_thread.h
@@ -1,6 +1,8 @@
 #ifndef FIO_HELPER_THREAD_H
 #define FIO_HELPER_THREAD_H
 
+#include <stdbool.h>
+
 extern void helper_reset(void);
 extern void helper_do_stat(void);
 extern bool helper_should_exit(void);


### PR DESCRIPTION
- missing headers should be included at the places where they are certainly used, so include <stdbool.h>
- helper_thread_create() function requires two structures to be declared, so declare in advance `struct fio_sem` and `struct sk_out`

Signed-off-by: Denis Pronin <dannftk@yandex.ru>