### PR TITLE
Fix issue when start randwrite by using nfs engine

### DIFF
--- a/engines/nfs.c
+++ b/engines/nfs.c
@@ -280,7 +280,7 @@ static int fio_libnfs_open(struct thread_data *td, struct fio_file *f)
 	nfs_data = calloc(1, sizeof(struct nfs_data));
 	nfs_data->options = options;
 
-	if (td->o.td_ddir == TD_DDIR_WRITE)
+	if (td_write(td))
 		flags |= O_CREAT | O_RDWR;
 	else
 		flags |= O_RDWR;


### PR DESCRIPTION
Fio would fail to stop jobs when set io mode other than write by using nfs engine. This fix can make sure randwrite works correctly since both write and randwrite will create file first and then start IO.

Note: for nfs engine, other IO modes which include read will require user to have the file ready before test start. If we want fio to setup and extend the file before job start, that would involve more code changes. The fix here only make randwrite would behave the same as write, and this should match what user should expect.
