### PR TITLE
io_uring: Add 'write_mode' option for optional cmds

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2857,6 +2857,22 @@ with the caveat that when used on the command line, they must come after the
 	With writefua option set to 1, write operations include
 	the force unit access (fua) flag. Default is 0.
 
+.. option:: write_mode=str : [io_uring_cmd]
+
+        Specifies the type of write operation.  Defaults to 'write'.
+
+                **write**
+                        Use Write commands for write operations
+
+                **uncor**
+                        Use Write Uncorrectable commands for write opreations
+
+                **zeroes**
+                        Use Write Zeroes commands for write operations
+
+                **verify**
+                        Use Verify commands for write operations
+
 .. option:: sg_write_mode=str : [sg]
 
 	Specify the type of write commands to issue. This option can take ten values:

--- a/engines/nvme.c
+++ b/engines/nvme.c
@@ -363,7 +363,7 @@ void fio_nvme_uring_cmd_trim_prep(struct nvme_uring_cmd *cmd, struct io_u *io_u,
 
 int fio_nvme_uring_cmd_prep(struct nvme_uring_cmd *cmd, struct io_u *io_u,
 			    struct iovec *iov, struct nvme_dsm *dsm,
-			    unsigned int cdw12_flags)
+			    uint8_t write_opcode, unsigned int cdw12_flags)
 {
 	struct nvme_data *data = FILE_ENG_DATA(io_u->file);
 	__u64 slba;
@@ -376,7 +376,7 @@ int fio_nvme_uring_cmd_prep(struct nvme_uring_cmd *cmd, struct io_u *io_u,
 		cmd->opcode = nvme_cmd_read;
 		break;
 	case DDIR_WRITE:
-		cmd->opcode = nvme_cmd_write;
+		cmd->opcode = write_opcode;
 		break;
 	case DDIR_TRIM:
 		fio_nvme_uring_cmd_trim_prep(cmd, io_u, dsm);

--- a/engines/nvme.h
+++ b/engines/nvme.h
@@ -75,7 +75,10 @@ enum nvme_admin_opcode {
 enum nvme_io_opcode {
 	nvme_cmd_write			= 0x01,
 	nvme_cmd_read			= 0x02,
+	nvme_cmd_write_uncor		= 0x04,
+	nvme_cmd_write_zeroes		= 0x08,
 	nvme_cmd_dsm			= 0x09,
+	nvme_cmd_verify			= 0x0c,
 	nvme_cmd_io_mgmt_recv		= 0x12,
 	nvme_zns_cmd_mgmt_send		= 0x79,
 	nvme_zns_cmd_mgmt_recv		= 0x7a,
@@ -427,7 +430,7 @@ int fio_nvme_get_info(struct fio_file *f, __u64 *nlba, __u32 pi_act,
 
 int fio_nvme_uring_cmd_prep(struct nvme_uring_cmd *cmd, struct io_u *io_u,
 			    struct iovec *iov, struct nvme_dsm *dsm,
-			    unsigned int cdw12_flags);
+			    uint8_t write_opcode, unsigned int cdw12_flags);
 
 void fio_nvme_pi_fill(struct nvme_uring_cmd *cmd, struct io_u *io_u,
 		      struct nvme_cmd_ext_io_opts *opts);

--- a/fio.1
+++ b/fio.1
@@ -2640,6 +2640,26 @@ unit access (fua) flag. Default: 0.
 With writefua option set to 1, write operations include the force
 unit access (fua) flag. Default: 0.
 .TP
+.BI (io_uring_cmd)write_mode \fR=\fPstr
+Specifies the type of write operation.  Defaults to 'write'.
+.RS
+.RS
+.TP
+.B write
+Use Write commands for write operations
+.TP
+.B uncor
+Use Write Uncorrectable commands for write opreations
+.TP
+.B zeroes
+Use Write Zeroes commands for write operations
+.TP
+.B verify
+Use Verify commands for write operations
+.TP
+.RE
+.RE
+.TP
 .BI (sg)sg_write_mode \fR=\fPstr
 Specify the type of write commands to issue. This option can take multiple
 values:


### PR DESCRIPTION
Add a new option 'write_mode' to support additional optional Write
command family such as Write Uncorrectable and Write Zeroes in NVMe.
Since we have io_uring_cmd ioengine where we can define the actual
opcode of the command, this option will be used to test NVMe device with
various combination of Write command types.

'write_mode' option can be given either 'write', 'uncor', 'zeroes' or
'verify'.  'write' is for normal Write command which is by default,
'uncor' is for Write Uncorrectable, 'zeroes' for Write Zeroes and 'verify'
for Verify command  This should be used with DDIR_WRITE ddir.

This patch updates command's opcode in fio_ioring_init() to avoid
branches in the I/O hottest path giving opcode value to the
fio_nvme_uring_cmd_prep() as an argument.