### PR TITLE
ioengines: implement dircreate, dirstat, dirdelete engines to fileoperations.c

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2192,6 +2192,21 @@ I/O engine
 			and 'nrfiles', so that the files will be created.
 			This engine is to measure file delete.
 
+		**dircreate**
+			Simply create the directories and do no I/O to them.  You still need to
+			set  `filesize` so that all the accounting still occurs, but no
+			actual I/O will be done other than creating the directories.
+
+		**dirstat**
+			Simply do stat() and do no I/O to the directories. You need to set 'filesize'
+			and 'nrfiles', so that directories will be created.
+			This engine is to measure directory lookup and meta data access.
+
+		**dirdelete**
+			Simply delete the directories by rmdir() and do no I/O to them. You need to set 'filesize'
+			and 'nrfiles', so that the directories will be created.
+			This engine is to measure directory delete.
+
 		**libpmem**
 			Read and write using mmap I/O to a file on a filesystem
 			mounted with DAX on a persistent memory device through the PMDK

--- a/examples/dircreate-ioengine.fio
+++ b/examples/dircreate-ioengine.fio
@@ -1,0 +1,25 @@
+# Example dircreate job
+#
+# create_on_open is needed so that the open happens during the run and not the
+# setup.
+#
+# openfiles needs to be set so that you do not exceed the maximum allowed open
+# files.
+#
+# filesize needs to be set to a non zero value so fio will actually run, but the
+# IO will not really be done and the write latency numbers will only reflect the
+# open times.
+[global]
+create_on_open=1
+nrfiles=30
+ioengine=dircreate
+fallocate=none
+filesize=4k
+openfiles=1
+
+[t0]
+[t1]
+[t2]
+[t3]
+[t4]
+[t5]

--- a/examples/dirdelete-ioengine.fio
+++ b/examples/dirdelete-ioengine.fio
@@ -1,0 +1,18 @@
+# Example dirdelete job
+
+# 'filedelete' engine only do 'rmdir(dirname)'.
+# 'filesize' must be set, then directories will be created at setup stage.
+# 'unlink' is better set to 0, since the directory is deleted in measurement.
+# the options disabled completion latency output such as 'disable_clat' and 'gtod_reduce' must not set.
+[global]
+ioengine=dirdelete
+filesize=4k
+nrfiles=200
+unlink=0
+
+[t0]
+[t1]
+[t2]
+[t3]
+[t4]
+[t5]

--- a/examples/dirstat-ioengine.fio
+++ b/examples/dirstat-ioengine.fio
@@ -1,0 +1,19 @@
+# Example dirstat job
+
+# 'dirstat' engine only do 'stat(dirname)', file will not be open().
+# 'filesize' must be set, then files will be created at setup stage.
+
+[global]
+ioengine=dirstat
+numjobs=10
+filesize=4k
+nrfiles=5
+thread
+
+[t0]
+[t1]
+[t2]
+[t3]
+[t4]
+[t5]
+

--- a/fio.1
+++ b/fio.1
@@ -2004,6 +2004,21 @@ Simply delete files by unlink() and do no I/O to the file. You need to set 'file
 and 'nrfiles', so that files will be created.
 This engine is to measure file delete.
 .TP
+.B dircreate
+Simply create the directories and do no I/O to them.  You still need to set
+\fBfilesize\fR so that all the accounting still occurs, but no actual I/O will be
+done other than creating the directories.
+.TP
+.B dirstat
+Simply do stat() and do no I/O to the directory. You need to set 'filesize'
+and 'nrfiles', so that directories will be created.
+This engine is to measure directory lookup and meta data access.
+.TP
+.B dirdelete
+Simply delete directories by unlink() and do no I/O to the directory. You need to set 'filesize'
+and 'nrfiles', so that directories will be created.
+This engine is to measure directory delete.
+.TP
 .B libpmem
 Read and write using mmap I/O to a file on a filesystem
 mounted with DAX on a persistent memory device through the PMDK


