### PR TITLE
backend: fix zero-numberio in dry-run

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1703,8 +1703,11 @@ static uint64_t do_dry_run(struct thread_data *td)
 		io_u_set(td, io_u, IO_U_F_FLIGHT);
 		io_u->error = 0;
 		io_u->resid = 0;
-		if (ddir_rw(acct_ddir(io_u)))
+		if (ddir_rw(acct_ddir(io_u))) {
+			io_u->numberio = td->io_issues[acct_ddir(io_u)];
 			td->io_issues[acct_ddir(io_u)]++;
+		}
+
 		if (ddir_rw(io_u->ddir)) {
 			io_u_mark_depth(td, 1);
 			td->ts.total_io_u[io_u->ddir]++;


### PR DESCRIPTION
In offline verification, io_hist_tree is not saved to the state file, so `io_u->numberio` is always zero in the second job (the verify phase). To address this, `do_dry_run()` simulates the saved WRITE job and logs io_u entries into io_hist_tree via `log_io_piece()`. The issue is that `io_u->numberio` is always zero when passed to log_io_piece().

To reproduce this issue, run the following jobs in turn.

	[test]
	name=writetest
	filename=/dev/nvme0n1
	ioengine=io_uring
	direct=1
	bs=512K
	iodepth=128
	rw=randwrite
	runtime=20
	time_based
	verify=crc32c
	verify_state_save=1
	do_verify=0

	[test]
	name=writetest
	filename=/dev/nvme0n1
	ioengine=io_uring
	direct=1
	bs=512K
	iodepth=128
	rw=randwrite
	verify=crc32c
	verify_state_load=1
	verify_only=1
	verify_dump=1

Fixes: #2013