### PR TITLE
Fix: parse.c opt_len() to use minimal distance to delimiter to determine option length

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -480,14 +480,17 @@ static size_t opt_len(const char *str)
 	char delimiter[] = {',', ':'};
 	char *postfix;
 	unsigned int i;
+	size_t candidate_len;
 
+	size_t prefix_len = strlen(str);
 	for (i = 0; i < FIO_ARRAY_SIZE(delimiter); i++) {
 		postfix = strchr(str, delimiter[i]);
-		if (postfix)
-			return (int)(postfix - str);
+		candidate_len = (size_t)(postfix - str);
+		if (postfix && candidate_len < prefix_len)
+			prefix_len = candidate_len;
 	}
 
-	return strlen(str);
+	return prefix_len;
 }
 
 static int str_match_len(const struct value_pair *vp, const char *str)


### PR DESCRIPTION
Use minimal distance to delimiter to determine option length

Current implementation of `opt_len()` function is using array of possible delimiters for option name search.
They are `{',', ':'}`.

The loop at https://github.com/axboe/fio/blob/813445e7129240d51216e396a5ba8e19296b6581/parse.c#L484 takes first found delimiter and return without trying to search by the rest of possibilities.

This causes `__handle_option()` function to falsely include into option name all chars up to first ',' ignoring any ':' chars.
Resulting not possible to parse options like `zoned:50/5:30/15:20/,50/10:50/90`.

Fixes: https://github.com/axboe/fio/issues/1923

Signed-off-by: Leonid Kozlov <leonid.e.kozlov@gmail.com>