### PR TITLE
man: update HOWTO and README links

### DIFF
--- a/fio.1
+++ b/fio.1
@@ -5294,6 +5294,6 @@ Sample jobfiles are available in the `examples/' directory.
 .br
 These are typically located under `/usr/share/doc/fio'.
 .P
-\fBHOWTO\fR: \fIhttp://git.kernel.dk/cgit/fio/plain/HOWTO\fR
+\fBHOWTO\fR: \fIhttp://git.kernel.dk/cgit/fio/plain/HOWTO.rst\fR
 .br
-\fBREADME\fR: \fIhttp://git.kernel.dk/cgit/fio/plain/README\fR
+\fBREADME\fR: \fIhttp://git.kernel.dk/cgit/fio/plain/README.rst\fR


### PR DESCRIPTION
Fixes: 7c1f6a2f8837 ("docs: rename HOWTO to HOWTO.rst")
Fixes: 79e1e2802e1c ("docs: rename README to README.rst")