### PR TITLE
riscv64: get clock from `rdtime` instead of `rdcycle`

### DIFF
--- a/arch/arch-riscv64.h
+++ b/arch/arch-riscv64.h
@@ -16,7 +16,7 @@ static inline unsigned long long get_cpu_clock(void)
 {
 	unsigned long val;
 
-	asm volatile("rdcycle %0" : "=r"(val));
+	asm volatile("rdtime %0" : "=r"(val));
 	return val;
 }
 #define ARCH_HAVE_CPU_CLOCK


### PR DESCRIPTION
`rdcycle` pseudo-instruction accesses the "cycle CSR" which holds the real count of CPU core clock cycles [1]. As this leaves room for side-channel attacks, access to this register from userland might be forbidden by the kernel, which results in a SIGILL [2].

Anyhow, it seems that the actual usage of the `get_cpu_clock` function in fio is about getting a wall-clock rather than the actual CPU core clock (for instance, x86 uses `rdtsc`), so this is technically a bug. The "time CSR" is the proper register to track time on riscv64. Also, the "time CSR" is more likely to be available from userspace and not cause a crash.

[1] RISC-V ISA Section 10.1: https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf


[2] https://lore.kernel.org/all/YxIzgYP3MujXdqwj@aurel32.net/T/