### PR TITLE
io_uring: Add .errdetails to parse CQ status

### DIFF
--- a/engines/librpma_fio.c
+++ b/engines/librpma_fio.c
@@ -790,7 +790,7 @@ struct io_u *librpma_fio_client_event(struct thread_data *td, int event)
 	return io_u;
 }
 
-char *librpma_fio_client_errdetails(struct io_u *io_u)
+char *librpma_fio_client_errdetails(struct thread_data *td, struct io_u *io_u)
 {
 	/* get the string representation of an error */
 	enum ibv_wc_status status = io_u->error;

--- a/engines/librpma_fio.h
+++ b/engines/librpma_fio.h
@@ -162,7 +162,7 @@ int librpma_fio_client_getevents(struct thread_data *td, unsigned int min,
 
 struct io_u *librpma_fio_client_event(struct thread_data *td, int event);
 
-char *librpma_fio_client_errdetails(struct io_u *io_u);
+char *librpma_fio_client_errdetails(struct thread_data *td, struct io_u *io_u);
 
 static inline int librpma_fio_client_io_read(struct thread_data *td,
 		struct io_u *io_u, int flags)

--- a/engines/sg.c
+++ b/engines/sg.c
@@ -1154,7 +1154,7 @@ int fio_sgio_close(struct thread_data *td, struct fio_file *f)
  * Build an error string with details about the driver, host or scsi
  * error contained in the sg header Caller will use as necessary.
  */
-static char *fio_sgio_errdetails(struct io_u *io_u)
+static char *fio_sgio_errdetails(struct thread_data *td, struct io_u *io_u)
 {
 	struct sg_io_hdr *hdr = &io_u->hdr;
 #define MAXERRDETAIL 1024

--- a/io_u.c
+++ b/io_u.c
@@ -1963,7 +1963,7 @@ static void __io_u_log_error(struct thread_data *td, struct io_u *io_u)
 	zbd_log_err(td, io_u);
 
 	if (td->io_ops->errdetails) {
-		char *err = td->io_ops->errdetails(io_u);
+		char *err = td->io_ops->errdetails(td, io_u);
 
 		log_err("fio: %s\n", err);
 		free(err);

--- a/ioengines.h
+++ b/ioengines.h
@@ -9,7 +9,7 @@
 #include "zbd_types.h"
 #include "dataplacement.h"
 
-#define FIO_IOOPS_VERSION	35
+#define FIO_IOOPS_VERSION	36
 
 #ifndef CONFIG_DYNAMIC_ENGINES
 #define FIO_STATIC	static
@@ -40,7 +40,7 @@ struct ioengine_ops {
 	int (*commit)(struct thread_data *);
 	int (*getevents)(struct thread_data *, unsigned int, unsigned int, const struct timespec *);
 	struct io_u *(*event)(struct thread_data *, int);
-	char *(*errdetails)(struct io_u *);
+	char *(*errdetails)(struct thread_data *, struct io_u *);
 	int (*cancel)(struct thread_data *, struct io_u *);
 	void (*cleanup)(struct thread_data *);
 	int (*open_file)(struct thread_data *, struct fio_file *);


### PR DESCRIPTION
Background
 - fio normally prints out the strerr and errno value when facing errors.  In case of io_uring_cmd ioengine with --cmd_type=nvme, io_u->error represents the CQ entry status code type and status code which should be parsed as a NVMe error value rather than errno.

In io_u error failure condition, it prints out parsed CQ entry error status values with SCT(Status Code Type) and SC(Status Code).  The print will be like the following example:

  fio: io_uring_cmd: /dev/ng0n1: cq entry status (sct=0x00; sc=0x04)

If --cmd_type!=nvme, it prints out generic status code like below:

  fio: io_uring_cmd: /dev/<devnode>: status=0x4