### PR TITLE
engines/http: Add S3 security token support

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -3013,6 +3013,10 @@ with the caveat that when used on the command line, they must come after the
 
 	The S3 key/access id.
 
+.. option:: http_s3_security_token=str : [http]
+
+	The S3 security token.
+
 .. option:: http_s3_sse_customer_key=str : [http]
 
         The encryption customer key in SSE server side.

--- a/fio.1
+++ b/fio.1
@@ -2605,6 +2605,9 @@ The S3 secret key.
 .BI (http)http_s3_keyid \fR=\fPstr
 The S3 key/access id.
 .TP
+.BI (http)http_s3_security_token \fR=\fPstr
+The S3 security token.
+.TP
 .BI (http)http_s3_sse_customer_key \fR=\fPstr
 The encryption customer key in SSE server side.
 .TP


### PR DESCRIPTION
Security tokens are an element of S3 authorization in some environments. This change adds a parameter to allow users to specify a security token, and pass this to S3 requests with the appropriate header.
