### PR TITLE
FDP fixes

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -1533,10 +1533,12 @@ static int fio_ioring_cmd_fetch_ruhs(struct thread_data *td, struct fio_file *f,
 				     struct fio_ruhs_info *fruhs_info)
 {
 	struct nvme_fdp_ruh_status *ruhs;
-	int bytes, ret, i;
+	int bytes, nr_ruhs, ret, i;
 
-	bytes = sizeof(*ruhs) + FDP_MAX_RUHS * sizeof(struct nvme_fdp_ruh_status_desc);
-	ruhs = scalloc(1, bytes);
+	nr_ruhs = fruhs_info->nr_ruhs;
+	bytes = sizeof(*ruhs) + fruhs_info->nr_ruhs * sizeof(struct nvme_fdp_ruh_status_desc);
+
+	ruhs = calloc(1, bytes);
 	if (!ruhs)
 		return -ENOMEM;
 
@@ -1545,12 +1547,10 @@ static int fio_ioring_cmd_fetch_ruhs(struct thread_data *td, struct fio_file *f,
 		goto free;
 
 	fruhs_info->nr_ruhs = le16_to_cpu(ruhs->nruhsd);
-	if (fruhs_info->nr_ruhs > FDP_MAX_RUHS)
-		fruhs_info->nr_ruhs = FDP_MAX_RUHS;
-	for (i = 0; i < fruhs_info->nr_ruhs; i++)
+	for (i = 0; i < nr_ruhs; i++)
 		fruhs_info->plis[i] = le16_to_cpu(ruhs->ruhss[i].pid);
 free:
-	sfree(ruhs);
+	free(ruhs);
 	return ret;
 }
 

--- a/engines/xnvme.c
+++ b/engines/xnvme.c
@@ -1253,7 +1253,7 @@ static int xnvme_fioe_fetch_ruhs(struct thread_data *td, struct fio_file *f,
 	struct xnvme_dev *dev;
 	struct xnvme_spec_ruhs *ruhs;
 	struct xnvme_cmd_ctx ctx;
-	uint32_t ruhs_nbytes;
+	uint32_t ruhs_nbytes, nr_ruhs;
 	uint32_t nsid;
 	int err = 0, err_lock;
 
@@ -1276,7 +1276,8 @@ static int xnvme_fioe_fetch_ruhs(struct thread_data *td, struct fio_file *f,
 		goto exit;
 	}
 
-	ruhs_nbytes = sizeof(*ruhs) + (FDP_MAX_RUHS * sizeof(struct xnvme_spec_ruhs_desc));
+	nr_ruhs = fruhs_info->nr_ruhs;
+	ruhs_nbytes = sizeof(*ruhs) + (fruhs_info->nr_ruhs * sizeof(struct xnvme_spec_ruhs_desc));
 	ruhs = xnvme_buf_alloc(dev, ruhs_nbytes);
 	if (!ruhs) {
 		err = -errno;
@@ -1296,7 +1297,7 @@ static int xnvme_fioe_fetch_ruhs(struct thread_data *td, struct fio_file *f,
 	}
 
 	fruhs_info->nr_ruhs = ruhs->nruhsd;
-	for (uint32_t idx = 0; idx < fruhs_info->nr_ruhs; ++idx) {
+	for (uint32_t idx = 0; idx < nr_ruhs; ++idx) {
 		fruhs_info->plis[idx] = le16_to_cpu(ruhs->desc[idx].pi);
 	}
 


### PR DESCRIPTION

The current way of fdp ruhs initialization limited it to a maximum of 128 ruhs descriptors. Fio allows a total of 128 placement id 
indices at a time, but for devices supporting more the 128 ruhs, users should have the ability to pass any 128 placement id index / indices (0 to max number of ruhs - 1). This series fixes that.