### PR TITLE
iolog, dataplacement: fix coverity scan defect

### DIFF
--- a/iolog.c
+++ b/iolog.c
@@ -145,7 +145,7 @@ static int ipo_special(struct thread_data *td, struct io_piece *ipo)
 				int dp_init_ret = dp_init(td);
 
 				if (dp_init_ret != 0) {
-					td_verror(td, dp_init_ret, "dp_init");
+					td_verror(td, abs(dp_init_ret), "dp_init");
 					return -1;
 				}
 			}

--- a/iolog.c
+++ b/iolog.c
@@ -236,14 +236,14 @@ int read_iolog_get(struct thread_data *td, struct io_u *io_u)
 						io_u->buflen, io_u->file->file_name);
 			if (ipo->delay)
 				iolog_delay(td, ipo->delay);
+
+			if (td->o.dp_type != FIO_DP_NONE)
+				dp_fill_dspec_data(td, io_u);
 		} else {
 			elapsed = mtime_since_genesis();
 			if (ipo->delay > elapsed)
 				usec_sleep(td, (ipo->delay - elapsed) * 1000);
 		}
-
-		if (td->o.dp_type != FIO_DP_NONE)
-			dp_fill_dspec_data(td, io_u);
 
 		free(ipo);
 


### PR DESCRIPTION
### **iolog: fix Error handling issues (NEGATIVE_RETURNS)**

CID 494151: Error handling issues (NEGATIVE_RETURNS) @ io_u.c:1877 in get_io_u()
This patch removes negative returns from dp_init() to ensure
its value can be properly consumed by td_verror()

Signed-off-by: Hyunwoo Park <dshw.park@samsung.com>
 
### **iolog: fix Null pointer dereferences (FORWARD_NULL)**

CID 494150: Null pointer dereferences (FORWARD_NULL) @ iolog.c:148 in ipo_special()
This patch removes the possibility of null pointer dereferencing(io_u->file)
throughout the call stack of get_io_u() → read_iolog_get() → dp_fill_dspec_data()

Signed-off-by: Hyunwoo Park <dshw.park@samsung.com>