### PR TITLE
fixing missing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ FIO_OBJS += lex.yy.o y.tab.o
 GFIO_OBJS += lex.yy.o y.tab.o
 endif
 
--include $(OBJS:.o=.d)
+-include $(OBJS:.o=.d) $(T_OBJS:.o=.d) $(UT_OBJS:.o=.d)
 
 T_SMALLOC_OBJS = t/stest.o
 T_SMALLOC_OBJS += gettime.o fio_sem.o pshared.o smalloc.o t/log.o t/debug.o \


### PR DESCRIPTION
Fixing missing dependencies

This PR fixes an issue in the Makefile. Specifically, previously, any modifications of files like lib/types.h would not trigger a rebuild of t/verify-state.o. The PR fixes this by including them as additional dependencies. Mainly, T_OBJS and UT_OBJS do not use .d files to record dependencies correctly, unlike OBJS.
The previous PR had to be reopened due to an error during the merge of commits.

Signed-off-by: Jun Lyu lvjun_dnt@outlook.com
