### PR TITLE
fix typo in helper_thread.c and add sigmask var to configure script in order to handle msys2.

### DIFF
--- a/configure
+++ b/configure
@@ -864,7 +864,8 @@ cat > $TMPC <<EOF
 #include <signal.h> /* pthread_sigmask() */
 int main(void)
 {
-  return pthread_sigmask(0, NULL, NULL);
+  sigset_t sigmask;
+  return pthread_sigmask(0, NULL, &sigmask);
 }
 EOF
 if compile_prog "" "$LIBS" "pthread_sigmask" ; then

--- a/helper_thread.c
+++ b/helper_thread.c
@@ -106,13 +106,14 @@ static int read_from_pipe(int fd, void *buf, size_t len)
 
 static void block_signals(void)
 {
-#ifdef HAVE_PTHREAD_SIGMASK
+#ifdef CONFIG_PTHREAD_SIGMASK
 	sigset_t sigmask;
+
+	int ret;
 
 	ret = pthread_sigmask(SIG_UNBLOCK, NULL, &sigmask);
 	assert(ret == 0);
 	ret = pthread_sigmask(SIG_BLOCK, &sigmask, NULL);
-	assert(ret == 0);
 #endif
 }
 


### PR DESCRIPTION
fix typo in helper_thread.c and add sigmask var to configure to detect the existence of pthread_sigmask.

Compiling the code with the typo fix of "#ifdef CONFIG_PTHREAD_SIGMASK" will show that ret is unknown, hence, we are adding the line "int ret;". This fix of typo will fix some other bugs I've encountered.
In case of a msys2, configure script handles it, it triggers the same warning that is in the build failure to fail to detect pthread_sigmask when it is defined to be a noop.

Signed-off-by: Shai Levy [shailevy23@gmail.com](mailto:shailevy23@gmail.com).