### PR TITLE
nfs: Fix incorrect engine registering for '--enghelp' list

### DIFF
--- a/engines/nfs.c
+++ b/engines/nfs.c
@@ -308,7 +308,7 @@ static int fio_libnfs_close(struct thread_data *td, struct fio_file *f)
 	return ret;
 }
 
-struct ioengine_ops ioengine = {
+static struct ioengine_ops ioengine = {
 	.name		= "nfs",
 	.version	= FIO_IOOPS_VERSION,
 	.setup		= fio_libnfs_setup,


### PR DESCRIPTION
`ioengine` from `nfs` (internal) engine is incorrectly exported thus overriding its value in constructor callbacks of other external engines, that are used for registering engine for listing with `--enghelp`.

Because flist is unsafe to double adding it also making `engine_list` to become corrupt and causing infinite loop or abnormal list termination when printing engine list.

Issue: https://github.com/axboe/fio/issues/1655
Fixes: 9326926b ("NFS engine")

---
It seems that `ioengine` for internal engines should not be exported and should be always `static`.

The change is tested downstream on ALT Linux.