### PR TITLE
fdp: support scheme placement id selection

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2529,8 +2529,12 @@ with the caveat that when used on the command line, they must come after the
 			Round robin over available placement IDs. This is the
 			default.
 
-	The available placement ID (indices) are defined by the option
-	:option:`plids`.
+		**scheme**
+			Choose a placement ID (index) based on the scheme file defined by
+			the option :option:`dp_scheme`.
+
+	The available placement ID (indices) are defined by the option :option:`fdp_pli`
+	or :option:`plids` except for the case of **scheme**.
 
 .. option:: plids=str, fdp_pli=str : [io_uring_cmd] [xnvme]
 
@@ -2540,6 +2544,26 @@ with the caveat that when used on the command line, they must come after the
         identifiers to specific jobs. If you want fio to use FDP placement
         identifiers only at indices 0, 2 and 5 specify ``plids=0,2,5``. For
         streams this should be a comma-separated list of Stream IDs.
+
+.. option:: dp_scheme=str : [io_uring_cmd] [xnvme]
+
+	Defines which placement ID (index) to be selected based on offset(LBA) range.
+	The file should contains one or more scheme entries in the following format:
+
+		0, 10737418240, 0
+		10737418240, 21474836480, 1
+		21474836480, 32212254720, 2
+		...
+
+	Each line, a scheme entry, contains start offset, end offset, and placement ID
+	(index) separated by comma(,). If the write offset is within the range of a certain
+	scheme entry(start offset ≤ offset < end offset), the corresponding placement ID
+	(index) will be selected. If the write offset belongs to multiple scheme entries,
+	the first matched scheme entry will be applied. If the offset is not within any range
+	of scheme entry, dspec field will be set to 0, default RUH. (Caution: In case of
+	multiple devices in a job, all devices of the job will be affected by the scheme. If
+	this option is specified, the option :option:`plids` or :option:`fdp_pli` will be
+	ignored.)
 
 .. option:: md_per_io_size=int : [io_uring_cmd] [xnvme]
 