### PR DESCRIPTION
test log:

$ ../fio dircreate-ioengine.fio
t0: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dircreate, iodepth=1
t1: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dircreate, iodepth=1
fio-3.36
Starting 2 processes

t0: (groupid=0, jobs=1): err= 0: pid=1324336: Fri Mar 22 10:24:08 2024
  read: IOPS=10.0k, BW=39.1MiB/s (41.0MB/s)(40.0KiB/1msec)
    clat (usec): min=62, max=244, avg=91.96, stdev=54.43
    clat percentiles (usec):
     |  1.00th=[   63],  5.00th=[   63], 10.00th=[   63], 20.00th=[   63],
     | 30.00th=[   68], 40.00th=[   70], 50.00th=[   71], 60.00th=[   82],
     | 70.00th=[   86], 80.00th=[   86], 90.00th=[   93], 95.00th=[  245],
     | 99.00th=[  245], 99.50th=[  245], 99.90th=[  245], 99.95th=[  245],
     | 99.99th=[  245]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=10,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t1: (groupid=0, jobs=1): err= 0: pid=1324337: Fri Mar 22 10:24:08 2024
  read: IOPS=10.0k, BW=39.1MiB/s (41.0MB/s)(40.0KiB/1msec)
    clat (usec): min=64, max=138, avg=89.45, stdev=25.25
    clat percentiles (usec):
     |  1.00th=[   65],  5.00th=[   65], 10.00th=[   65], 20.00th=[   69],
     | 30.00th=[   70], 40.00th=[   72], 50.00th=[   81], 60.00th=[   85],
     | 70.00th=[   93], 80.00th=[  103], 90.00th=[  124], 95.00th=[  139],
     | 99.00th=[  139], 99.50th=[  139], 99.90th=[  139], 99.95th=[  139],
     | 99.99th=[  139]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=10,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
   READ: bw=78.1MiB/s (81.9MB/s), 39.1MiB/s-39.1MiB/s (41.0MB/s-41.0MB/s), io=80.0KiB (81.9kB), run=1-1msec

$ ../fio dirstat-ioengine.fio
t0: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirstat, iodepth=1
...
t1: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirstat, iodepth=1
...
fio-3.36
Starting 4 threads

