### PR TITLE
FIO with fsync option issues more DDIR_SYNC commands than expected

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -2113,7 +2113,6 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 	if (ddir_sync(ddir)) {
 		if (io_u->error)
 			goto error;
-		td->last_was_sync = true;
 		if (f) {
 			f->first_write = -1ULL;
 			f->last_write = -1ULL;
@@ -2123,7 +2122,6 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 		return;
 	}
 
-	td->last_was_sync = false;
 	td->last_ddir = ddir;
 
 	if (!io_u->error && ddir_rw(ddir)) {

--- a/ioengines.c
+++ b/ioengines.c
@@ -436,6 +436,8 @@ enum fio_q_status td_io_queue(struct thread_data *td, struct io_u *io_u)
 			io_u_mark_depth(td, 1);
 			td->ts.total_io_u[io_u->ddir]++;
 		}
+
+		td->last_was_sync = ddir_sync(io_u->ddir);
 	} else if (ret == FIO_Q_QUEUED) {
 		td->io_u_queued++;
 
@@ -445,6 +447,8 @@ enum fio_q_status td_io_queue(struct thread_data *td, struct io_u *io_u)
 
 		if (td->io_u_queued >= td->o.iodepth_batch)
 			td_io_commit(td);
+
+		td->last_was_sync = ddir_sync(io_u->ddir);
 	}
 
 	if (!td_ioengine_flagged(td, FIO_SYNCIO) &&


### PR DESCRIPTION
FIO with fsync option issues more DDIR_SYNC commands than expected

# Issue and root cause
When fsync option is used, the number of flush (or DDIR_SYNC) commands
issued is more than the expected number of flush commands.
To elaborate:
- In the fio config file, consider fsync=1
1. FIO issues 1 write command
2. After write completes, FIO sets last_was_sync variable to false
3. FIO issues 1 flush command
4. FIO keeps issuing flush commands since last_was_sync is still false
and this causes more flush commands to be issued than expected
5. last_was_sync is set to true after the flush command completes
- The above steps repeats until the workload is completed.
# Fix
Instead of setting last_was_sync to true after flush command is completed
and setting last_was_sync to false after write command is completed,
set last_was_sync to true after flush command is issued and set
last_was_sync to false after write command is issued.

Signed-off-by: Celestine Chen celestinechen@google.com