### PR TITLE
Fix configure with --build-static which enables static RDMA in #1801

### DIFF
--- a/configure
+++ b/configure
@@ -1005,8 +1005,9 @@ int main(int argc, char **argv)
   return pd != NULL;
 }
 EOF
-if test "$disable_rdma" != "yes" && compile_prog "" "-libverbs" "libverbs" ; then
+if test "$disable_rdma" != "yes" && compile_prog "" "-libverbs -lnl-3 -lnl-route-3" "libverbs" ; then
     libverbs="yes"
+    LIBS="-libverbs -lnl-3 -lnl-route-3 $LIBS"
 fi
 print_config "libverbs" "$libverbs"
 
@@ -1024,8 +1025,9 @@ int main(int argc, char **argv)
   return 0;
 }
 EOF
-if test "$disable_rdma" != "yes" && compile_prog "" "-lrdmacm" "rdma"; then
+if test "$disable_rdma" != "yes" && compile_prog "" "-lrdmacm -lnl-3 -lnl-route-3" "rdma"; then
     rdmacm="yes"
+    LIBS="-libverbs -lnl-3 -lnl-route-3 $LIBS"
 fi
 print_config "rdmacm" "$rdmacm"
 


### PR DESCRIPTION
Fix configure with --build-static option which enables static RDMA in Issue #1801

This pull request to probe static libibverbs/librdmacm library. It's neccessary to enable static RDMA engine build with netlink libnl-3 and libnl-route-3.

Signed-off-by: Huang Shumin longway68@qq.com
