### PR TITLE
test, memcpy: reorder #includes to use platform-specific code

### DIFF
--- a/crc/test.c
+++ b/crc/test.c
@@ -3,10 +3,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../os/os.h"
 #include "../gettime.h"
 #include "../fio_time.h"
 #include "../lib/rand.h"
-#include "../os/os.h"
 
 #include "../crc/md5.h"
 #include "../crc/crc64.h"

--- a/lib/memcpy.c
+++ b/lib/memcpy.c
@@ -5,9 +5,9 @@
 
 #include "memcpy.h"
 #include "rand.h"
+#include "../os/os.h"
 #include "../fio_time.h"
 #include "../gettime.h"
-#include "../os/os.h"
 
 #define BUF_SIZE	32 * 1024 * 1024ULL
 


### PR DESCRIPTION
Include `os/os.h` before `fio_time.h` in the header files. Fixes #1993.


