### PR TITLE
engines/http: Fix memory leak

### DIFF
--- a/engines/http.c
+++ b/engines/http.c
@@ -250,6 +250,7 @@ static char *_aws_uriencode(const char *uri)
 	for (i = 0; (c = uri[i]); i++) {
 		if (n > bufsize-5) {
 			log_err("encoding the URL failed\n");
+			free(r);
 			return NULL;
 		}
 


### PR DESCRIPTION
Found by Red Hat's OpenScanHub:

fio-3.35/engines/http.c:253: leaked_storage: Variable r going out of scope leaks the storage it points to.

Signed-off-by: Pavel Reichl <preichl@redhat.com>