### PR TITLE
Fix hang on Windows when multiple --client args are present

### DIFF
--- a/os/windows/posix.c
+++ b/os/windows/posix.c
@@ -899,10 +899,9 @@ int poll(struct pollfd fds[], nfds_t nfds, int timeout)
 	FD_ZERO(&exceptfds);
 
 	for (i = 0; i < nfds; i++) {
-		if (fds[i].fd == INVALID_SOCKET) {
-			fds[i].revents = 0;
+		fds[i].revents = 0;
+		if (fds[i].fd == INVALID_SOCKET) 
 			continue;
-		}
 
 		if (fds[i].events & POLLIN)
 			FD_SET(fds[i].fd, &readfds);


### PR DESCRIPTION
The Windows poll function does not clear revents field before it is populated.  As a result, subsequent calls to poll using the same pollfd reference return with revents set even when there is nothing available to read.  This later results in a hang in recv().