### PR TITLE
Support QNX OS platform

### DIFF
--- a/configure
+++ b/configure
@@ -366,6 +366,8 @@ elif check_define __sun__ ; then
   CFLAGS="$CFLAGS -D_REENTRANT"
 elif check_define _WIN32 ; then
   targetos='CYGWIN'
+elif check_define __QNX__ ; then
+  targetos='QNX'
 else
   targetos=`uname -s`
 fi
@@ -465,6 +467,9 @@ CYGWIN*)
   sched_idle="yes"
   pthread_condattr_setclock="no"
   pthread_affinity="no"
+  ;;
+QNX)
+  LIBS="-lsocket"
   ;;
 esac
 
@@ -1090,6 +1095,7 @@ if test "$have_vasprintf" != "yes" ; then
 fi
 cat > $TMPC << EOF
 #include <stdio.h>
+#include <stdarg.h>
 
 int main(int argc, char **argv)
 {

--- a/engines/e4defrag.c
+++ b/engines/e4defrag.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 
 #include "../fio.h"
 #include "../optgroup.h"

--- a/os/os-qnx.h
+++ b/os/os-qnx.h
@@ -1,0 +1,100 @@
+#ifndef FIO_OS_QNX_H
+#define FIO_OS_QNX_H
+
+#define	FIO_OS	os_qnx
+#include <stdint.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/param.h>
+#include <sys/statvfs.h>
+#include <sys/ioctl.h>
+#include <sys/utsname.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/dcmd_cam.h>
+
+/* XXX hack to avoid conflicts between rbtree.h and <sys/tree.h> */
+#undef RB_BLACK
+#undef RB_RED
+#undef RB_ROOT
+
+#include "../file.h"
+
+/* QNX is not supporting SA_RESTART. Use SA_NOCLDSTOP instead of it */
+#ifndef SA_RESTART
+#define SA_RESTART SA_NOCLDSTOP
+#endif
+
+#define FIO_NO_HAVE_SHM_H
+
+typedef uint64_t __u64;
+typedef unsigned int __u32;
+
+#define FIO_USE_GENERIC_INIT_RANDOM_STATE
+#define FIO_HAVE_FS_STAT
+#define FIO_HAVE_GETTID
+
+#define OS_MAP_ANON		MAP_ANON
+
+#ifndef PTHREAD_STACK_MIN
+#define PTHREAD_STACK_MIN 4096
+#endif
+
+#define fio_swap16(x)	swap16(x)
+#define fio_swap32(x)	swap32(x)
+#define fio_swap64(x)	swap64(x)
+
+#ifdef CONFIG_PTHREAD_GETAFFINITY
+#define FIO_HAVE_GET_THREAD_AFFINITY
+#define fio_get_thread_affinity(mask)	\
+	pthread_getaffinity_np(pthread_self(), sizeof(mask), &(mask))
+#endif
+
+static inline int blockdev_size(struct fio_file *f, unsigned long long *bytes)
+{
+	struct stat statbuf;
+	if (fstat(f->fd, &statbuf) == -1) {
+		perror("fstat");
+	} else {
+		*bytes = (unsigned long long)(statbuf.st_blocksize * statbuf.st_nblocks);
+		return 0;
+	}
+
+	*bytes = 0;
+	return errno;
+}
+
+static inline int blockdev_invalidate_cache(struct fio_file *f)
+{
+	return ENOTSUP;
+}
+
+static inline unsigned long long os_phys_mem(void)
+{
+	int mib[2] = { CTL_HW, HW_PHYSMEM64 };
+	uint64_t mem;
+	size_t len = sizeof(mem);
+
+	sysctl(mib, 2, &mem, &len, NULL, 0);
+	return mem;
+}
+
+static inline unsigned long long get_fs_free_size(const char *path)
+{
+	unsigned long long ret;
+	struct statvfs s;
+
+	if (statvfs(path, &s) < 0)
+		return -1ULL;
+
+	ret = s.f_frsize;
+	ret *= (unsigned long long) s.f_bfree;
+	return ret;
+}
+
+#ifdef MADV_FREE
+#define FIO_MADV_FREE	MADV_FREE
+#endif
+
+#endif

--- a/os/os.h
+++ b/os/os.h
@@ -24,6 +24,7 @@ enum {
 	os_windows,
 	os_android,
 	os_dragonfly,
+	os_qnx,
 
 	os_nr,
 };
@@ -39,6 +40,8 @@ typedef enum {
 #include "os-freebsd.h"
 #elif defined(__OpenBSD__)
 #include "os-openbsd.h"
+#elif defined(__QNX__)
+#include "os-qnx.h"
 #elif defined(__NetBSD__)
 #include "os-netbsd.h"
 #elif defined(__sun__)


### PR DESCRIPTION
Add support QNX OS platform

To  mainline those changes for better maintenance.

Compile command: QNX SDP7.1 example
./configure --cc=aarch64-unknown-nto-qnx7.1.0-gcc --disable-shm; make

Basic file read and write test with ioengine=sync is verified.

Signed-off-by: Huang weiliang <weller.huang@us.bosch.com>