### PR TITLE
Fixing doc errors

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -369,7 +369,7 @@ files:
 
 Here we have no *global* section, as we only have one job defined anyway.  We
 want to use async I/O here, with a depth of 4 for each file. We also increased
-the buffer size used to 32KiB and define numjobs to 4 to fork 4 identical
+the block size used to 32KiB and define numjobs to 4 to fork 4 identical
 jobs. The result is 4 processes each randomly writing to their own 64MiB
 file. Instead of using the above job file, you could have given the parameters
 on the command line. For this case, you would specify::


### PR DESCRIPTION
Fixed a minor error in section 1.12 of the documentation

I understand that the bs parameter should mean block size
![image](https://github.com/user-attachments/assets/a3af445c-440e-40bd-aca0-f376922305f7)

Signed-off-by: 1397472492@qq.com
