### PR TITLE
correctly free thread_data options at the topmost parent process

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2494,10 +2494,7 @@ reap:
 							strerror(ret));
 			} else {
 				pid_t pid;
-				void *eo;
 				dprint(FD_PROCESS, "will fork\n");
-				eo = td->eo;
-				read_barrier();
 				pid = fork();
 				if (!pid) {
 					int ret;
@@ -2506,7 +2503,6 @@ reap:
 					_exit(ret);
 				} else if (__td_index == fio_debug_jobno)
 					*fio_debug_jobp = pid;
-				free(eo);
 				free(fd);
 				fd = NULL;
 			}

--- a/cairo_text_helpers.c
+++ b/cairo_text_helpers.c
@@ -1,3 +1,5 @@
+#include "cairo_text_helpers.h"
+
 #include <cairo.h>
 #include <gtk/gtk.h>
 #include <math.h>

--- a/cairo_text_helpers.h
+++ b/cairo_text_helpers.h
@@ -1,6 +1,8 @@
 #ifndef CAIRO_TEXT_HELPERS_H
 #define CAIRO_TEXT_HELPERS_H
 
+#include <cairo.h>
+
 void draw_centered_text(cairo_t *cr, const char *font, double x, double y,
 			       double fontsize, const char *text);
 

--- a/goptions.h
+++ b/goptions.h
@@ -1,6 +1,8 @@
 #ifndef GFIO_OPTIONS_H
 #define GFIO_OPTIONS_H
 
+#include <gtk/gtk.h>
+
 void gopt_get_options_window(GtkWidget *window, struct gfio_client *gc);
 void gopt_init(void);
 void gopt_exit(void);

--- a/ioengines.c
+++ b/ioengines.c
@@ -238,7 +238,8 @@ void free_ioengine(struct thread_data *td)
 	if (td->eo && td->io_ops->options) {
 		options_free(td->io_ops->options, td->eo);
 		free(td->eo);
-		td->eo = NULL;
+		if (td->o.use_thread)
+			td->eo = NULL;
 	}
 
 	if (td->io_ops->dlhandle) {

--- a/log.c
+++ b/log.c
@@ -1,3 +1,5 @@
+#include "log.h"
+
 #include <unistd.h>
 #include <string.h>
 #include <stdarg.h>

--- a/options.c
+++ b/options.c
@@ -5829,9 +5829,9 @@ void fio_options_free(struct thread_data *td)
 	options_free(fio_options, &td->o);
 	if (td->eo && td->io_ops && td->io_ops->options) {
 		options_free(td->io_ops->options, td->eo);
-		free(td->eo);
-		td->eo = NULL;
 	}
+	free(td->eo);
+	td->eo = NULL;
 }
 
 void fio_dump_options_free(struct thread_data *td)


### PR DESCRIPTION
for non-threaded mode: since thread_data::eo is a pointer within shared  memory between the topmost fio parent process and its children let the  fio parent process set the pointer to NULL as just it frees its copy of  'eo' as memory previously allocated by means of 'malloc' meaning that  each child and the parent process itself must free it

for threaded mode we leave it as it has always been

also we do not need to check td->io_ops for being able to free td->eo in
 fio_options_free()

This PR should fix double-free problem described in [this issue](https://github.com/axboe/fio/issues/1598) and also should fix issue described in [this PR](https://github.com/axboe/fio/pull/1581)