### PR TITLE
iolog: fix disk stats issue

### DIFF
--- a/iolog.c
+++ b/iolog.c
@@ -588,6 +588,8 @@ int init_iolog(struct thread_data *td)
 	if (ret)
 		td_verror(td, EINVAL, "failed initializing iolog");
 
+	init_disk_util(td);
+
 	return ret;
 }
 


### PR DESCRIPTION
iolog: fix disk stats issue
    
In the iolog replay scenario, the disk util in the td structure is
not initialized, resulting in the disk stats not being correctly
updated.
    
Fixes: https://github.com/axboe/fio/issues/1735
    
Signed-off-by: Yong Gang <yygcode@gmail.com>