### PR TITLE
backend.c: fix async ioengine prep/queue direction mismatch in experimental_verify

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -666,12 +666,20 @@ static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 				} else if (io_u->ddir == DDIR_TRIM) {
 					io_u->ddir = DDIR_READ;
 					io_u_set(td, io_u, IO_U_F_TRIMMED);
+					if (td_io_prep(td, io_u)) {
+						put_io_u(td, io_u);
+						continue;
+					}
 					break;
 				} else if (io_u->ddir == DDIR_WRITE) {
 					io_u->ddir = DDIR_READ;
 					io_u->numberio = td->verify_read_issues;
 					td->verify_read_issues++;
 					populate_verify_io_u(td, io_u);
+					if (td_io_prep(td, io_u)) {
+						put_io_u(td, io_u);
+						continue;
+					}
 					break;
 				} else {
 					put_io_u(td, io_u);


### PR DESCRIPTION
When using --experimental_verify=1 with async ioengines like libaio, there was a critical mismatch between the I/O direction set during prep and the direction used when queuing operations.

The issue occurred because get_io_u() calls td_io_prep() which configures ioengine structures (like iocb) for WRITE operations, but then io_u->ddir is changed from WRITE to READ for verification after prep completes. This left the iocb configured for writes while fio's accounting expected reads, causing incorrect I/O statistics and potential data integrity issues.

Fix by calling td_io_prep() again after changing the data direction in both TRIM and WRITE cases, ensuring async ioengines re-sync their internal structures with the final I/O direction.

Fixes #1955
