### PR TITLE
For nfs engine, treat randwrite the same as write when opening file

### DIFF
--- a/engines/nfs.c
+++ b/engines/nfs.c
@@ -280,7 +280,7 @@ static int fio_libnfs_open(struct thread_data *td, struct fio_file *f)
 	nfs_data = calloc(1, sizeof(struct nfs_data));
 	nfs_data->options = options;
 
-	if (td->o.td_ddir == TD_DDIR_WRITE)
+	if (td_write(td))
 		flags |= O_CREAT | O_RDWR;
 	else
 		flags |= O_RDWR;


### PR DESCRIPTION
When use nfs engine, only write mode can work if file doesn't exist before test starts. This code change just made randwrite behaves the same as write. So both write and randwrite could work in scenario where file doesn't exist before test start.

Note: other than write and randwrite mode, nfs engine would report error when test start. This is because fio would not layout the file before test start. This also indicate that currently nfs engine requires user to make sure files are ready before test when choose mode such as read, randread and readwrite.

This requires more code changes. So now just add one line code change to let randwrite can work.
