### PR TITLE
fix: prevent null pointer dereference in run_dedupe_threads

### DIFF
--- a/t/dedupe.c
+++ b/t/dedupe.c
@@ -457,6 +457,8 @@ static int run_dedupe_threads(struct fio_file *f, uint64_t dev_size,
 	total_items = dev_size / blocksize;
 	cur_offset = 0;
 	size_lock = fio_sem_init(FIO_SEM_UNLOCKED);
+	if (size_lock == NULL)
+		return 1;
 
 	threads = malloc(num_threads * sizeof(struct worker_thread));
 	for (i = 0; i < num_threads; i++) {


### PR DESCRIPTION
### Describe

Fixes a potential null pointer dereference in `run_dedupe_threads()` by adding a null check before calling `fio_sem_remove()`.
### Expected behavior
If `fio_sem_init()` fails (returns `NULL`), the program should skip calling `fio_sem_remove()` to avoid dereferencing a null pointer.
### Actual behavior
When `fio_sem_init()` fails and returns `NULL`, the code still calls `fio_sem_remove(size_lock)`, which dereferences the pointer without validation, leading to undefined behavior or a crash.

This is a minimal and safe fix that prevents a crash without altering the original logic. It improves code robustness by explicitly guarding against a potential null pointer, which aligns with good defensive programming practices.
Thanks for reviewing.