### PR TITLE
io_uring: ensure accurate real_file_size setup for full device access with PI enabled

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -1610,7 +1610,10 @@ static int fio_ioring_cmd_get_file_size(struct thread_data *td,
 			return ret;
 		}
 
-		f->real_file_size = data->lba_size * nlba;
+		if (data->lba_ext)
+			f->real_file_size = data->lba_ext * nlba;
+		else
+			f->real_file_size = data->lba_size * nlba;
 		fio_file_set_size_known(f);
 
 		FILE_SET_ENG_DATA(f, data);


### PR DESCRIPTION
### Description

When Protection Information (PI) is enabled on NVMe devices, the file size was incorrectly calculated using `data->lba_size` instead of `data->lba_ext`. This caused FIO to access only a portion of the device(e.g. 4096/(4096+64)=98.46%), leading to incomplete I/O coverage during tests.

This patch updates the `real_file_size` calculation logic to conditionally use `data->lba_ext` when available, and fall back to `data->lba_size` otherwise. This ensures that FIO correctly calculates the full storage capacity and accesses the entire device area when PI is enabled.

### Fixes
- Incomplete device access in FIO when PI is enabled
- Incorrect `real_file_size` assignment due to using `lba_size` instead of `lba_ext`