### PR TITLE
io_u: get io_u from io_u_freelist when TD_FSYNCING

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -1701,7 +1701,7 @@ struct io_u *__get_io_u(struct thread_data *td)
 		__td_io_u_lock(td);
 
 again:
-	if (!io_u_rempty(&td->io_u_requeues)) {
+	if (td->runstate != TD_FSYNCING && !io_u_rempty(&td->io_u_requeues)) {
 		io_u = io_u_rpop(&td->io_u_requeues);
 		io_u->resid = 0;
 	} else if (!queue_full(td)) {


### PR DESCRIPTION
As Commit 813445e71292 ('backend: clean up requeued io_u's') has been applied, backend cleans up the remained io_u's in td->io_u_requeues. However, with end_fsync=1, the __get_io_u() function returns an io_u from td->io_u_requeues if any io_u exist, and pops it. This leads that the synced io_u will not put file which it got, and, finally, cannot close the file.

This patch returns io_u from td->io_u_free_list when td->runstate is TD_FSYNCING, so that the io_u's in td->io_u_requeues will be cleaned up and leads to close file appropriately.
