### PR TITLE
crct10: use isa-l for crc if available

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2507,6 +2507,10 @@ with the caveat that when used on the command line, they must come after the
 	If this is set to 0, fio generates protection information for
 	write case and verifies for read case. Default: 1.
 
+	For 16 bit CRC generation fio will use isa-l if available otherwise
+	it will use the default slower generator.
+	(see: https://github.com/intel/isa-l)
+
 .. option:: pi_chk=str[,str][,str] : [io_uring_cmd]
 
 	Controls the protection information check. This can take one or more

--- a/configure
+++ b/configure
@@ -189,6 +189,7 @@ libiscsi="no"
 libnbd="no"
 libnfs=""
 xnvme=""
+isal=""
 libblkio=""
 libzbc=""
 dfs=""
@@ -262,6 +263,8 @@ for opt do
   ;;
   --disable-xnvme) xnvme="no"
   ;;
+  --disable-isal) isal="no"
+  ;;
   --disable-libblkio) libblkio="no"
   ;;
   --disable-tcmalloc) disable_tcmalloc="yes"
@@ -322,6 +325,7 @@ if test "$show_help" = "yes" ; then
   echo "--enable-libiscsi       Enable iscsi support"
   echo "--enable-libnbd         Enable libnbd (NBD engine) support"
   echo "--disable-xnvme         Disable xnvme support even if found"
+  echo "--disable-isal          Disable isal support even if found"
   echo "--disable-libblkio      Disable libblkio support even if found"
   echo "--disable-libzbc        Disable libzbc even if found"
   echo "--disable-tcmalloc      Disable tcmalloc support"
@@ -2684,6 +2688,28 @@ if test "$xnvme" != "no" ; then
 fi
 print_config "xnvme engine" "$xnvme"
 
+if test "$targetos" = "Linux" ; then
+##########################################
+# Check ISA-L support
+cat > $TMPC << EOF
+#include <isa-l/crc.h>
+#include <stddef.h>
+int main(void)
+{
+  return crc16_t10dif(0, NULL, 4096);
+}
+EOF
+if test "$isal" != "no" ; then
+  if compile_prog "" "-lisal" "ISAL"; then
+    isal="yes"
+    LIBS="-lisal $LIBS"
+  else
+    isal="no"
+  fi
+fi
+print_config "isal" "$isal"
+fi
+
 ##########################################
 # Check if we have libblkio
 if test "$libblkio" != "no" ; then
@@ -3333,6 +3359,9 @@ if test "$xnvme" = "yes" ; then
   output_sym "CONFIG_LIBXNVME"
   echo "LIBXNVME_CFLAGS=$xnvme_cflags" >> $config_host_mak
   echo "LIBXNVME_LIBS=$xnvme_libs" >> $config_host_mak
+fi
+if test "$isal" = "yes" ; then
+  output_sym "CONFIG_LIBISAL"
 fi
 if test "$libblkio" = "yes" ; then
   output_sym "CONFIG_LIBBLKIO"

--- a/crc/crct10dif_common.c
+++ b/crc/crct10dif_common.c
@@ -24,6 +24,17 @@
  *
  */
 
+#ifdef CONFIG_LIBISAL
+#include <isa-l/crc.h>
+
+extern unsigned short fio_crc_t10dif(unsigned short crc,
+				     const unsigned char *buffer,
+				     unsigned int len)
+{
+	return crc16_t10dif(crc, buffer, len);
+}
+
+#else
 #include "crc-t10dif.h"
 
 /* Table generated using the following polynomium:
@@ -76,3 +87,5 @@ extern unsigned short fio_crc_t10dif(unsigned short crc,
 
 	return crc;
 }
+
+#endif

--- a/fio.1
+++ b/fio.1
@@ -2263,6 +2263,10 @@ size greater than protection information size, fio will not generate or verify
 the protection information portion of metadata for write or read case
 respectively. If this is set to 0, fio generates protection information for
 write case and verifies for read case. Default: 1.
+
+For 16 bit CRC generation fio will use isa-l if available otherwise it will
+use the default slower generator.
+(see: https://github.com/intel/isa-l)
 .TP
 .BI (io_uring_cmd)pi_chk \fR=\fPstr[,str][,str]
 Controls the protection information check. This can take one or more of these


### PR DESCRIPTION
isa-l provides fast implementation for various polynomials.
This will be only used for end to end data protection, and has a significant impact on performance.

For ISA_L please check: https://github.com/intel/isa-l