t0: (groupid=0, jobs=1): err= 0: pid=1324396: Fri Mar 22 10:24:53 2024
  read: IOPS=5000, BW=19.5MiB/s (20.5MB/s)(20.0KiB/1msec)
    clat (nsec): min=1399, max=12766, avg=3808.20, stdev=5009.80
    clat percentiles (nsec):
     |  1.00th=[ 1400],  5.00th=[ 1400], 10.00th=[ 1400], 20.00th=[ 1400],
     | 30.00th=[ 1448], 40.00th=[ 1448], 50.00th=[ 1672], 60.00th=[ 1672],
     | 70.00th=[ 1752], 80.00th=[ 1752], 90.00th=[12736], 95.00th=[12736],
     | 99.00th=[12736], 99.50th=[12736], 99.90th=[12736], 99.95th=[12736],
     | 99.99th=[12736]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=0
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=5,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t0: (groupid=0, jobs=1): err= 0: pid=1324397: Fri Mar 22 10:24:53 2024
  read: IOPS=5000, BW=19.5MiB/s (20.5MB/s)(20.0KiB/1msec)
    clat (nsec): min=1427, max=6171, avg=2489.80, stdev=2061.84
    clat percentiles (nsec):
     |  1.00th=[ 1432],  5.00th=[ 1432], 10.00th=[ 1432], 20.00th=[ 1432],
     | 30.00th=[ 1480], 40.00th=[ 1480], 50.00th=[ 1608], 60.00th=[ 1608],
     | 70.00th=[ 1768], 80.00th=[ 1768], 90.00th=[ 6176], 95.00th=[ 6176],
     | 99.00th=[ 6176], 99.50th=[ 6176], 99.90th=[ 6176], 99.95th=[ 6176],
     | 99.99th=[ 6176]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=0
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=5,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t1: (groupid=0, jobs=1): err= 0: pid=1324398: Fri Mar 22 10:24:53 2024
  read: IOPS=5000, BW=19.5MiB/s (20.5MB/s)(20.0KiB/1msec)
    clat (nsec): min=1515, max=5798, avg=2472.60, stdev=1864.92
    clat percentiles (nsec):
     |  1.00th=[ 1512],  5.00th=[ 1512], 10.00th=[ 1512], 20.00th=[ 1512],
     | 30.00th=[ 1528], 40.00th=[ 1528], 50.00th=[ 1640], 60.00th=[ 1640],
     | 70.00th=[ 1880], 80.00th=[ 1880], 90.00th=[ 5792], 95.00th=[ 5792],
     | 99.00th=[ 5792], 99.50th=[ 5792], 99.90th=[ 5792], 99.95th=[ 5792],
     | 99.99th=[ 5792]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=0
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=5,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t1: (groupid=0, jobs=1): err= 0: pid=1324399: Fri Mar 22 10:24:53 2024
  read: IOPS=5000, BW=19.5MiB/s (20.5MB/s)(20.0KiB/1msec)
    clat (nsec): min=1703, max=6886, avg=2788.00, stdev=2291.51
    clat percentiles (nsec):
     |  1.00th=[ 1704],  5.00th=[ 1704], 10.00th=[ 1704], 20.00th=[ 1704],
     | 30.00th=[ 1736], 40.00th=[ 1736], 50.00th=[ 1768], 60.00th=[ 1768],
     | 70.00th=[ 1848], 80.00th=[ 1848], 90.00th=[ 6880], 95.00th=[ 6880],
     | 99.00th=[ 6880], 99.50th=[ 6880], 99.90th=[ 6880], 99.95th=[ 6880],
     | 99.99th=[ 6880]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=0
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=5,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
   READ: bw=78.1MiB/s (81.9MB/s), 19.5MiB/s-19.5MiB/s (20.5MB/s-20.5MB/s), io=80.0KiB (81.9kB), run=1-1msec

$ ../fio dirdelete-ioengine.fio
t0: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirdelete, iodepth=1
t1: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirdelete, iodepth=1
t2: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirdelete, iodepth=1
t3: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirdelete, iodepth=1
t4: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirdelete, iodepth=1
t5: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=dirdelete, iodepth=1
fio-3.36
Starting 6 processes

