### PR TITLE
Make `should_fsync()` taking a constant.

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -628,7 +628,7 @@ static inline bool multi_range_trim(struct thread_data *td, struct io_u *io_u)
 	return false;
 }
 
-static inline bool should_fsync(struct thread_data *td)
+static inline bool should_fsync(const struct thread_data *td)
 {
 	if (ddir_sync(td->last_ddir_issued))
 		return false;


### PR DESCRIPTION
Make `should_fsync()` safer by using a pointer to a constant thread_data structure instance.
This update is mostly to address the need of `get_sync_ddir()` function (a caller of `should_fsync()`) to operate with a `thread_data` instance as a constant. See PR #1799 for details.

Signed-off-by: Roman Sofin roma.sofin@gmail.com