### PR TITLE
Update docs to clarify how to pass job options in client mode

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -5105,6 +5105,9 @@ is the connect string, and `remote-args` and `job file(s)` are sent to the
 server. The `server` string follows the same format as it does on the server
 side, to allow IP/hostname/socket and port strings.
 
+Note that all job options must be defined in job files when running fio as a
+client. Any job options specified in `remote-args` will be ignored.
+
 Fio can connect to multiple servers this way::
 
     fio --client=<server1> <job file(s)> --client=<server2> <job file(s)>

--- a/fio.1
+++ b/fio.1
@@ -4838,6 +4838,9 @@ is the connect string, and `remote\-args' and `job file(s)' are sent to the
 server. The `server' string follows the same format as it does on the server
 side, to allow IP/hostname/socket and port strings.
 .P
+Note that all job options must be defined in job files when running fio as a
+client. Any job options specified in `remote\-args' will be ignored.
+.P
 Fio can connect to multiple servers this way:
 .RS
 .P


### PR DESCRIPTION
When run in client mode, fio does not pass any job options specified on the command line to the fio server. When run in client mode, all job options must be specified via local or remote job files. Update the docs to indicate this to avoid end-user confusion.

Fixes #1629

Signed-off-by: Nick Neumann nick@pcpartpicker.com