--- a/cconv.c
+++ b/cconv.c
@@ -94,6 +94,7 @@ int convert_thread_options_to_cpu(struct thread_options *o,
 	string_to_cpu(&o->ioscheduler, top->ioscheduler);
 	string_to_cpu(&o->profile, top->profile);
 	string_to_cpu(&o->cgroup, top->cgroup);
+	string_to_cpu(&o->dp_scheme_file, top->dp_scheme_file);
 
 	o->allow_create = le32_to_cpu(top->allow_create);
 	o->allow_mounted_write = le32_to_cpu(top->allow_mounted_write);
@@ -398,6 +399,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 	string_to_net(top->ioscheduler, o->ioscheduler);
 	string_to_net(top->profile, o->profile);
 	string_to_net(top->cgroup, o->cgroup);
+	string_to_net(top->dp_scheme_file, o->dp_scheme_file);
 
 	top->allow_create = cpu_to_le32(o->allow_create);
 	top->allow_mounted_write = cpu_to_le32(o->allow_mounted_write);

--- a/dataplacement.h
+++ b/dataplacement.h
@@ -7,6 +7,7 @@
 #define FDP_DIR_DTYPE		2
 #define FDP_MAX_RUHS		128
 #define FIO_MAX_DP_IDS 		16
+#define DP_MAX_SCHEME_ENTRIES	32
 
 /*
  * How fio chooses what placement identifier to use next. Choice of
@@ -15,8 +16,8 @@
 enum {
 	FIO_DP_RANDOM	= 0x1,
 	FIO_DP_RR	= 0x2,
+	FIO_DP_SCHEME	= 0x3,
 };
-
 
 enum {
 	FIO_DP_NONE	= 0x0,
@@ -28,6 +29,17 @@ struct fio_ruhs_info {
 	uint32_t nr_ruhs;
 	uint32_t pli_loc;
 	uint16_t plis[];
+};
+
+struct fio_ruhs_scheme_entry {
+	unsigned long long start_offset;
+	unsigned long long end_offset;
+	uint16_t pli;
+};
+
+struct fio_ruhs_scheme {
+	uint16_t nr_schemes;
+	struct fio_ruhs_scheme_entry scheme_entries[DP_MAX_SCHEME_ENTRIES];
 };
 
 int dp_init(struct thread_data *td);

--- a/file.h
+++ b/file.h
@@ -103,6 +103,7 @@ struct fio_file {
 	uint64_t io_size;
 
 	struct fio_ruhs_info *ruhs_info;
+	struct fio_ruhs_scheme *ruhs_scheme;
 
 	/*
 	 * Zoned block device information. See also zonemode=zbd.

--- a/fio.1
+++ b/fio.1
@@ -2294,9 +2294,14 @@ Choose a placement ID at random (uniform).
 .TP
 .B roundrobin
 Round robin over available placement IDs. This is the default.
+.TP
+.B scheme
+Choose a placement ID (index) based on the scheme file defined by
+the option \fBdp_scheme\fP.
 .RE
 .P
-The available placement ID (indices) are defined by the \fBplids\fR option.
+The available placement ID (indices) are defined by \fBplids\fR or
+\fBfdp_pli\fR option except for the case of \fBscheme\fP.
 .RE
 .TP
 .BI (io_uring_cmd,xnvme)plids=str, fdp_pli \fR=\fPstr
@@ -2306,6 +2311,31 @@ available Placement IDs, so use this to isolate these identifiers to specific
 jobs. If you want fio to use placement identifier only at indices 0, 2 and 5
 specify, you would set `plids=0,2,5`. For streams this should be a
 comma-separated list of Stream IDs.
+.TP
+.BI (io_uring_cmd,xnvme)\fR\fBdp_scheme\fP=str
+Defines which placement ID (index) to be selected based on offset(LBA) range.
+The file should contains one or more scheme entries in the following format:
+.sp
+.RS
+.RS
+0, 10737418240, 0
+.br
+10737418240, 21474836480, 1
+.br
+21474836480, 32212254720, 2
+.br
+\&...
+.RE
+.sp
+Each line, a scheme entry, contains start offset, end offset, and placement ID
+(index) separated by comma(,). If the write offset is within the range of a certain
+scheme entry(start offset ≤ offset < end offset), the corresponding placement ID
+(index) will be selected. If the write offset belongs to multiple scheme entries,
+the first matched scheme entry will be applied. If the offset is not within any range
+of scheme entry, dspec field will be set to 0, default RUH. (Caution: In case of
+multiple devices in a job, all devices of the job will be affected by the scheme. If
+this option is specified, the option \fBplids\fP or \fBfdp_pli\fP will be ignored.)
+.RE
 .TP
 .BI (io_uring_cmd,xnvme)md_per_io_size \fR=\fPint
 Size in bytes for separate metadata buffer per IO. Default: 0.

--- a/server.h
+++ b/server.h
@@ -51,7 +51,7 @@ struct fio_net_cmd_reply {
 };
 
 enum {
-	FIO_SERVER_VER			= 104,
+	FIO_SERVER_VER			= 105,
 
 	FIO_SERVER_MAX_FRAGMENT_PDU	= 1024,
 	FIO_SERVER_MAX_CMD_MB		= 2048,

--- a/thread_options.h
+++ b/thread_options.h
@@ -396,6 +396,7 @@ struct thread_options {
 	unsigned int dp_id_select;
 	unsigned int dp_ids[FIO_MAX_DP_IDS];
 	unsigned int dp_nr_ids;
+	char *dp_scheme_file;
 
 	unsigned int log_entries;
 	unsigned int log_prio;
@@ -713,6 +714,7 @@ struct thread_options_pack {
 	uint32_t dp_id_select;
 	uint32_t dp_ids[FIO_MAX_DP_IDS];
 	uint32_t dp_nr_ids;
+	uint8_t dp_scheme_file[FIO_TOP_STR_MAX];
 
 	uint32_t num_range;
 	/*


### PR DESCRIPTION
### **fdp: support scheme placement id (index) selection**
    
Add a new placement id selection method called scheme. It allows
users to assign a placement ID (index) depending on the offset range.
The strategy of the scheme is specified in the file by user and
is applicable using the option dp_scheme.

Signed-off-by: Hyunwoo Park <dshw.park@samsung.com>

### **t/nvmept_fdp: add tests(302,303,400,401) for fdp scheme**
   
- 302/303: invalid options tests
- 400/401: check whether fdp scheme works properly
    
Signed-off-by: Hyunwoo Park <dshw.park@samsung.com>