### PR TITLE
Fix: add NULL check after calloc() in fileoperations.c init()

### DIFF
--- a/engines/fileoperations.c
+++ b/engines/fileoperations.c
@@ -283,7 +283,9 @@ static int init(struct thread_data *td)
 	struct fc_data *data;
 
 	data = calloc(1, sizeof(*data));
-
+	if (data == NULL)
+		return -ENOMEM;
+	
 	if (td_read(td))
 		data->stat_ddir = DDIR_READ;
 	else if (td_write(td))


### PR DESCRIPTION
Fix: add NULL check after calloc() in fileoperations.c init()

This patch adds a NULL check after `calloc()` in the `init()` function of
fileoperations.c. If memory allocation fails, dereferencing `data` would
result in undefined behavior.
This change ensures a graceful return (-ENOMEM) instead. The fix improves
robustness with no effect on normal execution flow.

Fixes: #1920 

Signed-off-by: Hoyoung Lee <lhywkd22@gmail.com>