### PR TITLE
sprandom: fix warning: comparison will always evaluate as true

### DIFF
--- a/sprandom.c
+++ b/sprandom.c
@@ -120,11 +120,11 @@ static void print_d_array(const char *hdr, double *darray, size_t len)
 
 	buf_output_init(&out);
 
-	log_buf(&out, "[");
+	__log_buf(&out, "[");
 	for (i = 0; i < len - 1; i++)
-		log_buf(&out, "%.2f, ", darray[i]);
+		__log_buf(&out, "%.2f, ", darray[i]);
 
-	log_buf(&out, "%.2f]\n", darray[len - 1]);
+	__log_buf(&out, "%.2f]\n", darray[len - 1]);
 	if (hdr)
 		dprint(FD_SPRANDOM, "%s: ", hdr);
 
@@ -139,11 +139,11 @@ static void print_d_points(struct point *parray, size_t len)
 
 	buf_output_init(&out);
 
-	log_buf(&out, "[");
+	__log_buf(&out, "[");
 	for (i = 0; i < len - 1; i++)
-		log_buf(&out, "(%.2f %.2f), ", parray[i].x, parray[i].y);
+		__log_buf(&out, "(%.2f %.2f), ", parray[i].x, parray[i].y);
 
-	log_buf(&out, "(%.2f %.2f)]\n", parray[len - 1].x, parray[len - 1].y);
+	__log_buf(&out, "(%.2f %.2f)]\n", parray[len - 1].x, parray[len - 1].y);
 	dprint(FD_SPRANDOM, "%s", out.buf);
 	buf_output_free(&out);
 }


### PR DESCRIPTION
The log_buf() macro checks whether the buffer is NULL, but in this case the variable is defined on the stack and can never be NULL.

Use the low-level __log_buf() function to eliminate the warning.

Fixes the following warning with 32-bit build:
LDFLAGS="-m32" ./configure --disable-native --extra-cflags="-m32 -march=i386" && make

sprandom.c: In function ‘print_d_array’:
log.h:24:12: warning: the comparison will always evaluate as ‘true’ \ for the address of ‘out’ will never be NULL [-Waddress]
   if ((buf) != NULL)    \

