### PR TITLE
write_hist_log: do not require ZLIB for a CLI client

### DIFF
--- a/init.c
+++ b/init.c
@@ -1769,7 +1769,7 @@ static int add_job(struct thread_data *td, const char *jobname, int job_add_num,
 		const char *suf;
 
 #ifndef CONFIG_ZLIB
-		if (td->client_type) {
+		if (td->client_type != FIO_CLIENT_TYPE_CLI) {
 			log_err("fio: --write_hist_log requires zlib in client/server mode\n");
 			goto err;
 		}


### PR DESCRIPTION
write_hist_log: do not require ZLIB for a CLI client

Since `td->client_type` is always non-zero (CLI is 1, GUI is 2), the check `if (td->client_type)` in `init.c` always triggers, causing --write_hist_log to be unusable when ZLIB is not configured.

This patch proposes to replace the check with
```
if (td->client_type != FIO_CLIENT_TYPE_CLI) { ...
```
I am not 100% clear whether this is the right approach to check whether we are NOT in a client-server setup.
Fixes #1996

Signed-off-by: Eric Gouriou <egouriou@google.com>