### PR TITLE
zbd: fix assertion issue during reset zone when using percentage offset

### DIFF
--- a/file.h
+++ b/file.h
@@ -101,6 +101,7 @@ struct fio_file {
 	uint64_t real_file_size;
 	uint64_t file_offset;
 	uint64_t io_size;
+	uint64_t start_offset_update;
 
 	struct fio_ruhs_info *ruhs_info;
 

--- a/filesetup.c
+++ b/filesetup.c
@@ -1173,6 +1173,7 @@ int setup_files(struct thread_data *td)
 	need_extend = 0;
 	for_each_file(td, f, i) {
 		f->file_offset = get_start_offset(td, f);
+		f->start_offset_update = f->file_offset;
 
 		/*
 		 * Update ->io_size depending on options specified.

--- a/libfio.c
+++ b/libfio.c
@@ -122,6 +122,9 @@ void clear_io_state(struct thread_data *td, int all)
 	for_each_file(td, f, i) {
 		fio_file_clear_done(f);
 		f->file_offset = get_start_offset(td, f);
+		if (f->file_offset != f->start_offset_update) {
+			f->file_offset = f->start_offset_update;
+		}
 	}
 
 	/*

--- a/zbd.c
+++ b/zbd.c
@@ -698,6 +698,7 @@ static bool zbd_zone_align_file_sizes(struct thread_data *td,
 			 new_offset);
 		f->io_size -= (new_offset - f->file_offset);
 		f->file_offset = new_offset;
+		f->start_offset_update = new_offset;
 	}
 
 	z = zbd_offset_to_zone(f, f->file_offset + f->io_size);


### PR DESCRIPTION
Please confirm that your commit message(s) follow these guidelines:

zbd: fix assertion issue during reset zone when using percentage offset

Add a new member for structure fio_file to record the new start offset which is ever updated, especially in zbd test, the file offset maybe ever adjusted according to the zone's boundary and bs alignment when using percentage offset value.

Signed-off-by: LinXpy <paynefd1222@163.com>