t0: (groupid=0, jobs=1): err= 0: pid=1324479: Fri Mar 22 10:25:28 2024
  read: IOPS=20.0k, BW=78.1MiB/s (81.9MB/s)(80.0KiB/1msec)
    clat (nsec): min=34868, max=83102, avg=43906.55, stdev=10354.00
    clat percentiles (nsec):
     |  1.00th=[35072],  5.00th=[35072], 10.00th=[36096], 20.00th=[37120],
     | 30.00th=[38656], 40.00th=[40192], 50.00th=[41216], 60.00th=[41728],
     | 70.00th=[44800], 80.00th=[45312], 90.00th=[48384], 95.00th=[55040],
     | 99.00th=[83456], 99.50th=[83456], 99.90th=[83456], 99.95th=[83456],
     | 99.99th=[83456]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=20,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t1: (groupid=0, jobs=1): err= 0: pid=1324480: Fri Mar 22 10:25:28 2024
  read: IOPS=20.0k, BW=78.1MiB/s (81.9MB/s)(80.0KiB/1msec)
    clat (nsec): min=32572, max=76486, avg=42892.40, stdev=9624.42
    clat percentiles (nsec):
     |  1.00th=[32640],  5.00th=[32640], 10.00th=[33536], 20.00th=[35584],
     | 30.00th=[38144], 40.00th=[38144], 50.00th=[40704], 60.00th=[42240],
     | 70.00th=[43776], 80.00th=[45312], 90.00th=[48896], 95.00th=[55040],
     | 99.00th=[76288], 99.50th=[76288], 99.90th=[76288], 99.95th=[76288],
     | 99.99th=[76288]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=20,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t2: (groupid=0, jobs=1): err= 0: pid=1324481: Fri Mar 22 10:25:28 2024
  read: IOPS=20.0k, BW=78.1MiB/s (81.9MB/s)(80.0KiB/1msec)
    clat (nsec): min=36055, max=82108, avg=43614.80, stdev=10216.20
    clat percentiles (nsec):
     |  1.00th=[36096],  5.00th=[36096], 10.00th=[36608], 20.00th=[36608],
     | 30.00th=[38656], 40.00th=[40192], 50.00th=[41216], 60.00th=[41728],
     | 70.00th=[42240], 80.00th=[47872], 90.00th=[50944], 95.00th=[51968],
     | 99.00th=[82432], 99.50th=[82432], 99.90th=[82432], 99.95th=[82432],
     | 99.99th=[82432]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=20,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t3: (groupid=0, jobs=1): err= 0: pid=1324482: Fri Mar 22 10:25:28 2024
  read: IOPS=20.0k, BW=78.1MiB/s (81.9MB/s)(80.0KiB/1msec)
    clat (nsec): min=25191, max=90014, avg=43661.90, stdev=12597.10
    clat percentiles (nsec):
     |  1.00th=[25216],  5.00th=[25216], 10.00th=[35072], 20.00th=[37632],
     | 30.00th=[38656], 40.00th=[39680], 50.00th=[40704], 60.00th=[41728],
     | 70.00th=[42752], 80.00th=[45312], 90.00th=[52480], 95.00th=[56064],
     | 99.00th=[89600], 99.50th=[89600], 99.90th=[89600], 99.95th=[89600],
     | 99.99th=[89600]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=20,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t4: (groupid=0, jobs=1): err= 0: pid=1324483: Fri Mar 22 10:25:28 2024
  read: IOPS=20.0k, BW=78.1MiB/s (81.9MB/s)(80.0KiB/1msec)
    clat (nsec): min=33248, max=66109, avg=43044.40, stdev=7634.81
    clat percentiles (nsec):
     |  1.00th=[33024],  5.00th=[33024], 10.00th=[35072], 20.00th=[38144],
     | 30.00th=[38656], 40.00th=[39680], 50.00th=[40704], 60.00th=[41728],
     | 70.00th=[43776], 80.00th=[47360], 90.00th=[52992], 95.00th=[53504],
     | 99.00th=[66048], 99.50th=[66048], 99.90th=[66048], 99.95th=[66048],
     | 99.99th=[66048]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=20,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1
t5: (groupid=0, jobs=1): err= 0: pid=1324484: Fri Mar 22 10:25:28 2024
  read: IOPS=20.0k, BW=78.1MiB/s (81.9MB/s)(80.0KiB/1msec)
    clat (nsec): min=36094, max=64810, avg=43460.75, stdev=7702.69
    clat percentiles (nsec):
     |  1.00th=[36096],  5.00th=[36096], 10.00th=[36608], 20.00th=[37632],
     | 30.00th=[37632], 40.00th=[40192], 50.00th=[41216], 60.00th=[42240],
     | 70.00th=[42752], 80.00th=[47360], 90.00th=[51456], 95.00th=[59648],
     | 99.00th=[64768], 99.50th=[64768], 99.90th=[64768], 99.95th=[64768],
     | 99.99th=[64768]
  cpu          : usr=0.00%, sys=0.00%, ctx=0, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=20,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
   READ: bw=469MiB/s (492MB/s), 78.1MiB/s-78.1MiB/s (81.9MB/s-81.9MB/s), io=480KiB (492kB), run=1-1msec
