### PR TITLE
io_uring: Fix error status of cqe

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -476,7 +476,7 @@ static struct io_u *fio_ioring_cmd_event(struct thread_data *td, int event)
 	io_u = (struct io_u *) (uintptr_t) cqe->user_data;
 
 	if (cqe->res != 0) {
-		io_u->error = -cqe->res;
+		io_u->error = abs(cqe->res);
 		return io_u;
 	} else {
 		io_u->error = 0;

--- a/options.c
+++ b/options.c
@@ -495,7 +495,11 @@ static int ignore_error_type(struct thread_data *td, enum error_type_bit etype,
 		if (fname[0] == 'E') {
 			error[i] = str2error(fname);
 		} else {
-			error[i] = atoi(fname);
+			int base = 10;
+			if (!strncmp(fname, "0x", 2) ||
+					!strncmp(fname, "0X", 2))
+				base = 16;
+			error[i] = strtol(fname, NULL, base);
 			if (error[i] < 0)
 				error[i] = -error[i];
 		}


### PR DESCRIPTION
The 'io_uring_cmd' ioengine returns the status code type and status code of
NVMe CQE [27:17] to io_u in case of errors.  The first patch fixes the CQE
value being returned as negative since it's not an errno.  The next one is a
trivial patch to support hexadecimal format to 'ignore_error' option to mask
values such as the status type and status code in a more comfortable way.