### PR TITLE
Small fdp fixes

### DIFF
--- a/dataplacement.c
+++ b/dataplacement.c
@@ -71,16 +71,16 @@ static int init_ruh_info(struct thread_data *td, struct fio_file *f)
 	ruhs = calloc(1, sizeof(*ruhs));
 	ret = fdp_ruh_info(td, f, ruhs);
 	if (ret) {
-		log_info("fio: ruh info failed for %s (%d)\n",
-			 f->file_name, -ret);
+		log_err("fio: ruh info failed for %s (%d)\n",
+			f->file_name, -ret);
 		goto out;
 	}
 
 	nr_ruhs = ruhs->nr_ruhs;
 	ruhs = realloc(ruhs, sizeof(*ruhs) + nr_ruhs * sizeof(*ruhs->plis));
 	if (!ruhs) {
-		log_info("fio: ruhs buffer realloc failed for %s\n",
-			 f->file_name);
+		log_err("fio: ruhs buffer realloc failed for %s\n",
+			f->file_name);
 		ret = -ENOMEM;
 		goto out;
 	}
@@ -88,8 +88,8 @@ static int init_ruh_info(struct thread_data *td, struct fio_file *f)
 	ruhs->nr_ruhs = nr_ruhs;
 	ret = fdp_ruh_info(td, f, ruhs);
 	if (ret) {
-		log_info("fio: ruh info failed for %s (%d)\n",
-			 f->file_name, -ret);
+		log_err("fio: ruh info failed for %s (%d)\n",
+			f->file_name, -ret);
 		goto out;
 	}
 
@@ -151,7 +151,7 @@ static int init_ruh_scheme(struct thread_data *td, struct fio_file *f)
 
 	if (!scheme_fp) {
 		log_err("fio: ruh scheme failed to open scheme file %s\n",
-			 td->o.dp_scheme_file);
+			td->o.dp_scheme_file);
 		ret = -errno;
 		goto out;
 	}

--- a/dataplacement.c
+++ b/dataplacement.c
@@ -52,7 +52,7 @@ static int init_ruh_info(struct thread_data *td, struct fio_file *f)
 			log_err("fio: stream IDs must be provided for dataplacement=streams\n");
 			return -EINVAL;
 		}
-		ruhs = scalloc(1, sizeof(*ruhs) + FDP_MAX_RUHS * sizeof(*ruhs->plis));
+		ruhs = scalloc(1, sizeof(*ruhs) + FIO_MAX_DP_IDS * sizeof(*ruhs->plis));
 		if (!ruhs)
 			return -ENOMEM;
 
@@ -94,15 +94,14 @@ static int init_ruh_info(struct thread_data *td, struct fio_file *f)
 	}
 
 	if (td->o.dp_nr_ids == 0) {
-		if (ruhs->nr_ruhs > FDP_MAX_RUHS)
-			ruhs->nr_ruhs = FDP_MAX_RUHS;
+		if (ruhs->nr_ruhs > FIO_MAX_DP_IDS)
+			ruhs->nr_ruhs = FIO_MAX_DP_IDS;
 	} else {
-		if (td->o.dp_nr_ids > FDP_MAX_RUHS) {
-			ret = -EINVAL;
-			goto out;
-		}
 		for (i = 0; i < td->o.dp_nr_ids; i++) {
 			if (td->o.dp_ids[i] >= ruhs->nr_ruhs) {
+				log_err("fio: for %s PID index %d must be smaller than %d\n",
+					f->file_name, td->o.dp_ids[i],
+					ruhs->nr_ruhs);
 				ret = -EINVAL;
 				goto out;
 			}

--- a/dataplacement.h
+++ b/dataplacement.h
@@ -5,7 +5,6 @@
 
 #define STREAMS_DIR_DTYPE	1
 #define FDP_DIR_DTYPE		2
-#define FDP_MAX_RUHS		128
 #define FIO_MAX_DP_IDS 		128
 #define DP_MAX_SCHEME_ENTRIES	32
 

--- a/ioengines.h
+++ b/ioengines.h
@@ -9,7 +9,7 @@
 #include "zbd_types.h"
 #include "dataplacement.h"
 
-#define FIO_IOOPS_VERSION	34
+#define FIO_IOOPS_VERSION	35
 
 #ifndef CONFIG_DYNAMIC_ENGINES
 #define FIO_STATIC	static


### PR DESCRIPTION
This series has 3 patches
1. Removing FDP_MAX_RUHS, as now we are fetching all the ruhs reported by the device, and then parsing the ones requested as per the placement ID indices.
2. log_info to log_err for all the error messages.
3. Incrementing FIO_IOOPS_VERSION, for any external ioengine which may be using fdp_fetch_ruhs.
