### PR TITLE
Fix mandoc warnings

### DIFF
--- a/fio.1
+++ b/fio.1
@@ -1,4 +1,4 @@
-.TH fio 1 "August 2017" "User Manual"
+.TH fio 1 "May 2025" "User Manual"
 .SH NAME
 fio \- flexible I/O tester
 .SH SYNOPSIS


### PR DESCRIPTION
Running
```
mandoc -W warning,stop ./fio.1 > /dev/null
```
spits out a load of warnings/errors:
```
mandoc: ./fio.1:1658:2: ERROR: skipping end of block that is not open: RE
mandoc: ./fio.1:1931:14: WARNING: undefined escape, printing literally: \=
mandoc: ./fio.1:1936:14: WARNING: undefined escape, printing literally: \=
mandoc: ./fio.1:2092:2: WARNING: line scope broken: RE breaks TP
mandoc: ./fio.1:2133:2: WARNING: line scope broken: RE breaks TP
mandoc: ./fio.1:2139:2: ERROR: skipping end of block that is not open: RE
mandoc: ./fio.1:2334:2: WARNING: line scope broken: RE breaks TP
mandoc: ./fio.1:2602:72: WARNING: invalid escape sequence: \Ron\fP.  
mandoc: ./fio.1:2713:2: WARNING: line scope broken: RE breaks TP
mandoc: ./fio.1:2729:2: WARNING: line scope broken: RE breaks TP
mandoc: ./fio.1:4463:2: WARNING: line scope broken: RE breaks TP
mandoc: ./fio.1:4504:2: WARNING: line scope broken: RE breaks TP
mandoc: ./fio.1:4995:2: ERROR: skipping end of block that is not open: RE
mandoc: ./fio.1:1:11: WARNING: cannot parse date, using it verbatim: TH August 2017
mandoc: ./fio.1:1018:2: WARNING: skipping paragraph macro: PP empty
mandoc: ./fio.1:1035:2: WARNING: skipping paragraph macro: PP empty
mandoc: ./fio.1:1939:2: WARNING: skipping paragraph macro: PP empty
mandoc: ./fio.1:1939:2: WARNING: skipping paragraph macro: PP empty
mandoc: ./fio.1:2140:2: WARNING: skipping paragraph macro: PP empty
mandoc: ./fio.1:2139:2: WARNING: skipping paragraph macro: br at the end of SS
mandoc: ./fio.1:4894:2: WARNING: skipping paragraph macro: PP empty
mandoc: see above the output for ERROR messages
```

- Fix all of the above apart from "cannot parse date" (because mandoc only accepts American style "Month Day, Year" style dates and the fio man date is more agnostic)
- Tidy up some problem formatting along the way

Changed output was eyeballed with
```
MANOPT='--nh --nj' man ./fio.1
```
on Ubuntu 24.04 and
```
man ./fio.1
```
on macOS 15.6.