### PR TITLE
Sync for file operations

### DIFF
--- a/engines/falloc.c
+++ b/engines/falloc.c
@@ -76,14 +76,18 @@ static enum fio_q_status fio_fallocate_queue(struct thread_data *td,
 
 	fio_ro_check(td, io_u);
 
-	if (io_u->ddir == DDIR_READ)
-		flags = FALLOC_FL_KEEP_SIZE;
-	else if (io_u->ddir == DDIR_WRITE)
-		flags = 0;
-	else if (io_u->ddir == DDIR_TRIM)
-		flags = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
+	if (io_u->ddir != DDIR_SYNC) {
+		if (io_u->ddir == DDIR_READ)
+			flags = FALLOC_FL_KEEP_SIZE;
+		else if (io_u->ddir == DDIR_WRITE)
+			flags = 0;
+		else if (io_u->ddir == DDIR_TRIM)
+			flags = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
 
-	ret = fallocate(f->fd, flags, io_u->offset, io_u->xfer_buflen);
+		ret = fallocate(f->fd, flags, io_u->offset, io_u->xfer_buflen);
+	} else {
+		ret = do_io_u_sync(td, io_u);
+	}
 
 	if (ret)
 		io_u->error = errno;

--- a/engines/fileoperations.c
+++ b/engines/fileoperations.c
@@ -264,6 +264,8 @@ static int invalidate_do_nothing(struct thread_data *td, struct fio_file *f)
 
 static enum fio_q_status queue_io(struct thread_data *td, struct io_u *io_u)
 {
+	if (io_u->ddir == DDIR_SYNC && do_io_u_sync(td, io_u))
+		io_u->error = errno;
 	return FIO_Q_COMPLETED;
 }
 

--- a/engines/ftruncate.c
+++ b/engines/ftruncate.c
@@ -15,16 +15,17 @@ static enum fio_q_status fio_ftruncate_queue(struct thread_data *td,
 					     struct io_u *io_u)
 {
 	struct fio_file *f = io_u->file;
-	int ret;
+	int ret = 0;
 
 	fio_ro_check(td, io_u);
 
-	if (io_u->ddir != DDIR_WRITE) {
+	if (io_u->ddir == DDIR_WRITE)
+		ret = ftruncate(f->fd, io_u->offset);
+	else if (io_u->ddir == DDIR_SYNC)
+		ret = do_io_u_sync(td, io_u);
+	else
 		io_u->error = EINVAL;
-		return FIO_Q_COMPLETED;
-	}
 
-	ret = ftruncate(f->fd, io_u->offset);
 	if (ret)
 		io_u->error = errno;
 


### PR DESCRIPTION
Hi! This small patch adds the ability to use fsync in file ioengines, more specifically in: fileoperations, falloc, and ftruncate.