### PR TITLE
t/verify-state.c fixes/improvements

### DIFF
--- a/fio.h
+++ b/fio.h
@@ -73,8 +73,6 @@ struct fio_sem;
 
 #define MAX_TRIM_RANGE	256
 
-#define INVALID_NUMBERIO UINT64_MAX
-
 /*
  * Range for trim command
  */

--- a/t/verify-state.c
+++ b/t/verify-state.c
@@ -29,8 +29,13 @@ static void show_s(struct thread_io_list *s, unsigned int no_s)
 	if (!s->depth)
 		return;
 	for (i = s->depth - 1; i >= 0; i--) {
-		printf("\t%llu\n",
-				(unsigned long long) s->inflight[i].numberio);
+		uint64_t numberio;
+		numberio = s->inflight[i].numberio;
+		if (numberio == INVALID_NUMBERIO)
+			printf("\tNot inflight\n");
+		else
+			printf("\t%llu\n",
+			       (unsigned long long) s->inflight[i].numberio);
 	}
 }
 

--- a/t/verify-state.c
+++ b/t/verify-state.c
@@ -84,7 +84,7 @@ static void show_verify_state(void *buf, size_t size)
 		return;
 	}
 
-	if (hdr->version == 0x04)
+	if (hdr->version == VSTATE_HDR_VERSION)
 		show(s, size);
 	else
 		log_err("Unsupported version %d\n", (int) hdr->version);

--- a/verify-state.h
+++ b/verify-state.h
@@ -101,4 +101,6 @@ static inline void verify_state_gen_name(char *out, size_t size,
 	out[size - 1] = '\0';
 }
 
+#define INVALID_NUMBERIO UINT64_MAX
+
 #endif


### PR DESCRIPTION
- Improve verify state inflight output that is dumped by t/fio-verify-state
- Synchronise verify state version in t/verify-state.c so it works with state files produced by the current fio and will automatically pick up future verify state version bumps