### PR TITLE
fio: fix formats under MIPS64/PPC

### DIFF
--- a/engines/nvme.h
+++ b/engines/nvme.h
@@ -7,6 +7,8 @@
 #ifndef FIO_NVME_H
 #define FIO_NVME_H
 
+#define __SANE_USERSPACE_TYPES__
+
 #include <linux/nvme_ioctl.h>
 #include "../fio.h"
 


### PR DESCRIPTION
__SANE_USERSPACE_TYPES__ needs to be defined to get consistent formats on all platforms.

