### PR TITLE
backend: get io_u from requeue if exists

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -269,7 +269,8 @@ static bool fio_io_sync(struct thread_data *td, struct fio_file *f)
 
 	io_u->ddir = DDIR_SYNC;
 	io_u->file = f;
-	io_u_set(td, io_u, IO_U_F_NO_FILE_PUT);
+	if (td->runstate != TD_FSYNCING)
+		io_u_set(td, io_u, IO_U_F_NO_FILE_PUT);
 
 	if (td_io_prep(td, io_u)) {
 		put_io_u(td, io_u);

--- a/io_u.c
+++ b/io_u.c
@@ -1701,7 +1701,7 @@ struct io_u *__get_io_u(struct thread_data *td)
 		__td_io_u_lock(td);
 
 again:
-	if (td->runstate != TD_FSYNCING && !io_u_rempty(&td->io_u_requeues)) {
+	if (!io_u_rempty(&td->io_u_requeues)) {
 		io_u = io_u_rpop(&td->io_u_requeues);
 		io_u->resid = 0;
 	} else if (!queue_full(td)) {


### PR DESCRIPTION
If the `iodepth=1`, which means only 1 io_u can alive, and also if it is in `td->io_u_requeues`, the `td->io_u_freelist` is empty. With `end_fsync=1` in this, `__get_io_u()` will return `NULL`, because there are no free io_u in `td->io_u_freelist` and `td->runstate` is `FSYNCING`. This leads that the sync operation will be failed with message `end_fsync failed for file <filename>`.

This patch fixes that the io_u's in `td->io_u_requeues` will be returned if `td->runstate == TD_FSYNCING`, and will not be set the `IO_U_F_NO_FILE_PUT` flag, which causes the file's reference count never goes to 0.
