### PR TITLE
Add .readthedocs.yaml file.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - epub
+   - pdf


### PR DESCRIPTION
Now to create documentation on readthedocs.org the project must have a configuration file.
