### PR TITLE
FIO continues to issue flush (DDIR_SYNC) commands while there is already an outstanding flush command.

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1046,11 +1046,13 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 				goto reap;
 			break;
 		}
+
 		if (ddir_sync(io_u->ddir)) {
 			td->last_was_sync = true;
 		} else {
 			td->last_was_sync = false;
 		}
+
 		if (io_u->ddir == DDIR_WRITE && td->flags & TD_F_DO_VERIFY) {
 			if (!(io_u->flags & IO_U_F_PATTERN_DONE)) {
 				io_u_set(td, io_u, IO_U_F_PATTERN_DONE);

--- a/backend.c
+++ b/backend.c
@@ -50,6 +50,7 @@
 #include "pshared.h"
 #include "zone-dist.h"
 #include "fio_time.h"
+#include "io_ddir.h"
 
 static struct fio_sem *startup_sem;
 static struct flist_head *cgroup_list;
@@ -1045,7 +1046,11 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 				goto reap;
 			break;
 		}
-
+		if (ddir_sync(io_u->ddir)) {
+			td->last_was_sync = true;
+		} else {
+			td->last_was_sync = false;
+		}
 		if (io_u->ddir == DDIR_WRITE && td->flags & TD_F_DO_VERIFY) {
 			if (!(io_u->flags & IO_U_F_PATTERN_DONE)) {
 				io_u_set(td, io_u, IO_U_F_PATTERN_DONE);

--- a/io_u.c
+++ b/io_u.c
@@ -2102,7 +2102,6 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 	if (ddir_sync(ddir)) {
 		if (io_u->error)
 			goto error;
-		td->last_was_sync = true;
 		if (f) {
 			f->first_write = -1ULL;
 			f->last_write = -1ULL;
@@ -2112,7 +2111,6 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 		return;
 	}
 
-	td->last_was_sync = false;
 	td->last_ddir = ddir;
 
 	if (!io_u->error && ddir_rw(ddir)) {


### PR DESCRIPTION
FIO continues to issue flush (DDIR_SYNC) commands while there is already an outstanding flush command.

# Issue and root cause
When fsync option is used, the number of flush (or DDIR_SYNC) commands
issued is more than the expected number of flush commands.
To elaborate:
- In the fio config file, consider fsync=1
1. FIO issues 1 write command
2. After write completes, FIO sets last_was_sync variable to false
3. FIO issues 1 flush command
4. FIO keeps issuing flush commands since last_was_sync is still false
and this causes more flush commands to be issued than expected
5. last_was_sync is set to true after the flush command completes
- The above steps repeats until the workload is completed.
# Fix
Instead of setting last_was_sync to true after flush command is completed
and setting last_was_sync to false after write command is completed,
set last_was_sync to true after flush command is issued and set
last_was_sync to false after write command is issued.

Signed-off-by: Celestine Chen celestinechen@google.com