### PR TITLE
bump up FIO_IOOPS_VERSION

### DIFF
--- a/ioengines.h
+++ b/ioengines.h
@@ -9,7 +9,7 @@
 #include "zbd_types.h"
 #include "fdp.h"
 
-#define FIO_IOOPS_VERSION	33
+#define FIO_IOOPS_VERSION	34
 
 #ifndef CONFIG_DYNAMIC_ENGINES
 #define FIO_STATIC	static


### PR DESCRIPTION
This was left out when multi range trim support was added.

Fixes: commit b3251e31 (trim: add support for multiple ranges)

