### PR TITLE
io_uring CQ reap cleanup

### DIFF
--- a/arch/arch.h
+++ b/arch/arch.h
@@ -53,6 +53,8 @@ extern unsigned long arch_flags;
 #define atomic_load_acquire(p)					\
 	std::atomic_load_explicit(p,				\
 			     std::memory_order_acquire)
+#define atomic_store_relaxed(p, v)				\
+	std::atomic_store_explicit((p), (v), std::memory_order_relaxed)
 #define atomic_store_release(p, v)				\
 	std::atomic_store_explicit(p, (v),			\
 			     std::memory_order_release)
@@ -67,6 +69,9 @@ extern unsigned long arch_flags;
 #define atomic_load_acquire(p)					\
 	atomic_load_explicit((_Atomic typeof(*(p)) *)(p),	\
 			     memory_order_acquire)
+#define atomic_store_relaxed(p, v)				\
+	atomic_store_explicit((_Atomic typeof(*(p)) *)(p), (v),	\
+			      memory_order_relaxed)
 #define atomic_store_release(p, v)				\
 	atomic_store_explicit((_Atomic typeof(*(p)) *)(p), (v),	\
 			      memory_order_release)

--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -674,7 +674,7 @@ static char *fio_ioring_cmd_errdetails(struct thread_data *td,
 	return msg;
 }
 
-static int fio_ioring_cqring_reap(struct thread_data *td, unsigned int max)
+static unsigned fio_ioring_cqring_reap(struct thread_data *td, unsigned int max)
 {
 	struct ioring_data *ld = td->io_ops_data;
 	struct io_cq_ring *ring = &ld->cq_ring;

--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -710,7 +710,6 @@ static int fio_ioring_getevents(struct thread_data *td, unsigned int min,
 		r = fio_ioring_cqring_reap(td, events, max);
 		if (r) {
 			events += r;
-			max -= r;
 			if (actual_min != 0)
 				actual_min -= r;
 			continue;


### PR DESCRIPTION
- Fix `fio_ioring_getevents()` incorrectly decreasing the `max` number of events
- Only load the CQ `tail` index once for the full batch of available CQEs
- Simplify the control flow in `fio_ioring_getevents()`
- Justify advancing the CQ `tail` index before reading the CQEs, and relax the ordering of the atomic store