### PR TITLE
Remove leftover code for platforms lacking clock_gettime and clockid_t

### DIFF
--- a/configure
+++ b/configure
@@ -1185,6 +1185,8 @@ if compile_prog "" "" "clock_gettime"; then
 elif compile_prog "" "-lrt" "clock_gettime"; then
     clock_gettime="yes"
     LIBS="-lrt $LIBS"
+else
+  fatal "clock_gettime is not supported"
 fi
 print_config "clock_gettime" "$clock_gettime"
 
@@ -1209,26 +1211,6 @@ EOF
   fi
 fi
 print_config "CLOCK_MONOTONIC" "$clock_monotonic"
-
-##########################################
-# clockid_t probe
-if test "$clockid_t" != "yes" ; then
-  clockid_t="no"
-fi
-cat > $TMPC << EOF
-#include <time.h>
-#include <string.h>
-int main(int argc, char **argv)
-{
-  volatile clockid_t cid;
-  memset((void*)&cid, 0, sizeof(cid));
-  return 0;
-}
-EOF
-if compile_prog "" "$LIBS" "clockid_t"; then
-  clockid_t="yes"
-fi
-print_config "clockid_t" "$clockid_t"
 
 ##########################################
 # gettimeofday() probe
@@ -3102,14 +3084,8 @@ fi
 if test "$libverbs" = "yes" -a "$rdmacm" = "yes" ; then
   output_sym "CONFIG_RDMA"
 fi
-if test "$clock_gettime" = "yes" ; then
-  output_sym "CONFIG_CLOCK_GETTIME"
-fi
 if test "$clock_monotonic" = "yes" ; then
   output_sym "CONFIG_CLOCK_MONOTONIC"
-fi
-if test "$clockid_t" = "yes"; then
-  output_sym "CONFIG_CLOCKID_T"
 fi
 if test "$gettimeofday" = "yes" ; then
   output_sym "CONFIG_GETTIMEOFDAY"

--- a/fio.c
+++ b/fio.c
@@ -30,10 +30,6 @@ int main(int argc, char *argv[], char *envp[])
 	if (initialize_fio(envp))
 		return 1;
 
-#if !defined(CONFIG_GETTIMEOFDAY) && !defined(CONFIG_CLOCK_GETTIME)
-#error "No available clock source!"
-#endif
-
 	if (fio_server_create_sk_key())
 		goto done;
 

--- a/gettime.c
+++ b/gettime.c
@@ -136,20 +136,10 @@ int fio_get_mono_time(struct timespec *ts)
 {
 	int ret;
 
-#ifdef CONFIG_CLOCK_GETTIME
 #if defined(CONFIG_CLOCK_MONOTONIC)
 	ret = clock_gettime(CLOCK_MONOTONIC, ts);
 #else
 	ret = clock_gettime(CLOCK_REALTIME, ts);
-#endif
-#else
-	struct timeval tv;
-
-	ret = gettimeofday(&tv, NULL);
-	if (ret == 0) {
-		ts->tv_sec = tv.tv_sec;
-		ts->tv_nsec = tv.tv_usec * 1000;
-	}
 #endif
 	assert(ret <= 0);
 	return ret;
@@ -168,7 +158,6 @@ static void __fio_gettime(struct timespec *tp)
 		break;
 		}
 #endif
-#ifdef CONFIG_CLOCK_GETTIME
 	case CS_CGETTIME: {
 		if (fio_get_mono_time(tp) < 0) {
 			log_err("fio: fio_get_mono_time() fails\n");
@@ -176,7 +165,6 @@ static void __fio_gettime(struct timespec *tp)
 		}
 		break;
 		}
-#endif
 #ifdef ARCH_HAVE_CPU_CLOCK
 	case CS_CPUCLOCK: {
 		uint64_t nsecs, t, multiples;

--- a/libfio.c
+++ b/libfio.c
@@ -406,10 +406,6 @@ int initialize_fio(char *envp[])
 		return 1;
 	}
 
-#if !defined(CONFIG_GETTIMEOFDAY) && !defined(CONFIG_CLOCK_GETTIME)
-#error "No available clock source!"
-#endif
-
 	arch_init(envp);
 
 	sinit();

--- a/options.c
+++ b/options.c
@@ -3109,12 +3109,10 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 			    .help = "Use gettimeofday(2) for timing",
 			  },
 #endif
-#ifdef CONFIG_CLOCK_GETTIME
 			  { .ival = "clock_gettime",
 			    .oval = CS_CGETTIME,
 			    .help = "Use clock_gettime(2) for timing",
 			  },
-#endif
 #ifdef ARCH_HAVE_CPU_CLOCK
 			  { .ival = "cpu",
 			    .oval = CS_CPUCLOCK,

--- a/os/os-mac.h
+++ b/os/os-mac.h
@@ -37,10 +37,6 @@
 	pthread_getaffinity_np(pthread_self(), sizeof(mask), &(mask))
 #endif
 
-#ifndef CONFIG_CLOCKID_T
-typedef unsigned int clockid_t;
-#endif
-
 #define FIO_OS_DIRECTIO
 static inline int fio_set_odirect(struct fio_file *f)
 {

--- a/os/os.h
+++ b/os/os.h
@@ -174,11 +174,7 @@ extern int fio_cpus_split(os_cpu_mask_t *mask, unsigned int cpu);
 #endif
 
 #ifndef FIO_PREFERRED_CLOCK_SOURCE
-#ifdef CONFIG_CLOCK_GETTIME
 #define FIO_PREFERRED_CLOCK_SOURCE	CS_CGETTIME
-#else
-#define FIO_PREFERRED_CLOCK_SOURCE	CS_GTOD
-#endif
 #endif
 
 #ifndef CONFIG_SOCKLEN_T


### PR DESCRIPTION
Drop the remaining workaround code for platforms lacking clock_gettime and clockid_t. Produce an error on configure if clock_gettime is unavailable.

Submitted on behalf of @sitsofe.