### PR TITLE
fix assert failed when timeout during call rate_ddir

### DIFF
--- a/io_ddir.h
+++ b/io_ddir.h
@@ -11,6 +11,7 @@ enum fio_ddir {
 	DDIR_WAIT,
 	DDIR_LAST,
 	DDIR_INVAL = -1,
+	DDIR_TIMEOUT = -2,
 
 	DDIR_RWDIR_CNT = 3,
 	DDIR_RWDIR_SYNC_CNT = 4,

--- a/zbd.c
+++ b/zbd.c
@@ -2171,6 +2171,7 @@ retry:
 	case DDIR_WAIT:
 	case DDIR_LAST:
 	case DDIR_INVAL:
+	case DDIR_TIMEOUT:
 		goto accept;
 	}
 


### PR DESCRIPTION
fix assert failed when timeout during call rate_ddir

Adding DDIR_TIMEOUT in enum `fio_ddir`, and `rate_ddir` returns it when fio timeouts. `set_io_u_file` will directly break out of the loop, and `fill_io_u` won't be called again, which causes assert to fail in `rate_ddir`, because td->rwmix_ddir is DDIR_INVAL.

 Signed-off-by: QingSong Zhu <zhuqingsong.0909@bytedance.com>
