### PR TITLE
Support platform QNX OS

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -118,12 +118,20 @@ static void set_sig_handlers(void)
 
 	memset(&act, 0, sizeof(act));
 	act.sa_handler = sig_int;
+	#if defined(__QNX__)
+	act.sa_flags = SA_NOCLDSTOP;
+	#else
 	act.sa_flags = SA_RESTART;
+	#endif
 	sigaction(SIGINT, &act, NULL);
 
 	memset(&act, 0, sizeof(act));
 	act.sa_handler = sig_int;
+	#if defined(__QNX__)
+	act.sa_flags = SA_NOCLDSTOP;
+	#else
 	act.sa_flags = SA_RESTART;
+	#endif
 	sigaction(SIGTERM, &act, NULL);
 
 /* Windows uses SIGBREAK as a quit signal from other applications */
@@ -136,13 +144,21 @@ static void set_sig_handlers(void)
 
 	memset(&act, 0, sizeof(act));
 	act.sa_handler = sig_show_status;
+	#if defined(__QNX__)
+	act.sa_flags = SA_NOCLDSTOP;
+	#else
 	act.sa_flags = SA_RESTART;
+	#endif
 	sigaction(SIGUSR1, &act, NULL);
 
 	if (is_backend) {
 		memset(&act, 0, sizeof(act));
 		act.sa_handler = sig_int;
+		#if defined(__QNX__)
+		act.sa_flags = SA_NOCLDSTOP;
+		#else
 		act.sa_flags = SA_RESTART;
+		#endif
 		sigaction(SIGPIPE, &act, NULL);
 	}
 }

--- a/client.c
+++ b/client.c
@@ -652,12 +652,20 @@ static void client_signal_handler(void)
 
 	memset(&act, 0, sizeof(act));
 	act.sa_handler = sig_int;
+	#if defined(__QNX__)
+	act.sa_flags = SA_NOCLDSTOP;
+	#else
 	act.sa_flags = SA_RESTART;
+	#endif
 	sigaction(SIGINT, &act, NULL);
 
 	memset(&act, 0, sizeof(act));
 	act.sa_handler = sig_int;
+	#if defined(__QNX__)
+	act.sa_flags = SA_NOCLDSTOP;
+	#else
 	act.sa_flags = SA_RESTART;
+	#endif
 	sigaction(SIGTERM, &act, NULL);
 
 /* Windows uses SIGBREAK as a quit signal from other applications */
@@ -670,7 +678,11 @@ static void client_signal_handler(void)
 
 	memset(&act, 0, sizeof(act));
 	act.sa_handler = sig_show_status;
+	#if defined(__QNX__)
+	act.sa_flags = SA_NOCLDSTOP;
+	#else
 	act.sa_flags = SA_RESTART;
+	#endif
 	sigaction(SIGUSR1, &act, NULL);
 }
 

--- a/configure
+++ b/configure
@@ -366,6 +366,8 @@ elif check_define __sun__ ; then
   CFLAGS="$CFLAGS -D_REENTRANT"
 elif check_define _WIN32 ; then
   targetos='CYGWIN'
+elif check_define __QNX__ ; then
+  targetos='QNX'
 else
   targetos=`uname -s`
 fi
@@ -465,6 +467,9 @@ CYGWIN*)
   sched_idle="yes"
   pthread_condattr_setclock="no"
   pthread_affinity="no"
+  ;;
+QNX)
+  LIBS="-lsocket"
   ;;
 esac
 
@@ -1090,6 +1095,7 @@ if test "$have_vasprintf" != "yes" ; then
 fi
 cat > $TMPC << EOF
 #include <stdio.h>
