### PR TITLE
docs: update docs for verify_mode=compare of io_uring_cmd

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2896,7 +2896,9 @@ with the caveat that when used on the command line, they must come after the
                 **read**
                         Use Read commands for data verification
                 **compare**
-                        Use Compare commands for data verification
+                        Use Compare commands for data verification.  This option is only valid with
+                        specific pattern(s), which means it *must* be given with `verify=pattern` and
+                        `verify_pattern=<pattern>`.
 
 .. option:: sg_write_mode=str : [sg]
 

--- a/fio.1
+++ b/fio.1
@@ -2686,7 +2686,9 @@ Specifies the type of command to be used in the verification phase. Defaults to 
 Use Read commands for data verification
 .TP
 .B compare
-Use Compare commands for data verification
+Use Compare commands for data verification.  This option is only valid with
+specific pattern(s), which means it *must* be given with `verify=pattern` and
+`verify_pattern=<pattern>`.
 .TP
 .RE
 .RE


### PR DESCRIPTION
Add missing limitation of verify_mode=compare in io_uring_cmd ioengine.  Data verification with NVMe COMPARE command has been introduced in Commit 6170d92a61da ("io_uring: Support Compare command for verification") and this should have documented COMPARE command only supports in case of data pattern verification.

The two more options should be with --verify_mode=compare.
	verify_mode=compare
	verify=pattern
	verify_pattern=<pattern>

Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>

Reminders:

1. If you modify struct thread_options, also make corresponding changes in
   cconv.c and bump FIO_SERVER_VER in server.h
2. If you change the ioengine interface (hooks, flags, etc), remember to bump
   FIO_IOOPS_VERSION in ioengines.h.
