### PR TITLE
doc: Reference geom(4) for FreeBSD users

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -801,7 +801,7 @@ Target file/device
 
 	On Windows, disk devices are accessed as :file:`\\\\.\\PhysicalDrive0` for
 	the first device, :file:`\\\\.\\PhysicalDrive1` for the second etc.
-	Note: Windows and FreeBSD prevent write access to areas
+	Note: Windows and FreeBSD (refer to geom(4)) prevent write access to areas
 	of the disk containing in-use data (e.g. filesystems).
 
 	The filename "`-`" is a reserved name, meaning *stdin* or *stdout*.  Which


### PR DESCRIPTION
On FreeBSD, write access to Rank 1 geom providers is disabled by default.  However, it can be enabled with the `kern.geom.debugflags` sysctl as documented in geom(4). Point users to that manual page for smoother experience.