### PR TITLE
t/run-fio-tests: remove redundant pre_success lines

### DIFF
--- a/t/run-fio-tests.py
+++ b/t/run-fio-tests.py
@@ -931,7 +931,6 @@ TEST_LIST = [
         'success':          SUCCESS_DEFAULT,
         'pre_job':          None,
         'pre_success':      None,
-        'pre_success':      SUCCESS_DEFAULT,
         'requirements':     [Requirements.linux, Requirements.libaio],
     },
     {
@@ -941,7 +940,6 @@ TEST_LIST = [
         'success':          SUCCESS_DEFAULT,
         'pre_job':          None,
         'pre_success':      None,
-        'pre_success':      SUCCESS_DEFAULT,
         'requirements':     [Requirements.linux, Requirements.libaio],
     },
     {
@@ -951,7 +949,6 @@ TEST_LIST = [
         'success':          SUCCESS_DEFAULT,
         'pre_job':          None,
         'pre_success':      None,
-        'pre_success':      SUCCESS_DEFAULT,
         'requirements':     [],
     },
     {


### PR DESCRIPTION
Recently, three test case definitions were added to t/run-fio-tests. The added definitions have redundant pre_success lines. Remove them.

