### PR TITLE
oslib: blkzoned: add missing blkzoned_move_zone_wp() stub

### DIFF
--- a/oslib/blkzoned.h
+++ b/oslib/blkzoned.h
@@ -54,6 +54,12 @@ static inline int blkzoned_reset_wp(struct thread_data *td, struct fio_file *f,
 {
 	return -EIO;
 }
+static inline int blkzoned_move_zone_wp(struct thread_data *td,
+					struct fio_file *f, struct zbd_zone *z,
+					uint64_t length, const char *buf)
+{
+	return -EIO;
+}
 static inline int blkzoned_get_max_open_zones(struct thread_data *td, struct fio_file *f,
 					      unsigned int *max_open_zones)
 {


### PR DESCRIPTION
Commit 4175f4dbec5d ("oslib: blkzoned: add blkzoned_move_zone_wp() helper function") introduced the new function for Linux, but did not add its stub function for OSes that lack the blkzoned feature. This caused build failures on MacOS and Windows. Add the missing stub to fix it.

Fixes: 4175f4dbec5d ("oslib: blkzoned: add blkzoned_move_zone_wp() helper function")

This PR fixes [the compile error reported on the list](https://lore.kernel.org/fio/a4728f95-f894-4ee3-80e9-674635848806@kernel.dk/T/#me7176f5f61ce01ea60fd657d55fdd6fbbf22423b).