+#include <stdarg.h>
 
 int main(int argc, char **argv)
 {

--- a/engines/e4defrag.c
+++ b/engines/e4defrag.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 
 #include "../fio.h"
 #include "../optgroup.h"

--- a/init.c
+++ b/init.c
@@ -18,8 +18,14 @@
 
 #include "fio.h"
 #ifndef FIO_NO_HAVE_SHM_H
+#if defined(__QNX__)
+#include <sys/mman.h>
+#else
 #include <sys/shm.h>
 #endif
+#endif
+
+
 
 #include "parse.h"
 #include "smalloc.h"

--- a/memory.c
+++ b/memory.c
@@ -8,7 +8,11 @@
 
 #include "fio.h"
 #ifndef FIO_NO_HAVE_SHM_H
+#if defined(__QNX__)
+#include <sys/mman.h>
+#else
 #include <sys/shm.h>
+#endif
 #endif
 
 void fio_unpin_memory(struct thread_data *td)

--- a/os/os-qnx.h
+++ b/os/os-qnx.h
@@ -1,0 +1,97 @@
+#ifndef FIO_OS_QNX_H
+#define FIO_OS_QNX_H
+
+#define	FIO_OS	os_qnx
+#include <stdint.h>
+#include <errno.h>
+#include <sys/param.h>
+#include <sys/statvfs.h>
+#include <sys/ioctl.h>
+#include <sys/utsname.h>
+#include <sys/sysctl.h>
+#include <sys/dcmd_cam.h>
+
+/* XXX hack to avoid conflicts between rbtree.h and <sys/tree.h> */
+#undef RB_BLACK
+#undef RB_RED
+#undef RB_ROOT
+
+#include "../file.h"
+
+typedef uint64_t __u64;
+typedef unsigned int __u32;
+
+#define FIO_USE_GENERIC_INIT_RANDOM_STATE
+#define FIO_HAVE_FS_STAT
+#define FIO_HAVE_GETTID
+
+#define OS_MAP_ANON		MAP_ANON
+
+#ifndef PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN 4096
+#endif
+
+#define fio_swap16(x)	swap16(x)
+#define fio_swap32(x)	swap32(x)
+#define fio_swap64(x)	swap64(x)
+
+#ifdef CONFIG_PTHREAD_GETAFFINITY
+#define FIO_HAVE_GET_THREAD_AFFINITY
+#define fio_get_thread_affinity(mask)	\
+	pthread_getaffinity_np(pthread_self(), sizeof(mask), &(mask))
+#endif
+
+static inline int blockdev_size(struct fio_file *f, unsigned long long *bytes)
+{
+
+	struct cam_devinfo		cam;
+	if (devctl(f->fd, DCMD_CAM_DEVINFO, &cam, sizeof(cam), NULL) == EOK) {
+		*bytes  = cam.num_sctrs * 512;
+		return 0;
+	}
+
+	*bytes = 0;
+	return errno;
+}
+
+static inline int blockdev_invalidate_cache(struct fio_file *f)
+{
+	return ENOTSUP;
+}
+
+static inline unsigned long long os_phys_mem(void)
+{
+	int mib[2] = { CTL_HW, HW_PHYSMEM64 };
+	uint64_t mem;
+	size_t len = sizeof(mem);
+
+	sysctl(mib, 2, &mem, &len, NULL, 0);
+	return mem;
+}
+
+#ifndef CONFIG_HAVE_GETTID
+#error
+static inline int gettid(void)
+{
+	return (int)(intptr_t) pthread_self();
+}
+#endif
+
+static inline unsigned long long get_fs_free_size(const char *path)
+{
+	unsigned long long ret;
+	struct statvfs s;
+
+	if (statvfs(path, &s) < 0)
+		return -1ULL;
+
+	ret = s.f_frsize;
+	ret *= (unsigned long long) s.f_bfree;
+	return ret;
+}
+
+#ifdef MADV_FREE
+#define FIO_MADV_FREE	MADV_FREE
+#endif
+
+#endif

--- a/os/os.h
+++ b/os/os.h
@@ -24,7 +24,7 @@ enum {
 	os_windows,
 	os_android,
 	os_dragonfly,
-
+	os_qnx,
 	os_nr,
 };
 
@@ -39,6 +39,8 @@ typedef enum {
 #include "os-freebsd.h"
 #elif defined(__OpenBSD__)
 #include "os-openbsd.h"
+#elif defined(__QNX__)
+#include "os-qnx.h"
 #elif defined(__NetBSD__)
 #include "os-netbsd.h"
 #elif defined(__sun__)

--- a/oslib/inet_aton.h
+++ b/oslib/inet_aton.h
@@ -2,7 +2,9 @@
 #define FIO_INET_ATON_LIB_H
 
 #include <arpa/inet.h>
-
+#if defined(__QNX__)
+#include <sys/socket.h>
+#endif
 int inet_aton(const char *cp, struct in_addr *inp);
 
 #endif

--- a/server.c
+++ b/server.c
@@ -2743,9 +2743,15 @@ static void set_sig_handlers(void)
 	struct sigaction act = {
 		.sa_handler = sig_int,
 		#if defined(__QNX__)
+<<<<<<< HEAD
 		act.sa_flags = SA_NOCLDSTOP,
 		#else
 		act.sa_flags = SA_RESTART,
+=======
+		.sa_flags = SA_NOCLDSTOP,
+		#else
+		.sa_flags = SA_RESTART,
+>>>>>>> Support platform QNX OS
 		#endif
 	};
 

--- a/server.c
+++ b/server.c
@@ -2742,7 +2742,11 @@ static void set_sig_handlers(void)
 {
 	struct sigaction act = {
 		.sa_handler = sig_int,
-		.sa_flags = SA_RESTART,
+		#if defined(__QNX__)
+		act.sa_flags = SA_NOCLDSTOP,
+		#else
+		act.sa_flags = SA_RESTART,
+		#endif
 	};
 
 	sigaction(SIGINT, &act, NULL);


### PR DESCRIPTION
Compile with SDP7.1:
./configure --cc=aarch64-unknown-nto-qnx7.1.0-gcc --disable-shm make

Function is verfied by UFS device read and write test.

Signed-off-by: Huang weiliang <weller.huang@us.bosch.com>
