### PR TITLE
linux: use O_EXCL when opening a file for write

### DIFF
--- a/engines/nvme.c
+++ b/engines/nvme.c
@@ -819,7 +819,14 @@ int fio_nvme_reset_wp(struct thread_data *td, struct fio_file *f,
 	/* If the file is not yet opened, open it for this function. */
 	fd = f->fd;
 	if (fd < 0) {
-		fd = open(f->file_name, O_RDWR | O_LARGEFILE);
+		int flags = O_RDWR | O_LARGEFILE;
+
+#ifdef FIO_USE_O_EXCL
+		if (!td->o.allow_mounted_write)
+			flags |= O_EXCL;
+#endif
+
+		fd = open(f->file_name, flags);
 		if (fd < 0)
 			return -errno;
 	}

--- a/engines/xnvme.c
+++ b/engines/xnvme.c
@@ -302,6 +302,14 @@ static struct xnvme_opts xnvme_opts_from_fioe(struct thread_data *td)
 
 	opts.direct = td->o.odirect;
 
+	opts.rdonly = opts.wronly = opts.rdwr = 0;
+	if (td_rw(td))
+		opts.rdwr = 1;
+	else if (td_write(td))
+		opts.wronly = 1;
+	else
+		opts.rdonly = 1;
+
 	return opts;
 }
 

--- a/os/os-linux.h
+++ b/os/os-linux.h
@@ -430,4 +430,6 @@ static inline bool os_cpu_has(cpu_features feature)
 	return have_feature;
 }
 
+#define FIO_USE_O_EXCL
+
 #endif

--- a/oslib/linux-blkzoned.c
+++ b/oslib/linux-blkzoned.c
@@ -323,7 +323,14 @@ int blkzoned_reset_wp(struct thread_data *td, struct fio_file *f,
 	/* If the file is not yet opened, open it for this function. */
 	fd = f->fd;
 	if (fd < 0) {
-		fd = open(f->file_name, O_RDWR | O_LARGEFILE);
+		int flags = O_RDWR | O_LARGEFILE;
+
+#ifdef FIO_USE_O_EXCL
+		if (!td->o.allow_mounted_write)
+			flags |= O_EXCL;
+#endif
+
+		fd = open(f->file_name, flags);
 		if (fd < 0)
 			return -errno;
 	}


### PR DESCRIPTION
On linux systems, opening a device with O_EXCL will fail with EBUSY if the drive is in use.  For example, if a partition is mounted on /dev/nvme1n1p1, the current mounted filesystem check will allow running write workloads on /dev/nvme1n1 even if allow_mounted_write is zero.  Opening /dev/nvme1n1 with O_EXCL will fail with EBUSY in that case.  Add O_EXCL when opening a file with O_WRONLY or O_RDWR on linux systems.

Fixes: https://github.com/axboe/fio/issues/1820
Signed-of-by: Keith Reynolds <keith.reynolds@mext.ai>