### PR TITLE
Improve flushing pagecache on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ ifeq ($(CONFIG_TARGET_OS), HP-UX)
 endif
 ifeq ($(CONFIG_TARGET_OS), Darwin)
   LIBS	 += -lpthread -ldl
+  SOURCE += os/mac/posix.c
 endif
 ifneq (,$(findstring CYGWIN,$(CONFIG_TARGET_OS)))
   SOURCE += os/windows/cpu-affinity.c os/windows/posix.c os/windows/dlls.c

--- a/os/mac/posix.c
+++ b/os/mac/posix.c
@@ -1,0 +1,82 @@
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+
+#include "../../log.h"
+
+#include "posix.h"
+
+#define MMAP_CHUNK_SIZE		(16LL * 1024 * 1024 * 1024)
+
+/*
+ * NB: performance of discard_pages() will be slower under Rosetta.
+ */
+static int discard_pages(int fd, off_t offset, off_t len)
+{
+	/* Align offset and len to page size */
+	long pagesize = sysconf(_SC_PAGESIZE);
+	long offset_pad = offset % pagesize;
+	offset -= offset_pad;
+	len += offset_pad;
+	len = (len + pagesize - 1) & -pagesize;
+
+	while (len > 0) {
+		int saved_errno;
+		size_t mmap_len = MIN(MMAP_CHUNK_SIZE, len);
+		void *addr = mmap(0, mmap_len, PROT_NONE, MAP_SHARED, fd,
+				  offset);
+
+		if (addr == MAP_FAILED) {
+			saved_errno = errno;
+			log_err("discard_pages: failed to mmap (%s), "
+				"offset = %llu, len = %zu\n",
+				strerror(errno), offset, mmap_len);
+			return saved_errno;
+		}
+
+		if (msync(addr, mmap_len, MS_INVALIDATE)) {
+			saved_errno = errno;
+			log_err("discard_pages: msync failed to free cache "
+				"pages\n");
+
+			if (munmap(addr, mmap_len) < 0)
+				log_err("discard_pages: munmap failed (%s)\n",
+					strerror(errno));
+			return saved_errno;
+		}
+
+		if (munmap(addr, mmap_len) < 0) {
+			saved_errno = errno;
+			log_err("discard_pages: munmap failed (%s), "
+				"len = %zu)\n", strerror(errno), mmap_len);
+			return saved_errno;
+		}
+
+		len -= mmap_len;
+		offset += mmap_len;
+	}
+
+	return 0;
+}
+
+int posix_fadvise(int fd, off_t offset, off_t len, int advice)
+{
+	int ret;
+
+	switch(advice) {
+	case POSIX_FADV_NORMAL:
+	case POSIX_FADV_RANDOM:
+	case POSIX_FADV_SEQUENTIAL:
+		ret = 0;
+		break;
+	case POSIX_FADV_DONTNEED:
+		ret = discard_pages(fd, offset, len);
+		break;
+	default:
+		ret = EINVAL;
+	}
+
+	return ret;
+}

--- a/os/mac/posix.h
+++ b/os/mac/posix.h
@@ -1,0 +1,11 @@
+#ifndef FIO_MAC_POSIX_H
+#define FIO_MAC_POSIX_H
+
+#define POSIX_FADV_NORMAL       (0)
+#define POSIX_FADV_RANDOM       (1)
+#define POSIX_FADV_SEQUENTIAL   (2)
+#define POSIX_FADV_DONTNEED     (4)
+
+extern int posix_fadvise(int fd, off_t offset, off_t len, int advice);
+
+#endif

--- a/os/os-mac.h
+++ b/os/os-mac.h
@@ -17,6 +17,8 @@
 #include "../arch/arch.h"
 #include "../file.h"
 
+#include "mac/posix.h"
+
 #define FIO_USE_GENERIC_INIT_RANDOM_STATE
 #define FIO_HAVE_GETTID
 #define FIO_HAVE_CHARDEV_SIZE
@@ -117,3 +119,5 @@ static inline bool os_cpu_has(cpu_features feature)
 }
 
 #endif
+
+#define CONFIG_POSIX_FADVISE


### PR DESCRIPTION
The current behavior of flushing the pagecache via `posix_fadvise(POSIX_FADV_DONTNEED)` is not a valid operation on macOS. 

This can result in adverse outcomes when measuring performance. The change will instead flush via `mmap` and `msync`, which better reflects the desired behavior on macOS
