### PR TITLE
Fixes issue where Ki,Mi,Gi,Ti,Pi behave like K,KB etc instead of KiB.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -237,32 +237,33 @@ static unsigned long long __get_mult_bytes(const char *p, void *data,
 
 	/* If kb_base is 1000, use true units.
 	 * If kb_base is 1024, use opposite units.
+	 *
 	 */
-	if (!strncmp("pib", c, 3)) {
+	if (!strncmp("pib", c, 3) || !strncmp("pi", c, 2)) {
 		pow = 5;
 		if (kb_base == 1000)
 			mult = 1024;
 		else if (kb_base == 1024)
 			mult = 1000;
-	} else if (!strncmp("tib", c, 3)) {
+	} else if (!strncmp("tib", c, 3) || !strncmp("ti", c, 2)) {
 		pow = 4;
 		if (kb_base == 1000)
 			mult = 1024;
 		else if (kb_base == 1024)
 			mult = 1000;
-	} else if (!strncmp("gib", c, 3)) {
+	} else if (!strncmp("gib", c, 3) || !strncmp("gi", c, 2)) {
 		pow = 3;
 		if (kb_base == 1000)
 			mult = 1024;
 		else if (kb_base == 1024)
 			mult = 1000;
-	} else if (!strncmp("mib", c, 3)) {
+	} else if (!strncmp("mib", c, 3) || !strncmp("mi", c, 2)) {
 		pow = 2;
 		if (kb_base == 1000)
 			mult = 1024;
 		else if (kb_base == 1024)
 			mult = 1000;
-	} else if (!strncmp("kib", c, 3)) {
+	} else if (!strncmp("kib", c, 3) || !strncmp("ki", c, 2)) {
 		pow = 1;
 		if (kb_base == 1000)
 			mult = 1024;


### PR DESCRIPTION
Fixes issue where Ki,Mi,Gi,Ti,Pi behave like K,KB etc instead of KiB.

Fixes axboe/fio#1618
As described in issue 1618, the Ki,Mi,etc units do not behave as expected. The code in parse.c explicitly handles K,KB and KiB, but not Ki, this results in Ki being implicitly handled by the "K" check. This commit adds explicit handling of Ki,Mi, etc to match the behavior of KiB, MiB, etc.
This change also brings the behaviour in line with the documentation, though the examples have incorrect numbers for TB and have duplicated entries between kb_base=1000 and kb_base=1024.

Sean Ashton <sean@ashtech.one>