### PR TITLE
Fix a few issues found by scanner

### DIFF
--- a/engines/http.c
+++ b/engines/http.c
@@ -640,7 +640,6 @@ static enum fio_q_status fio_http_queue(struct thread_data *td,
 	char url[1024];
 	long status;
 	CURLcode res;
-	int r = -1;
 
 	fio_ro_check(td, io_u);
 	memset(&_curl_stream, 0, sizeof(_curl_stream));
@@ -712,7 +711,7 @@ static enum fio_q_status fio_http_queue(struct thread_data *td,
 	log_err("WARNING: Only DDIR_READ/DDIR_WRITE/DDIR_TRIM are supported!\n");
 
 err:
-	io_u->error = r;
+	io_u->error = -1;
 	td_verror(td, io_u->error, "transfer");
 out:
 	curl_slist_free_all(slist);

--- a/engines/rdma.c
+++ b/engines/rdma.c
@@ -276,7 +276,6 @@ static int cq_event_handler(struct thread_data *td, enum ibv_wc_opcode opcode)
 	int i;
 
 	while ((ret = ibv_poll_cq(rd->cq, 1, &wc)) == 1) {
-		ret = 0;
 		compevnum++;
 
 		if (wc.status) {

--- a/server.c
+++ b/server.c
@@ -1883,7 +1883,6 @@ void fio_server_send_ts(struct thread_stat *ts, struct group_run_stats *rs)
 
 		offset = (char *)extended_buf_wp - (char *)extended_buf;
 		ptr->ts.ss_bw_data_offset = cpu_to_le64(offset);
-		extended_buf_wp = ss_bw + (int) ts->ss_dur;
 	}
 
 	fio_net_queue_cmd(FIO_NET_CMD_TS, extended_buf, extended_buf_size, NULL, SK_F_COPY);


### PR DESCRIPTION
Following issues were found by Red Hat's OpenScanHub:

fio-3.35/engines/rdma.c:279:3: warning[deadcode.DeadStores]:
	Value stored to 'ret' is never read

fio-3.35/server.c:1884:3: warning[deadcode.DeadStores]:
	Value stored to 'extended_buf_wp' is never read

fio-3.35/engines/http.c:642: var_tested_neg:
	Assigning: "r" = a negative value.
fio-3.35/engines/http.c:714: assign: Assigning: "io_u->error" = "r". fio-3.35/engines/http.c:715: negative_returns: "io_u->error" is passed
	to a parameter that cannot be negative.

I suggest changing the data type of io_u->error from uint to int since it appears that negative values are being assigned to it.
