### PR TITLE
fix typo in helper_thread.c and run block_signals(void) function in linux only.

### DIFF
--- a/helper_thread.c
+++ b/helper_thread.c
@@ -106,13 +106,16 @@ static int read_from_pipe(int fd, void *buf, size_t len)
 
 static void block_signals(void)
 {
-#ifdef HAVE_PTHREAD_SIGMASK
-	sigset_t sigmask;
+#ifdef CONFIG_PTHREAD_SIGMASK
+	#if defined(__linux__)
+		sigset_t sigmask;
 
-	ret = pthread_sigmask(SIG_UNBLOCK, NULL, &sigmask);
-	assert(ret == 0);
-	ret = pthread_sigmask(SIG_BLOCK, &sigmask, NULL);
-	assert(ret == 0);
+		int ret;
+
+		ret = pthread_sigmask(SIG_UNBLOCK, NULL, &sigmask);
+		assert(ret == 0);
+		ret = pthread_sigmask(SIG_BLOCK, &sigmask, NULL);
+	#endif
 #endif
 }
 


### PR DESCRIPTION
fix typo in helper_thread.c and run block_signals(void) function in linux only.

Compiling the code with the typo fix of "#ifdef CONFIG_PTHREAD_SIGMASK" will show that ret is unknown, hence, we are adding the line "int ret;". This fix of typo will fix some other bugs I've encountered.

Also, sigmask works in linux environment, so we will if defined it to linux only.

Signed-off-by: Shai Levy shailevy23@gmail.com.

