### PR TITLE
Multi-job based data verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ SOURCE :=	$(sort $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/crc/*.c)) \
 		profiles/tiobench.c profiles/act.c io_u_queue.c filelock.c \
 		workqueue.c rate-submit.c optgroup.c helper_thread.c \
 		steadystate.c zone-dist.c zbd.c dedupe.c dataplacement.c \
-		sprandom.c
+		sprandom.c skiplist.c
 
 ifdef CONFIG_LIBHDFS
   HDFSFLAGS= -I $(JAVA_HOME)/include -I $(JAVA_HOME)/include/linux -I $(FIO_LIBHDFS_INCLUDE)

--- a/backend.c
+++ b/backend.c
@@ -614,6 +614,32 @@ static enum fio_q_status io_u_submit(struct thread_data *td, struct io_u *io_u)
 
 	return td_io_queue(td, io_u);
 }
+/*
+ * Check if this is the first job for the given verify table ID
+ */
+static bool is_first_job_for_table_id(struct thread_data *td, int table_id)
+{
+	int min_index = td->thread_number - 1;
+	int i;
+
+	for (i = 0; i < thread_number; i++) {
+		struct thread_data *td2 = tnumber_to_td(i);
+		if (td2->o.verify_table_id == table_id && i < min_index) {
+			min_index = i;
+		}
+	}
+
+	return (td->thread_number - 1) == min_index;
+}
+
+/*
+ * Check if this is the first job for the given shared verify table
+ */
+static bool is_first_job_for_table(struct thread_data *td,
+				   struct shared_verify_table *table)
+{
+	return is_first_job_for_table_id(td, table->table_id);
+}
 
 /*
  * The main verify engine. Runs over the writes we previously submitted,
@@ -627,6 +653,21 @@ static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 	int ret;
 
 	dprint(FD_VERIFY, "starting loop\n");
+
+	/*
+	 * If using shared verify table, wait for all write jobs to complete
+	 */
+	if (td->shared_verify_table) {
+		int active = atomic_load(&td->shared_verify_table->write_jobs_active);
+
+		if (active > 0) {
+			while (atomic_load(&td->shared_verify_table->write_jobs_done) < active) {
+				usleep(10000);
+				if (td->terminate)
+					return;
+			}
+		}
+	}
 
 	/*
 	 * sync io first and invalidate cache, to make sure we really
@@ -994,7 +1035,11 @@ void log_inflight(struct thread_data *td, struct io_u *io_u)
 		abort();
 	}
 
-	if (td->inflight_issued != io_u->numberio) {
+	/*
+	 * With shared verify tables, numberio is allocated globally across jobs,
+	 * so skip this check as td->inflight_issued is per-job
+	 */
+	if (!td->shared_verify_table && td->inflight_issued != io_u->numberio) {
 		log_err("inflight_issued does not match: numberio=%"PRIu64", inflight_issued=%"PRIu64"\n",
 			io_u->numberio, td->inflight_issued);
 		abort();
@@ -1180,11 +1225,16 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 			break;
 		}
 
-		if (io_u->ddir == DDIR_WRITE && td->flags & TD_F_DO_VERIFY) {
+		if ((io_u->ddir == DDIR_WRITE || io_u->ddir == DDIR_TRIM) &&
+		    td->flags & TD_F_DO_VERIFY) {
 			if (!(io_u->flags & IO_U_F_PATTERN_DONE)) {
 				io_u_set(td, io_u, IO_U_F_PATTERN_DONE);
-				io_u->numberio = td->io_issues[io_u->ddir];
-				populate_verify_io_u(td, io_u);
+				if (td->shared_verify_table)
+					io_u->numberio = atomic_fetch_add(&td->shared_verify_table->shared_numberio, 1);
+				else
+					io_u->numberio = td->io_issues[io_u->ddir];
+				if (io_u->ddir == DDIR_WRITE)
+					populate_verify_io_u(td, io_u);
 				log_inflight(td, io_u);
 			}
 		}
@@ -1230,11 +1280,18 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 		 * order of it. The logged unit will track when the IO has
 		 * completed.
 		 */
-		if (td_write(td) && io_u->ddir == DDIR_WRITE &&
-		    td->o.do_verify &&
+		if (((td_write(td) && io_u->ddir == DDIR_WRITE) || io_u->ddir == DDIR_TRIM) &&
 		    td->o.verify != VERIFY_NONE &&
-		    !td->o.experimental_verify)
-			log_io_piece(td, io_u);
+		    !td->o.experimental_verify &&
+		    (td->o.do_verify || td->shared_verify_table)) {
+			if (!log_io_piece(td, io_u)) {
+				dprint(FD_IO, "Overlap detected, skipping...\n");
+				invalidate_inflight(td, io_u);
+				clear_io_u(td, io_u);
+				ret = FIO_Q_BUSY;
+				goto reap;
+			}
+		}
 
 		if (td->o.io_submit_mode == IO_MODE_OFFLOAD) {
 			const unsigned long long blen = io_u->xfer_buflen;
@@ -1498,10 +1555,11 @@ int init_io_u_buffers(struct thread_data *td)
 
 	/*
 	 * For reads, writes, and multi-range trim operations we need a
-	 * data buffer
+	 * data buffer. Also need buffer if we're verifying trimmed data.
 	 */
 	if (td_ioengine_flagged(td, FIO_NOIO) ||
-	    !(td_read(td) || td_write(td) || (td_trim(td) && td->o.num_range > 1)))
+	    !(td_read(td) || td_write(td) || (td_trim(td) && td->o.num_range > 1) ||
+	      (td_trim(td) && td->o.do_verify && td->o.trim_zero)))
 		data_xfer = 0;
 
 	/*
@@ -1848,6 +1906,25 @@ static void *thread_main(void *data)
 		goto err;
 	}
 
+	if (o->verify_table_id > 0) {
+		td->shared_verify_table = get_shared_verify_table(o->verify_table_id);
+		if (!td->shared_verify_table) {
+			td_verror(td, ENOMEM, "failed to get shared verify table");
+			goto err;
+		}
+
+		if ((td_write(td) || td_trim(td)))
+			atomic_fetch_add(&td->shared_verify_table->write_jobs_active, 1);
+
+		/*
+		 * Load saved skiplist data from verify state if available.
+		 * Only the first job for this table should load to avoid
+		 * duplicate load attempts and error messages.
+		 */
+		if (is_first_job_for_table(td, td->shared_verify_table))
+			verify_load_state_skiplist(td);
+	}
+
 	td_set_runstate(td, TD_INITIALIZED);
 	dprint(FD_MUTEX, "up startup_sem\n");
 	fio_sem_up(startup_sem);
@@ -2065,9 +2142,12 @@ static void *thread_main(void *data)
 
 		prune_io_piece_log(td);
 
-		if (td->o.verify_only && td_write(td))
-			verify_bytes = do_dry_run(td);
-		else {
+		if (td->o.verify_only && (td_write(td) || td_trim(td))) {
+			if (!td->shared_verify_table && td_write(td))
+				verify_bytes = do_dry_run(td);
+			else
+				verify_bytes = atomic_load(&td->shared_verify_table->total_entries) * td->o.bs[DDIR_WRITE];
+		} else {
 			if (!td->o.rand_repeatable)
 				/* save verify rand state to replay hdr seeds later at verify */
 				frand_copy(&td->verify_state_last_do_io, &td->verify_state);
@@ -2124,6 +2204,10 @@ static void *thread_main(void *data)
 		fio_gettime(&td->start, NULL);
 		fio_sem_up(stat_sem);
 
+		if (td->shared_verify_table && td->o.do_verify &&
+				(td_write(td) || td_trim(td)))
+			atomic_fetch_add(&td->shared_verify_table->write_jobs_done, 1);
+
 		if (td->error || td->terminate)
 			break;
 
@@ -2131,6 +2215,18 @@ static void *thread_main(void *data)
 		    o->verify == VERIFY_NONE ||
 		    td_ioengine_flagged(td, FIO_UNIDIR))
 			continue;
+
+		/*
+		 * If --verify_table_id= is given, only one job can win the
+		 * race among write jobs and verify the entire io pieces at
+		 * once.  Until the verify job is done, wait here.
+		 */
+		if (td->shared_verify_table) {
+			int expected = 0;
+
+			if (!atomic_compare_exchange_strong(&td->shared_verify_table->verify_done, &expected, 1))
+				break;
+		}
 
 		clear_io_state(td, 0);
 
@@ -2184,8 +2280,30 @@ static void *thread_main(void *data)
 	}
 
 	if (td->o.verify_state_save && !(td->flags & TD_F_VSTATE_SAVED) &&
-	    (td->o.verify != VERIFY_NONE && td_write(td)))
-		verify_save_state(td->thread_number);
+	    (td->o.verify != VERIFY_NONE && !td->o.verify_only &&
+	     (td_write(td) || td_trim(td)))) {
+		/* For shared_verify_table, only the first job saves state */
+		if (td->shared_verify_table) {
+			struct shared_verify_table *table = td->shared_verify_table;
+
+			/* Signal this write job is done */
+			atomic_fetch_add(&table->write_jobs_done, 1);
+
+			/* Only save if this is the first job for this table */
+			if (is_first_job_for_table(td, table)) {
+				int active;
+
+				/* Wait for all write jobs to complete before saving state */
+				active = atomic_load(&table->write_jobs_active);
+				while (atomic_load(&table->write_jobs_done) < active)
+					usleep(1000);  /* Sleep 1ms */
+
+				verify_save_state(td->thread_number);
+			}
+		} else {
+			verify_save_state(td->thread_number);
+		}
+	}
 
 	fio_unpin_memory(td);
 
@@ -2207,6 +2325,11 @@ err:
 
 	if (o->verify_async)
 		verify_async_exit(td);
+
+	if (td->shared_verify_table) {
+		put_shared_verify_table(td->shared_verify_table);
+		td->shared_verify_table = NULL;
+	}
 
 	close_and_free_files(td);
 	cleanup_io_u(td);
@@ -2411,6 +2534,16 @@ static int fio_verify_load_state(struct thread_data *td)
 	int ret;
 
 	if (!td->o.verify_state)
+		return 0;
+
+	/*
+	 * For shared verify tables, only the first job should load state
+	 * to avoid duplicate load attempts and error messages.
+	 * Use verify_table_id instead of shared_verify_table pointer since
+	 * this function may be called before shared_verify_table is initialized.
+	 */
+	if (td->o.verify_table_id > 0 &&
+	    !is_first_job_for_table_id(td, td->o.verify_table_id))
 		return 0;
 
 	if (is_backend) {

--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -1619,6 +1619,16 @@ static int fio_ioring_io_u_init(struct thread_data *td, struct io_u *io_u)
 		io_u->engine_data = pi_data;
 	}
 
+	if (ld->is_uring_cmd_eng) {
+		if (ld->write_opcode == nvme_cmd_write_zeroes) {
+			if (o->deac)
+				io_u_set(td, io_u, IO_U_F_TRIMMED);
+			else
+				io_u_set(td, io_u, IO_U_F_ZEROED);
+		} else if (ld->write_opcode == nvme_cmd_write_uncor)
+			io_u_set(td, io_u, IO_U_F_ERRORED);
+	}
+
 	return 0;
 }
 

--- a/file.h
+++ b/file.h
@@ -164,6 +164,8 @@ struct fio_file {
 	enum fio_file_flags flags;
 
 	struct disk_util *du;
+
+	uint64_t file_name_hash;
 };
 
 #define FILE_ENG_DATA(f)		((f)->engine_data)

--- a/filesetup.c
+++ b/filesetup.c
@@ -1914,6 +1914,13 @@ int add_file(struct thread_data *td, const char *fname, int numjob, int inc)
 	/* can't handle smalloc failure from here */
 	assert(f->file_name);
 
+	/*
+	 * Get hashed value from the file name using djb2 algorithm
+	 */
+	f->file_name_hash = 0;
+	for (const char *p = f->file_name; *p; p++)
+		f->file_name_hash = (f->file_name_hash << 5) - f->file_name_hash + *p;
+
 	if (td->o.filetype)
 		f->filetype = td->o.filetype;
 	else

--- a/fio.h
+++ b/fio.h
@@ -452,6 +452,7 @@ struct thread_data {
 	struct rb_root io_hist_tree;
 	struct flist_head io_hist_list;
 	unsigned long io_hist_len;
+	struct shared_verify_table *shared_verify_table;
 
 	/*
 	 * For IO replaying

--- a/init.c
+++ b/init.c
@@ -856,7 +856,11 @@ static int fixup_options(struct thread_data *td)
 		o->size = -1ULL;
 
 	if (o->verify != VERIFY_NONE) {
-		if (td_write(td) && o->do_verify && o->numjobs > 1 &&
+		/*
+		 * In --verify_only=1 case, we don't warn users for multiple
+		 * writers data race which is for write phase.
+		 */
+		if (td_write(td) && o->do_verify && !o->verify_only && o->numjobs > 1 &&
 		    (o->filename ||
 		     !(o->unique_filename &&
 		       strstr(o->filename_format, "$jobname") &&
@@ -907,22 +911,8 @@ static int fixup_options(struct thread_data *td)
 							o->max_bs[DDIR_WRITE]);
 
 		if (o->verify_only) {
-			if (!fio_option_is_set(o, verify_write_sequence))
-				o->verify_write_sequence = 0;
-
 			if (!fio_option_is_set(o, verify_header_seed))
 				o->verify_header_seed = 0;
-		}
-
-		if (o->norandommap && !td_ioengine_flagged(td, FIO_SYNCIO) &&
-		    o->iodepth > 1) {
-			/*
-			 * Disable write sequence checks with norandommap and
-			 * iodepth > 1.
-			 * Unless we were explicitly asked to enable it.
-			 */
-			if (!fio_option_is_set(o, verify_write_sequence))
-				o->verify_write_sequence = 0;
 		}
 
 		/*

--- a/io_u.c
+++ b/io_u.c
@@ -2206,6 +2206,8 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 		}
 	} else if (io_u->error) {
 error:
+		if (io_u->flags & IO_U_F_ERRORED)
+			return;
 		icd->error = io_u->error;
 		io_u_log_error(td, io_u);
 	}

--- a/io_u.h
+++ b/io_u.h
@@ -24,6 +24,8 @@ enum {
 	IO_U_F_PATTERN_DONE	= 1 << 8,
 	IO_U_F_DEVICE_ERROR	= 1 << 9,
 	IO_U_F_VER_IN_DEV	= 1 << 10, /* Verify data in device */
+	IO_U_F_ZEROED		= 1 << 11, /* Zeroed data */
+	IO_U_F_ERRORED		= 1 << 12, /* Errored offset */
 };
 
 /*

--- a/iolog.c
+++ b/iolog.c
@@ -2080,9 +2080,12 @@ bool log_io_piece_shared(struct thread_data *td, struct io_u *io_u)
 
 	io_u->ipo = ipo;
 
-	if (io_u_should_trim(td, io_u) || io_u->ddir == DDIR_TRIM) {
+	if (io_u_should_trim(td, io_u) || io_u->ddir == DDIR_TRIM)
 		ipo->flags |= IP_F_TRIMMED;
-	}
+	else if (io_u->flags & IO_U_F_ZEROED)
+		ipo->flags |= IP_F_ZEROED;
+	else if (io_u->flags & IO_U_F_ERRORED)
+		ipo->flags |= IP_F_ERRORED;
 
 	/*
 	 * Use lock-free skiplist for concurrent insertion.

--- a/iolog.c
+++ b/iolog.c
@@ -14,12 +14,14 @@
 
 #include "flist.h"
 #include "fio.h"
+#include "hash.h"
 #include "trim.h"
 #include "filelock.h"
 #include "smalloc.h"
 #include "blktrace.h"
 #include "pshared.h"
 #include "lib/roundup.h"
+#include "skiplist.h"
 
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -218,10 +220,10 @@ int read_iolog_get(struct thread_data *td, struct io_u *io_u)
 
 		ret = ipo_special(td, ipo);
 		if (ret < 0) {
-			free(ipo);
+			free_io_piece(ipo);
 			break;
 		} else if (ret > 0) {
-			free(ipo);
+			free_io_piece(ipo);
 			continue;
 		}
 
@@ -245,7 +247,7 @@ int read_iolog_get(struct thread_data *td, struct io_u *io_u)
 				usec_sleep(td, (ipo->delay - elapsed) * 1000);
 		}
 
-		free(ipo);
+		free_io_piece(ipo);
 
 		if (io_u->ddir != DDIR_WAIT)
 			return 0;
@@ -265,7 +267,7 @@ void prune_io_piece_log(struct thread_data *td)
 		rb_erase(n, &td->io_hist_tree);
 		remove_trim_entry(td, ipo);
 		td->io_hist_len--;
-		free(ipo);
+		free_io_piece(ipo);
 	}
 
 	while (!flist_empty(&td->io_hist_list)) {
@@ -273,14 +275,14 @@ void prune_io_piece_log(struct thread_data *td)
 		flist_del(&ipo->list);
 		remove_trim_entry(td, ipo);
 		td->io_hist_len--;
-		free(ipo);
+		free_io_piece(ipo);
 	}
 }
 
 /*
  * log a successful write, so we can unwind the log for verify
  */
-void log_io_piece(struct thread_data *td, struct io_u *io_u)
+static void __log_io_piece(struct thread_data *td, struct io_u *io_u)
 {
 	struct fio_rb_node **p, *parent;
 	struct io_piece *ipo, *__ipo;
@@ -295,7 +297,8 @@ void log_io_piece(struct thread_data *td, struct io_u *io_u)
 
 	io_u->ipo = ipo;
 
-	if (io_u_should_trim(td, io_u)) {
+	if (io_u_should_trim(td, io_u) || io_u->ddir == DDIR_TRIM) {
+		ipo->flags |= IP_F_TRIMMED;
 		flist_add_tail(&ipo->trim_list, &td->trim_list);
 		td->trim_entries++;
 	}
@@ -350,7 +353,7 @@ restart:
 			rb_erase(parent, &td->io_hist_tree);
 			remove_trim_entry(td, __ipo);
 			if (!(__ipo->flags & IP_F_IN_FLIGHT))
-				free(__ipo);
+				free_io_piece(__ipo);
 			goto restart;
 		}
 	}
@@ -361,7 +364,17 @@ restart:
 	td->io_hist_len++;
 }
 
-void unlog_io_piece(struct thread_data *td, struct io_u *io_u)
+bool log_io_piece(struct thread_data *td, struct io_u *io_u)
+{
+	if (td->shared_verify_table)
+		return log_io_piece_shared(td, io_u);
+	else {
+		__log_io_piece(td, io_u);
+		return true;
+	}
+}
+
+static void __unlog_io_piece(struct thread_data *td, struct io_u *io_u)
 {
 	struct io_piece *ipo = io_u->ipo;
 
@@ -385,9 +398,17 @@ void unlog_io_piece(struct thread_data *td, struct io_u *io_u)
 	else if (ipo->flags & IP_F_ONLIST)
 		flist_del(&ipo->list);
 
-	free(ipo);
+	free_io_piece(ipo);
 	io_u->ipo = NULL;
 	td->io_hist_len--;
+}
+
+void unlog_io_piece(struct thread_data *td, struct io_u *io_u)
+{
+	if (td->shared_verify_table)
+		unlog_io_piece_shared(td, io_u);
+	else
+		__unlog_io_piece(td, io_u);
 }
 
 void trim_io_piece(const struct io_u *io_u)
@@ -1950,4 +1971,211 @@ void fio_writeout_logs(bool unit_logs)
 	for_each_td(td) {
 		td_writeout_logs(td, unit_logs);
 	} end_for_each();
+}
+
+/*
+ * Shared verify table implementation
+ */
+static struct shared_verify_table *shared_verify_tables[MAX_VERIFY_TABLES];
+static pthread_mutex_t shared_verify_lock = PTHREAD_MUTEX_INITIALIZER;
+
+struct shared_verify_table *get_shared_verify_table(int table_id)
+{
+	struct shared_verify_table *table;
+
+	if (table_id <= 0 || table_id >= MAX_VERIFY_TABLES)
+		return NULL;
+
+	pthread_mutex_lock(&shared_verify_lock);
+
+	table = shared_verify_tables[table_id];
+	if (!table) {
+		table = smalloc(sizeof(*table));
+		if (!table) {
+			pthread_mutex_unlock(&shared_verify_lock);
+			return NULL;
+		}
+
+		memset(table, 0, sizeof(*table));
+		table->table_id = table_id;
+		atomic_init(&table->total_entries, 0);
+		atomic_init(&table->shared_numberio, 0);
+		atomic_init(&table->verify_done, 0);
+		atomic_init(&table->write_jobs_active, 0);
+		atomic_init(&table->write_jobs_done, 0);
+		pthread_mutex_init(&table->ref_lock, NULL);
+
+		table->skiplist = skiplist_new();
+		if (!table->skiplist) {
+			pthread_mutex_destroy(&table->ref_lock);
+			sfree(table);
+			pthread_mutex_unlock(&shared_verify_lock);
+			return NULL;
+		}
+		shared_verify_tables[table_id] = table;
+	}
+
+	pthread_mutex_lock(&table->ref_lock);
+	table->ref_count++;
+	pthread_mutex_unlock(&table->ref_lock);
+
+	pthread_mutex_unlock(&shared_verify_lock);
+	return table;
+}
+
+void put_shared_verify_table(struct shared_verify_table *table)
+{
+	int should_free = 0;
+
+	if (!table)
+		return;
+
+	pthread_mutex_lock(&table->ref_lock);
+	table->ref_count--;
+	if (table->ref_count == 0)
+		should_free = 1;
+	pthread_mutex_unlock(&table->ref_lock);
+
+	if (!should_free)
+		return;
+
+	pthread_mutex_lock(&shared_verify_lock);
+
+	if (table->skiplist) {
+		skiplist_free(table->skiplist);
+		table->skiplist = NULL;
+	}
+
+	pthread_mutex_destroy(&table->ref_lock);
+	shared_verify_tables[table->table_id] = NULL;
+	sfree(table);
+
+	pthread_mutex_unlock(&shared_verify_lock);
+}
+
+bool log_io_piece_shared(struct thread_data *td, struct io_u *io_u)
+{
+	struct shared_verify_table *table = td->shared_verify_table;
+	struct io_piece *ipo;
+	struct skiplist_node *overlap_node;
+	int backoff = 0;
+
+	if (!table)
+		return true;
+
+	ipo = calloc(1, sizeof(struct io_piece));
+	init_ipo(ipo);
+	ipo->file = io_u->file;
+	ipo->file_name_hash = io_u->file->file_name_hash;
+	ipo->file_name = smalloc_strdup(io_u->file->file_name);
+	if (!ipo->file_name) {
+		free_io_piece(ipo);
+		io_u->ipo = NULL;
+		return false;
+	}
+	ipo->offset = io_u->offset;
+	ipo->len = io_u->buflen;
+	ipo->numberio = io_u->numberio;
+	ipo->flags = IP_F_IN_FLIGHT;
+
+	io_u->ipo = ipo;
+
+	if (io_u_should_trim(td, io_u) || io_u->ddir == DDIR_TRIM) {
+		ipo->flags |= IP_F_TRIMMED;
+	}
+
+	/*
+	 * Use lock-free skiplist for concurrent insertion.
+	 * Handle overlaps by detecting and deleting them before insert.
+	 * Retry indefinitely with exponential backoff.
+	 */
+	while (1) {
+		/* Check for overlapping ranges */
+		overlap_node = skiplist_search_overlap(table->skiplist,
+		                                        io_u->offset, io_u->buflen);
+
+		if (overlap_node) {
+			struct io_piece *overlap_ipo = (struct io_piece *)overlap_node->data;
+
+			/* If previous write is still in-flight, serialize by returning busy */
+			if (overlap_ipo && (atomic_load_acquire(&overlap_ipo->flags) & IP_F_IN_FLIGHT)) {
+				dprint(FD_VERIFY, "skiplist: overlap in-flight [%llu, %llu), blocked by [%llu, %llu)\n",
+				       (unsigned long long)io_u->offset,
+				       (unsigned long long)(io_u->offset + io_u->buflen),
+				       (unsigned long long)overlap_ipo->offset,
+				       (unsigned long long)(overlap_ipo->offset + overlap_ipo->len));
+				free_io_piece(ipo);
+				io_u->ipo = NULL;
+				return false;
+			}
+
+			if (skiplist_delete_node(table->skiplist, overlap_node) == 0) {
+				dprint(FD_VERIFY, "skiplist: delete overlap [%llu, %llu) for new [%llu, %llu)\n",
+				       (unsigned long long)overlap_ipo->offset,
+				       (unsigned long long)(overlap_ipo->offset + overlap_ipo->len),
+				       (unsigned long long)io_u->offset,
+				       (unsigned long long)(io_u->offset + io_u->buflen));
+				if (overlap_ipo) {
+					remove_trim_entry(td, overlap_ipo);
+					free_io_piece(overlap_ipo);
+				}
+				atomic_fetch_sub(&table->total_entries, 1);
+			}
+		}
+
+		if (skiplist_insert(table->skiplist, io_u->offset, io_u->buflen, ipo) == 0) {
+			dprint(FD_VERIFY, "skiplist: insert [%llu, %llu) numberio=%llu\n",
+			       (unsigned long long)io_u->offset,
+			       (unsigned long long)(io_u->offset + io_u->buflen),
+			       (unsigned long long)io_u->numberio);
+			ipo->flags |= IP_F_ONRB;
+			atomic_fetch_add(&table->total_entries, 1);
+			return true;
+		}
+
+		/* Insert failed (overlap detected by skiplist_insert), retry with backoff */
+		if (backoff < 1000) {
+			/* Exponential backoff up to 1000 iterations */
+			for (volatile int i = 0; i < backoff; i++)
+				;
+			backoff = backoff ? backoff * 2 : 1;
+		}
+	}
+}
+
+void unlog_io_piece_shared(struct thread_data *td, struct io_u *io_u)
+{
+	struct io_piece *ipo = io_u->ipo;
+
+	if (td->ts.nr_block_infos) {
+		uint32_t *info = io_u_block_info(td, io_u);
+		if (BLOCK_INFO_STATE(*info) < BLOCK_STATE_TRIM_FAILURE) {
+			if (io_u->ddir == DDIR_TRIM)
+				*info = BLOCK_INFO_SET_STATE(*info,
+						BLOCK_STATE_TRIM_FAILURE);
+			else if (io_u->ddir == DDIR_WRITE)
+				*info = BLOCK_INFO_SET_STATE(*info,
+						BLOCK_STATE_WRITE_FAILURE);
+		}
+	}
+
+	if (!ipo)
+		return;
+
+	if (ipo->flags & IP_F_ONRB) {
+		struct shared_verify_table *table = td->shared_verify_table;
+
+		if (skiplist_delete(table->skiplist, io_u->offset) == 0) {
+			dprint(FD_VERIFY, "skiplist: unlog delete [%llu, %llu) numberio=%llu\n",
+			       (unsigned long long)io_u->offset,
+			       (unsigned long long)(io_u->offset + io_u->buflen),
+			       (unsigned long long)io_u->numberio);
+			atomic_fetch_sub(&table->total_entries, 1);
+		}
+
+		ipo->flags &= ~IP_F_ONRB;
+	}
+
+	free_io_piece(ipo);
+	io_u->ipo = NULL;
 }

--- a/iolog.h
+++ b/iolog.h
@@ -245,6 +245,8 @@ enum {
 	IP_F_ONLIST	= 2,
 	IP_F_TRIMMED	= 4,
 	IP_F_IN_FLIGHT	= 8,
+	IP_F_ZEROED	= 16,
+	IP_F_ERRORED	= 32,
 };
 
 /*

--- a/options.c
+++ b/options.c
@@ -3140,6 +3140,18 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		.group	= FIO_OPT_G_RUNTIME,
 	},
 	{
+		.name	= "verify_table_id",
+		.lname	= "Shared Verify Table ID",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct thread_options, verify_table_id),
+		.help	= "Share verify state across jobs with same table ID (0 = per-job default)",
+		.def	= "0",
+		.minval	= 0,
+		.maxval	= 255,
+		.category = FIO_OPT_C_IO,
+		.group	= FIO_OPT_G_VERIFY,
+	},
+	{
 		.name	= "ramp_time",
 		.lname	= "Ramp time",
 		.type	= FIO_OPT_STR_VAL_TIME,

--- a/options.c
+++ b/options.c
@@ -3597,6 +3597,16 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		.group	= FIO_OPT_G_TRIM,
 	},
 	{
+		.name	= "trim_verify_error",
+		.lname	= "Trim verify error",
+		.type	= FIO_OPT_INT,
+		.off1	= offsetof(struct thread_options, trim_error),
+		.help	= "Error value for trim verification",
+		.def	= "0",
+		.category = FIO_OPT_C_IO,
+		.group	= FIO_OPT_G_TRIM,
+	},
+	{
 		.name	= "trim_backlog",
 		.lname	= "Trim backlog",
 		.type	= FIO_OPT_STR_VAL,
@@ -3630,6 +3640,12 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 	{
 		.name	= "trim_verify_zero",
 		.lname	= "Verify trim zero",
+		.type	= FIO_OPT_UNSUPPORTED,
+		.help	= "Fio does not support TRIM on your platform",
+	},
+	{
+		.name	= "trim_verify_error",
+		.lname	= "Trim verify error",
 		.type	= FIO_OPT_UNSUPPORTED,
 		.help	= "Fio does not support TRIM on your platform",
 	},

--- a/skiplist.c
+++ b/skiplist.c
@@ -1,0 +1,534 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdatomic.h>
+#include <time.h>
+#include <assert.h>
+#include "skiplist.h"
+
+/* Marked pointer handling - use LSB for marking */
+#define MARK_MASK    ((uintptr_t)0x1)
+#define PTR_MASK     (~MARK_MASK)
+
+static inline bool is_marked(struct skiplist_node *ptr)
+{
+	return ((uintptr_t)ptr & MARK_MASK) != 0;
+}
+
+static inline struct skiplist_node *get_unmarked(struct skiplist_node *ptr)
+{
+	return (struct skiplist_node *)((uintptr_t)ptr & PTR_MASK);
+}
+
+static inline struct skiplist_node *get_marked(struct skiplist_node *ptr)
+{
+	return (struct skiplist_node *)((uintptr_t)ptr | MARK_MASK);
+}
+
+/*
+ * Generate a random level for a new node using geometric distribution
+ */
+static int random_level(void)
+{
+	int level = 1;
+
+	while (level < SKIPLIST_MAX_LEVEL && ((double)rand() / RAND_MAX) < SKIPLIST_P)
+		level++;
+
+	return level;
+}
+
+/*
+ * Create a new skiplist node
+ */
+static struct skiplist_node *create_node(uint64_t offset, uint64_t length,
+                                         void *data, int level)
+{
+	size_t size = sizeof(struct skiplist_node) +
+	              level * sizeof(_Atomic(struct skiplist_node *));
+	struct skiplist_node *node = malloc(size);
+
+	if (!node)
+		return NULL;
+
+	node->offset = offset;
+	node->length = length;
+	node->data = data;
+	node->level = level;
+
+	for (int i = 0; i < level; i++)
+		atomic_init(&node->forward[i], NULL);
+
+	return node;
+}
+
+/*
+ * Initialize a new skiplist
+ */
+struct skiplist *skiplist_new(void)
+{
+	struct skiplist *list = malloc(sizeof(struct skiplist));
+	struct skiplist_node *header;
+	static atomic_bool seeded = false;
+	bool expected = false;
+
+	if (!list)
+		return NULL;
+
+	/* Create sentinel header node with max level */
+	header = create_node(0, 0, NULL, SKIPLIST_MAX_LEVEL);
+	if (!header) {
+		free(list);
+		return NULL;
+	}
+
+	atomic_init(&list->header, header);
+	atomic_init(&list->max_level, 1);
+	atomic_init(&list->count, 0);
+
+	/* Seed random number generator */
+	if (atomic_compare_exchange_strong(&seeded, &expected, true))
+		srand(time(NULL));
+
+	return list;
+}
+
+/*
+ * Free the entire skiplist
+ */
+void skiplist_free(struct skiplist *list)
+{
+	struct skiplist_node *header;
+	struct skiplist_node *current;
+
+	if (!list)
+		return;
+
+	header = atomic_load(&list->header);
+	current = get_unmarked(atomic_load(&header->forward[0]));
+
+	while (current) {
+		struct skiplist_node *next = get_unmarked(atomic_load(&current->forward[0]));
+		free(current);
+		current = next;
+	}
+
+	free(header);
+	free(list);
+}
+
+/*
+ * Check if two ranges overlap
+ */
+static inline bool ranges_overlap(uint64_t offset1, uint64_t length1,
+                                  uint64_t offset2, uint64_t length2)
+{
+	uint64_t end1 = offset1 + length1;
+	uint64_t end2 = offset2 + length2;
+
+	return (offset1 < end2) && (offset2 < end1);
+}
+
+/*
+ * Find predecessors and successors for a given key (offset)
+ */
+static bool find(struct skiplist *list, uint64_t offset,
+                 struct skiplist_node **preds, struct skiplist_node **succs)
+{
+	struct skiplist_node *pred, *curr, *succ;
+	int level;
+	bool found = false;
+
+retry:
+	pred = atomic_load(&list->header);
+
+	for (level = SKIPLIST_MAX_LEVEL - 1; level >= 0; level--) {
+		curr = get_unmarked(atomic_load(&pred->forward[level]));
+
+		while (curr != NULL) {
+			succ = atomic_load(&curr->forward[level]);
+
+			/* Remove marked nodes we encounter */
+			while (is_marked(succ)) {
+				struct skiplist_node *unmarked_succ = get_unmarked(succ);
+
+				/* Try to physically remove the marked node */
+				if (!atomic_compare_exchange_strong(&pred->forward[level],
+				                                     &curr, unmarked_succ)) {
+					goto retry;
+				}
+
+				curr = get_unmarked(atomic_load(&pred->forward[level]));
+				if (curr == NULL)
+					break;
+				succ = atomic_load(&curr->forward[level]);
+			}
+
+			if (curr == NULL)
+				break;
+
+			/* Move forward if current offset is less than target */
+			if (curr->offset < offset) {
+				pred = curr;
+				curr = get_unmarked(succ);
+			} else {
+				break;
+			}
+		}
+
+		if (preds)
+			preds[level] = pred;
+		if (succs)
+			succs[level] = curr;
+	}
+
+	/* Check if we found exact match */
+	if (curr && curr->offset == offset && !is_marked(atomic_load(&curr->forward[0])))
+		found = true;
+
+	return found;
+}
+
+/*
+ * Search for a node that contains the given offset
+ */
+struct skiplist_node *skiplist_search(struct skiplist *list, uint64_t offset)
+{
+	struct skiplist_node *pred, *curr;
+
+	if (!list)
+		return NULL;
+
+	pred = atomic_load(&list->header);
+
+	for (int level = SKIPLIST_MAX_LEVEL - 1; level >= 0; level--) {
+		curr = get_unmarked(atomic_load(&pred->forward[level]));
+
+		while (curr != NULL) {
+			if (is_marked(atomic_load(&curr->forward[0]))) {
+				/* Skip marked node - move to next */
+				curr = get_unmarked(atomic_load(&curr->forward[level]));
+				continue;
+			}
+
+			/* Check if offset falls within this node's range */
+			if (offset >= curr->offset && offset < curr->offset + curr->length)
+				return curr;
+
+			if (curr->offset > offset)
+				break;
+
+			pred = curr;
+			curr = get_unmarked(atomic_load(&curr->forward[level]));
+		}
+	}
+
+	return NULL;
+}
+
+/*
+ * Search for any node that overlaps with the range [offset, offset+length)
+ */
+struct skiplist_node *skiplist_search_overlap(struct skiplist *list,
+                                               uint64_t offset, uint64_t length)
+{
+	struct skiplist_node *pred, *curr;
+
+	if (!list)
+		return NULL;
+
+	pred = atomic_load(&list->header);
+
+	for (int level = SKIPLIST_MAX_LEVEL - 1; level >= 0; level--) {
+		curr = get_unmarked(atomic_load(&pred->forward[level]));
+
+		while (curr != NULL) {
+			if (is_marked(atomic_load(&curr->forward[0]))) {
+				/* Skip marked node - move to next */
+				curr = get_unmarked(atomic_load(&curr->forward[level]));
+				continue;
+			}
+
+			/* Check for overlap */
+			if (ranges_overlap(offset, length, curr->offset, curr->length))
+				return curr;
+
+			/* If current node's start is beyond our range, no more overlaps possible */
+			if (curr->offset >= offset + length)
+				break;
+
+			pred = curr;
+			curr = get_unmarked(atomic_load(&curr->forward[level]));
+		}
+	}
+
+	return NULL;
+}
+
+/*
+ * Insert a range [offset, offset+length) with associated data
+ */
+int skiplist_insert(struct skiplist *list, uint64_t offset,
+                    uint64_t length, void *data)
+{
+	struct skiplist_node *preds[SKIPLIST_MAX_LEVEL];
+	struct skiplist_node *succs[SKIPLIST_MAX_LEVEL];
+	struct skiplist_node *new_node;
+	int level, max_level;
+
+	if (!list)
+		return -1;
+
+	/* Generate random level for new node */
+	level = random_level();
+
+	while (true) {
+		struct skiplist_node *expected;
+		bool found;
+
+		/*
+		 * CRITICAL: Check for overlaps on every retry to prevent race conditions
+		 * Two threads could pass initial check simultaneously then both insert
+		 */
+		if (skiplist_search_overlap(list, offset, length) != NULL)
+			return -1;
+
+		/* Find position to insert */
+		found = find(list, offset, preds, succs);
+
+		/* If already exists, fail */
+		if (found)
+			return -1;
+
+		/* Double-check for overlaps with both predecessors and successors */
+		for (int i = 0; i < level && i < SKIPLIST_MAX_LEVEL; i++) {
+			/* Check successor overlap */
+			if (succs[i] && ranges_overlap(offset, length,
+			                               succs[i]->offset, succs[i]->length))
+				return -1;
+
+			/* Check predecessor overlap (skip header node) */
+			if (preds[i] && preds[i] != atomic_load(&list->header) &&
+			    ranges_overlap(offset, length,
+			                   preds[i]->offset, preds[i]->length))
+				return -1;
+		}
+
+		/* Create new node */
+		new_node = create_node(offset, length, data, level);
+		if (!new_node)
+			return -1;
+
+		/* Link new node to successors */
+		for (int i = 0; i < level; i++)
+			atomic_store(&new_node->forward[i], succs[i]);
+
+		/* Try to insert at level 0 first (most critical) */
+		expected = succs[0];
+		if (!atomic_compare_exchange_strong(&preds[0]->forward[0],
+		                                     &expected, new_node)) {
+			/* Failed, retry */
+			free(new_node);
+			continue;
+		}
+
+		/* Successfully inserted at level 0, now insert at higher levels */
+		for (int i = 1; i < level; i++) {
+			while (true) {
+				expected = succs[i];
+				if (atomic_compare_exchange_strong(&preds[i]->forward[i],
+				                                    &expected, new_node))
+					break;
+
+				/* Retry finding position for this level */
+				find(list, offset, preds, succs);
+			}
+		}
+
+		/* Update max level if necessary */
+		max_level = atomic_load(&list->max_level);
+		if (level > max_level) {
+			atomic_compare_exchange_strong(&list->max_level, &max_level, level);
+		}
+
+		atomic_fetch_add(&list->count, 1);
+		return 0;
+	}
+}
+
+/*
+ * Delete a range starting at offset
+ */
+int skiplist_delete(struct skiplist *list, uint64_t offset)
+{
+	struct skiplist_node *preds[SKIPLIST_MAX_LEVEL];
+	struct skiplist_node *succs[SKIPLIST_MAX_LEVEL];
+	struct skiplist_node *victim;
+
+	if (!list)
+		return -1;
+
+	while (true) {
+		struct skiplist_node *succ;
+		/* Find the node to delete */
+		bool found = find(list, offset, preds, succs);
+
+		if (!found)
+			return -1;
+
+		victim = succs[0];
+
+		/* Logically delete by marking all forward pointers from top to bottom */
+		for (int level = victim->level - 1; level >= 1; level--) {
+			do {
+				succ = atomic_load(&victim->forward[level]);
+				if (is_marked(succ))
+					break;
+			} while (!atomic_compare_exchange_strong(&victim->forward[level],
+			                                          &succ, get_marked(succ)));
+		}
+
+		/* Mark level 0 last */
+		succ = atomic_load(&victim->forward[0]);
+		while (true) {
+			if (is_marked(succ))
+				return -1;  /* Already deleted by another thread */
+
+			if (atomic_compare_exchange_strong(&victim->forward[0],
+			                                    &succ, get_marked(succ)))
+				break;
+		}
+
+		/* Physical deletion will be done by find() on next traversal */
+		atomic_fetch_sub(&list->count, 1);
+
+		/* Try to help with physical deletion */
+		find(list, offset, NULL, NULL);
+
+		return 0;
+	}
+}
+
+/*
+ * Delete a specific node by pointer (thread-safe)
+ * This is safer than delete-by-offset in concurrent scenarios
+ * where the same offset might be reused
+ */
+int skiplist_delete_node(struct skiplist *list, struct skiplist_node *target)
+{
+	struct skiplist_node *succ;
+
+	if (!list || !target)
+		return -1;
+
+	/* Check if already marked for deletion */
+	if (is_marked(atomic_load(&target->forward[0])))
+		return -1;
+
+	/* Logically delete by marking all forward pointers from top to bottom */
+	for (int level = target->level - 1; level >= 1; level--) {
+		do {
+			succ = atomic_load(&target->forward[level]);
+			if (is_marked(succ))
+				break;
+		} while (!atomic_compare_exchange_strong(&target->forward[level],
+		                                          &succ, get_marked(succ)));
+	}
+
+	/* Mark level 0 last */
+	succ = atomic_load(&target->forward[0]);
+	while (true) {
+		if (is_marked(succ))
+			return -1;  /* Already deleted by another thread */
+
+		if (atomic_compare_exchange_strong(&target->forward[0],
+		                                    &succ, get_marked(succ)))
+			break;
+	}
+
+	/* Physical deletion will be done by find() on next traversal */
+	atomic_fetch_sub(&list->count, 1);
+
+	/* Try to help with physical deletion */
+	find(list, target->offset, NULL, NULL);
+
+	return 0;
+}
+
+/*
+ * Get the number of nodes in the skiplist
+ */
+uint64_t skiplist_count(struct skiplist *list)
+{
+	if (!list)
+		return 0;
+
+	return atomic_load(&list->count);
+}
+
+/*
+ * Get the first node in the skiplist
+ */
+struct skiplist_node *skiplist_first(struct skiplist *list)
+{
+	struct skiplist_node *header, *first;
+
+	if (!list)
+		return NULL;
+
+	header = atomic_load(&list->header);
+	first = get_unmarked(atomic_load(&header->forward[0]));
+
+	/* Skip marked nodes */
+	while (first && is_marked(atomic_load(&first->forward[0]))) {
+		first = get_unmarked(atomic_load(&first->forward[0]));
+	}
+
+	return first;
+}
+
+struct skiplist_node *skiplist_next(struct skiplist *list, struct skiplist_node *node)
+{
+	struct skiplist_node *next;
+
+	if (!list || !node)
+		return NULL;
+
+	next = get_unmarked(atomic_load(&node->forward[0]));
+
+	/* Skip marked (deleted) nodes */
+	while (next && is_marked(atomic_load(&next->forward[0]))) {
+		next = get_unmarked(atomic_load(&next->forward[0]));
+	}
+
+	return next;
+}
+
+/*
+ * Print skiplist structure (for debugging)
+ */
+void skiplist_print(struct skiplist *list)
+{
+	struct skiplist_node *header;
+	struct skiplist_node *current;
+
+	if (!list)
+		return;
+
+	header = atomic_load(&list->header);
+	current = get_unmarked(atomic_load(&header->forward[0]));
+
+	printf("Skiplist (count=%llu, max_level=%d):\n",
+	       (unsigned long long)atomic_load(&list->count), atomic_load(&list->max_level));
+
+	while (current) {
+		printf("  [%llu, %llu) level=%d data=%p marked=%d\n",
+		       (unsigned long long)current->offset,
+		       (unsigned long long)(current->offset + current->length),
+		       current->level,
+		       current->data,
+		       is_marked(atomic_load(&current->forward[0])) ? 1 : 0);
+
+		current = get_unmarked(atomic_load(&current->forward[0]));
+	}
+}

--- a/skiplist.h
+++ b/skiplist.h
@@ -1,0 +1,98 @@
+#ifndef FIO_SKIPLIST_H
+#define FIO_SKIPLIST_H
+
+#include <stdint.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+#define SKIPLIST_MAX_LEVEL 16
+#define SKIPLIST_P 0.5  /* Probability for level promotion */
+
+struct skiplist_node {
+	uint64_t offset;        /* Start offset of the range */
+	uint64_t length;        /* Length of the range */
+	void *data;             /* User data pointer */
+
+	/* Variable-length array of forward pointers (atomic for lock-free) */
+	int level;
+	_Atomic(struct skiplist_node *) forward[];
+};
+
+/*
+ * Lock-free skiplist structure
+ * Uses atomic operations for concurrent access
+ */
+struct skiplist {
+	_Atomic(struct skiplist_node *) header;
+	_Atomic int max_level;
+	_Atomic uint64_t count;
+};
+
+/* Initialize a new skiplist */
+struct skiplist *skiplist_new(void);
+
+/* Free the entire skiplist */
+void skiplist_free(struct skiplist *list);
+
+/*
+ * Insert a range [offset, offset+length) with associated data
+ * Returns:
+ *   0 on success
+ *  -1 if overlapping range exists (overlap check)
+ */
+int skiplist_insert(struct skiplist *list, uint64_t offset,
+                    uint64_t length, void *data);
+
+/*
+ * Search for a node that contains the given offset
+ * Returns the node if found (where offset is in [node.offset, node.offset+node.length))
+ * Returns NULL if not found
+ */
+struct skiplist_node *skiplist_search(struct skiplist *list, uint64_t offset);
+
+/*
+ * Search for any node that overlaps with the range [offset, offset+length)
+ * Returns the first overlapping node found, or NULL if no overlap
+ */
+struct skiplist_node *skiplist_search_overlap(struct skiplist *list,
+                                               uint64_t offset, uint64_t length);
+
+/*
+ * Delete a range starting at offset
+ * Returns:
+ *   0 on success
+ *  -1 if not found
+ */
+int skiplist_delete(struct skiplist *list, uint64_t offset);
+
+/*
+ * Delete a specific node by pointer (safer for concurrent use)
+ * Returns:
+ *   0 on success
+ *  -1 if node already deleted or not found
+ */
+int skiplist_delete_node(struct skiplist *list, struct skiplist_node *node);
+
+/*
+ * Get the number of nodes in the skiplist
+ */
+uint64_t skiplist_count(struct skiplist *list);
+
+/*
+ * Get the first node in the skiplist (for iteration)
+ * Returns NULL if list is empty
+ */
+struct skiplist_node *skiplist_first(struct skiplist *list);
+
+/*
+ * Get the next node after the given node (for iteration)
+ * Returns NULL if no more nodes
+ */
+struct skiplist_node *skiplist_next(struct skiplist *list, struct skiplist_node *node);
+
+/*
+ * Print skiplist structure (for debugging)
+ */
+void skiplist_print(struct skiplist *list);
+
+#endif /* FIO_SKIPLIST_H */

--- a/t/verify-state.c
+++ b/t/verify-state.c
@@ -56,9 +56,9 @@ static void show(struct thread_io_list *s, size_t size)
 
 		show_s(s, no_s);
 		no_s++;
-		size -= __thread_io_list_sz(s->depth);
+		size -= __thread_io_list_sz(s->depth, s->skiplist_data_size);
 		s = (struct thread_io_list *)((char *) s +
-			__thread_io_list_sz(s->depth));
+			__thread_io_list_sz(s->depth, s->skiplist_data_size));
 	} while (size != 0);
 }
 

--- a/thread_options.h
+++ b/thread_options.h
@@ -416,6 +416,8 @@ struct thread_options {
 	unsigned int log_entries;
 	unsigned int log_prio;
 	unsigned int log_issue_time;
+
+	unsigned int trim_error;
 };
 
 #define FIO_TOP_STR_MAX		256
@@ -750,6 +752,8 @@ struct thread_options_pack {
 	uint8_t dp_scheme_file[FIO_TOP_STR_MAX];
 
 	uint32_t num_range;
+
+	uint32_t trim_error;
 	/*
 	 * verify_pattern followed by buffer_pattern from the unpacked struct
 	 */

--- a/thread_options.h
+++ b/thread_options.h
@@ -161,6 +161,8 @@ struct thread_options {
 	unsigned int verify_state_save;
 	unsigned int verify_write_sequence;
 	unsigned int verify_header_seed;
+	unsigned int verify_table_id;
+	unsigned int pad_verify;
 	unsigned int use_thread;
 	unsigned int unlink;
 	unsigned int unlink_each_loop;
@@ -500,6 +502,8 @@ struct thread_options_pack {
 	uint32_t verify_state_save;
 	uint32_t verify_write_sequence;
 	uint32_t verify_header_seed;
+	uint32_t verify_table_id;
+	uint32_t pad_verify;
 	uint32_t use_thread;
 	uint32_t unlink;
 	uint32_t unlink_each_loop;

--- a/trim.c
+++ b/trim.c
@@ -40,7 +40,7 @@ bool get_next_trim(struct thread_data *td, struct io_u *io_u)
 			rb_erase(&ipo->rb_node, &td->io_hist_tree);
 		}
 		td->io_hist_len--;
-		free(ipo);
+		free_io_piece(ipo);
 	} else
 		ipo->flags |= IP_F_TRIMMED;
 

--- a/verify-state.h
+++ b/verify-state.h
@@ -27,13 +27,26 @@ struct inflight_write {
 	uint64_t numberio;
 };
 
+/* Saved io_piece for shared_verify_table skiplist */
+struct saved_io_piece {
+	uint64_t offset;
+	uint64_t numberio;
+	uint32_t len;
+	uint32_t flags;
+	uint64_t file_name_hash;
+	/* file_name follows as null-terminated string */
+};
+
 struct thread_io_list {
 	uint32_t depth; /* I/O depth of the job that saves the verify state */
 	uint64_t numberio; /* Number of issued writes */
 	uint64_t index;
 	struct thread_rand_state rand;
 	uint8_t name[64];
+	uint32_t skiplist_count; /* Number of skiplist entries for shared_verify_table */
+	uint32_t skiplist_data_size; /* Total size in bytes of skiplist data */
 	struct inflight_write inflight[0];
+	/* skiplist entries follow after inflight array (for shared_verify_table) */
 };
 
 struct all_io_list {
@@ -41,7 +54,7 @@ struct all_io_list {
 	struct thread_io_list state[0];
 };
 
-#define VSTATE_HDR_VERSION	0x05
+#define VSTATE_HDR_VERSION	0x06
 
 struct verify_state_hdr {
 	uint64_t version;
@@ -59,16 +72,19 @@ extern int verify_load_state(struct thread_data *, const char *);
 extern void verify_free_state(struct thread_data *);
 extern int verify_state_should_stop(struct thread_data *, uint64_t);
 extern void verify_assign_state(struct thread_data *, void *);
+extern void verify_load_state_skiplist(struct thread_data *);
 extern int verify_state_hdr(struct verify_state_hdr *, struct thread_io_list *);
 
-static inline size_t __thread_io_list_sz(uint32_t depth)
+static inline size_t __thread_io_list_sz(uint32_t depth, uint32_t skiplist_data_size)
 {
-	return sizeof(struct thread_io_list) + depth * sizeof(struct inflight_write);
+	return sizeof(struct thread_io_list) +
+	       depth * sizeof(struct inflight_write) +
+	       skiplist_data_size;
 }
 
 static inline size_t thread_io_list_sz(struct thread_io_list *s)
 {
-	return __thread_io_list_sz(le32_to_cpu(s->depth));
+	return __thread_io_list_sz(le32_to_cpu(s->depth), le32_to_cpu(s->skiplist_data_size));
 }
 
 static inline struct thread_io_list *io_list_next(struct thread_io_list *s)

--- a/verify.c
+++ b/verify.c
@@ -910,6 +910,12 @@ static int verify_zero(struct io_u *io_u)
 
 static int verify_trimmed_io_u(struct thread_data *td, struct io_u *io_u)
 {
+	if (td->o.trim_error) {
+		if (td->o.trim_error == io_u->error)
+			return 0;
+		return EILSEQ;
+	}
+
 	if (!td->o.trim_zero)
 		return 0;
 

--- a/verify.c
+++ b/verify.c
@@ -16,6 +16,7 @@
 #include "lib/hweight.h"
 #include "lib/pattern.h"
 #include "oslib/asprintf.h"
+#include "skiplist.h"
 
 #include "crc/md5.h"
 #include "crc/crc64.h"
@@ -1403,7 +1404,7 @@ void populate_verify_io_u(struct thread_data *td, struct io_u *io_u)
 	fill_pattern_headers(td, io_u, 0, 0);
 }
 
-int get_next_verify(struct thread_data *td, struct io_u *io_u)
+static int __get_next_verify(struct thread_data *td, struct io_u *io_u)
 {
 	struct io_piece *ipo = NULL;
 
@@ -1471,7 +1472,7 @@ int get_next_verify(struct thread_data *td, struct io_u *io_u)
 		io_u->xfer_buflen = io_u->buflen;
 
 		remove_trim_entry(td, ipo);
-		free(ipo);
+		free_io_piece(ipo);
 		dprint(FD_VERIFY, "get_next_verify: ret io_u %p\n", io_u);
 
 		if (!td->o.verify_pattern_bytes) {
@@ -1485,6 +1486,14 @@ int get_next_verify(struct thread_data *td, struct io_u *io_u)
 nothing:
 	dprint(FD_VERIFY, "get_next_verify: empty\n");
 	return 1;
+}
+
+int get_next_verify(struct thread_data *td, struct io_u *io_u)
+{
+	if (td->shared_verify_table)
+		return get_next_verify_shared(td, io_u);
+	else
+		return __get_next_verify(td, io_u);
 }
 
 void fio_verify_init(struct thread_data *td)
@@ -1665,6 +1674,45 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 	*sz = sizeof(*rep);
 	*sz += nr * sizeof(struct thread_io_list);
 	*sz += depth * sizeof(struct inflight_write);
+
+	/* Add space for skiplist entries (saved_io_piece + filenames) */
+	/* Only save once per shared_verify_table (by first job) */
+	for_each_td(td) {
+		if (save_mask != IO_LIST_ALL && (__td_index + 1) != save_mask)
+			continue;
+		if (td->shared_verify_table) {
+			struct shared_verify_table *table = td->shared_verify_table;
+			struct skiplist_node *node;
+			int min_index = __td_index;
+			int i;
+
+			/* Find minimum thread index using this table_id */
+			for (i = 0; i < thread_number; i++) {
+				struct thread_data *td2 = tnumber_to_td(i);
+				if (td2->shared_verify_table &&
+				    td2->shared_verify_table->table_id == table->table_id &&
+				    i < min_index) {
+					min_index = i;
+				}
+			}
+
+			/* Only the job with minimum index saves skiplist */
+			if (__td_index == min_index) {
+				for (node = skiplist_first(table->skiplist); node; node = skiplist_next(table->skiplist, node)) {
+					struct io_piece *ipo = (struct io_piece *)node->data;
+					/*
+					 * Safety check: should not happen since we wait for all
+					 * write jobs to complete before saving state
+					 */
+					if (!ipo || !ipo->file_name)
+						continue;
+					*sz += sizeof(struct saved_io_piece);
+					*sz += strlen(ipo->file_name) + 1;
+				}
+			}
+		}
+	} end_for_each();
+
 	rep = calloc(1, *sz);
 
 	rep->threads = cpu_to_le64((uint64_t) nr);
@@ -1672,15 +1720,85 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 	next = &rep->state[0];
 	for_each_td(td) {
 		struct thread_io_list *s = next;
+		uint32_t skiplist_count = 0;
+		char *ptr, *start_ptr;
 
 		if (save_mask != IO_LIST_ALL && (__td_index + 1) != save_mask)
 			continue;
 
-		for (int i = 0; i < td->o.iodepth; i++)
-			s->inflight[i].numberio = cpu_to_le64(atomic_load_acquire(&td->inflight_numberio[i]));
+		/* Handle shared_verify_table */
+		if (td->shared_verify_table) {
+			struct shared_verify_table *table = td->shared_verify_table;
+			struct skiplist_node *node;
+			int min_index = __td_index;
+			int i;
 
-		s->depth = cpu_to_le32((uint32_t) td->o.iodepth);
-		s->numberio = cpu_to_le64((uint64_t) atomic_load_acquire(&td->inflight_issued));
+			/* Find minimum thread index using this table_id */
+			for (i = 0; i < thread_number; i++) {
+				struct thread_data *td2 = tnumber_to_td(i);
+				if (td2->shared_verify_table &&
+				    td2->shared_verify_table->table_id == table->table_id &&
+				    i < min_index) {
+					min_index = i;
+				}
+			}
+
+			/* Set depth to 0 for shared table (no inflight array) */
+			s->depth = 0;
+			s->numberio = cpu_to_le64((uint64_t)atomic_load(&table->shared_numberio));
+
+			/* Only the job with minimum index saves skiplist */
+			if (__td_index == min_index) {
+				/* Save skiplist entries after the inflight array (which is empty) */
+				ptr = (char *)&s->inflight[0];
+				start_ptr = ptr;
+
+				for (node = skiplist_first(table->skiplist); node; node = skiplist_next(table->skiplist, node)) {
+					struct io_piece *ipo = (struct io_piece *)node->data;
+					struct saved_io_piece *saved;
+					size_t name_len;
+
+					/*
+					 * Safety check: should not happen since we wait for all
+					 * write jobs to complete before saving state
+					 */
+					if (!ipo || !ipo->file_name)
+						continue;
+
+					saved = (struct saved_io_piece *)ptr;
+					name_len = strlen(ipo->file_name) + 1;
+
+					saved->offset = cpu_to_le64((uint64_t)ipo->offset);
+					saved->numberio = cpu_to_le64((uint64_t)ipo->numberio);
+					saved->len = cpu_to_le32((uint32_t)ipo->len);
+					saved->flags = cpu_to_le32((uint32_t)ipo->flags);
+					saved->file_name_hash = cpu_to_le64((uint64_t)ipo->file_name_hash);
+
+					ptr += sizeof(struct saved_io_piece);
+					memcpy(ptr, ipo->file_name, name_len);
+					ptr += name_len;
+
+					skiplist_count++;
+				}
+
+				s->skiplist_count = cpu_to_le32(skiplist_count);
+				s->skiplist_data_size = cpu_to_le32((uint32_t)(ptr - start_ptr));
+			} else {
+				/* Not the first job, don't save skiplist */
+				s->skiplist_count = 0;
+				s->skiplist_data_size = 0;
+			}
+		} else {
+			/* Non-shared table: save inflight array */
+			for (int i = 0; i < td->o.iodepth; i++)
+				s->inflight[i].numberio = cpu_to_le64(atomic_load_acquire(&td->inflight_numberio[i]));
+
+			s->depth = cpu_to_le32((uint32_t) td->o.iodepth);
+			s->skiplist_count = 0;
+			s->skiplist_data_size = 0;
+			s->numberio = cpu_to_le64((uint64_t) atomic_load_acquire(&td->inflight_issued));
+		}
+
 		s->index = cpu_to_le64((uint64_t) __td_index);
 		if (td->offset_state.use64) {
 			s->rand.state64.s[0] = cpu_to_le64(td->offset_state.state64.s1);
@@ -1810,6 +1928,8 @@ void verify_assign_state(struct thread_data *td, void *p)
 
 	s->depth = le32_to_cpu(s->depth);
 	s->numberio = le64_to_cpu(s->numberio);
+	s->skiplist_count = le32_to_cpu(s->skiplist_count);
+	s->skiplist_data_size = le32_to_cpu(s->skiplist_data_size);
 	s->rand.use64 = le64_to_cpu(s->rand.use64);
 
 	if (s->rand.use64) {
@@ -1826,6 +1946,75 @@ void verify_assign_state(struct thread_data *td, void *p)
 	}
 
 	td->vstate = p;
+}
+
+/*
+ * Load saved io_pieces from verify state into shared_verify_table skiplist.
+ * Called after shared_verify_table is initialized.
+ */
+void verify_load_state_skiplist(struct thread_data *td)
+{
+	struct thread_io_list *s = td->vstate;
+	struct shared_verify_table *table = td->shared_verify_table;
+	char *ptr;
+	int i, loaded = 0;
+
+	if (!s || !table || s->skiplist_count == 0)
+		return;
+
+	ptr = (char *)&s->inflight[s->depth];
+
+	for (i = 0; i < s->skiplist_count; i++) {
+		struct saved_io_piece *saved = (struct saved_io_piece *)ptr;
+		struct io_piece *ipo;
+		char *file_name;
+		size_t name_len;
+		uint64_t offset, numberio, file_name_hash;
+		uint32_t len, flags;
+
+		/* Convert endianness to local variables */
+		offset = le64_to_cpu(saved->offset);
+		numberio = le64_to_cpu(saved->numberio);
+		len = le32_to_cpu(saved->len);
+		flags = le32_to_cpu(saved->flags);
+		file_name_hash = le64_to_cpu(saved->file_name_hash);
+
+		/* Get filename */
+		ptr += sizeof(struct saved_io_piece);
+		file_name = ptr;
+		name_len = strlen(file_name) + 1;
+		ptr += name_len;
+
+		/* Create io_piece */
+		ipo = calloc(1, sizeof(struct io_piece));
+		if (!ipo)
+			break;
+
+		init_ipo(ipo);
+		ipo->offset = offset;
+		ipo->numberio = numberio;
+		ipo->len = len;
+		ipo->flags = flags & ~IP_F_IN_FLIGHT;  /* Not in-flight anymore */
+		ipo->file_name_hash = file_name_hash;
+		ipo->file_name = smalloc_strdup(file_name);
+
+		if (!ipo->file_name) {
+			free(ipo);
+			break;
+		}
+
+		/* Insert into skiplist */
+		if (skiplist_insert(table->skiplist, ipo->offset, ipo->len, ipo) == 0) {
+			ipo->flags |= IP_F_ONRB;
+			atomic_fetch_add(&table->total_entries, 1);
+			loaded++;
+		} else {
+			sfree(ipo->file_name);
+			free(ipo);
+		}
+	}
+
+	log_info("fio: loaded %d io_pieces into skiplist from verify state\n", loaded);
 }
 
 int verify_state_hdr(struct verify_state_hdr *hdr, struct thread_io_list *s)
@@ -1858,8 +2047,17 @@ int verify_load_state(struct thread_data *td, const char *prefix)
 		return 0;
 
 	fd = open_state_file(td->o.name, prefix, td->thread_number - 1, 0);
-	if (fd == -1)
+	if (fd == -1) {
+		/*
+		 * For shared_verify_table, missing state file is expected
+		 * for non-first jobs (they will share the loaded skiplist).
+		 * The error message from open_state_file is already printed,
+		 * but this is harmless - just return success.
+		 */
+		if (td->o.verify_table_id > 0)
+			return 0;
 		return 1;
+	}
 
 	ret = read(fd, &hdr, sizeof(hdr));
 	if (ret != sizeof(hdr)) {
@@ -1935,4 +2133,121 @@ int verify_state_should_stop(struct thread_data *td, uint64_t numberio)
 	}
 
 	return 0;
+}
+
+static struct fio_file *resolve_shared_verify_file(struct thread_data *td,
+						   const struct io_piece *ipo)
+{
+	struct fio_file *f;
+	unsigned int i;
+
+	if (!ipo->file_name)
+		return ipo->file;
+
+	for_each_file(td, f, i) {
+		if (f->file_name_hash == ipo->file_name_hash &&
+		    !strcmp(f->file_name, ipo->file_name))
+			return f;
+	}
+
+	return NULL;
+}
+
+int get_next_verify_shared(struct thread_data *td, struct io_u *io_u)
+{
+	struct shared_verify_table *table = td->shared_verify_table;
+	struct io_piece *ipo = NULL;
+	struct skiplist_node *node;
+
+	if (!table)
+		return 1;
+
+	/*
+	 * this io_u is from a requeue, we already filled the offsets
+	 */
+	if (io_u->file)
+		return 0;
+
+	/* Use skiplist to get first entry */
+	node = skiplist_first(table->skiplist);
+	if (!node)
+		goto out;
+
+	ipo = (struct io_piece *)node->data;
+	if (!ipo)
+		goto out;
+
+	/*
+	 * Ensure that the associated IO has completed
+	 */
+	if (atomic_load_acquire(&ipo->flags) & IP_F_IN_FLIGHT) {
+		ipo = NULL;
+		goto out;
+	}
+
+	/* Delete from skiplist (lock-free) */
+	if (skiplist_delete_node(table->skiplist, node) == 0) {
+		atomic_fetch_sub(&table->total_entries, 1);
+		assert(ipo->flags & IP_F_ONRB);
+		ipo->flags &= ~IP_F_ONRB;
+	} else {
+		/* Another thread deleted it */
+		ipo = NULL;
+	}
+
+out:
+
+	if (ipo) {
+		struct fio_file *resolved_file;
+
+		resolved_file = resolve_shared_verify_file(td, ipo);
+		if (!resolved_file) {
+			const char *name = ipo->file_name ? : "unknown";
+
+			log_err("fio: job %s cannot resolve shared verify file '%s'\n",
+				td->o.name, name);
+			remove_trim_entry(td, ipo);
+			free_io_piece(ipo);
+			return 1;
+		}
+
+		io_u->offset = ipo->offset;
+		io_u->verify_offset = ipo->offset;
+		io_u->buflen = ipo->len;
+		io_u->numberio = ipo->numberio;
+		io_u->file = resolved_file;
+		io_u_set(td, io_u, IO_U_F_VER_LIST);
+
+		if (ipo->flags & IP_F_TRIMMED)
+			io_u_set(td, io_u, IO_U_F_TRIMMED);
+
+		if (!fio_file_open(io_u->file)) {
+			int r = td_io_open_file(td, io_u->file);
+
+			if (r) {
+				dprint(FD_VERIFY, "failed file %s open\n",
+						io_u->file->file_name);
+				return 1;
+			}
+		}
+
+		get_file(io_u->file);
+		assert(fio_file_open(io_u->file));
+		io_u->ddir = DDIR_READ;
+		io_u->xfer_buf = io_u->buf;
+		io_u->xfer_buflen = io_u->buflen;
+
+		free_io_piece(ipo);
+		dprint(FD_VERIFY, "get_next_verify_shared: ret io_u %p\n", io_u);
+
+		if (!td->o.verify_pattern_bytes) {
+			io_u->rand_seed = __rand(&td->verify_state);
+			if (sizeof(int) != sizeof(long *))
+				io_u->rand_seed *= __rand(&td->verify_state);
+		}
+		return 0;
+	}
+
+	dprint(FD_VERIFY, "get_next_verify_shared: empty\n");
+	return 1;
 }

--- a/verify.c
+++ b/verify.c
@@ -892,23 +892,28 @@ static int mem_is_zero_slow(const void *data, size_t length, size_t *offset)
 	return !length;
 }
 
-static int verify_trimmed_io_u(struct thread_data *td, struct io_u *io_u)
+static int verify_zero(struct io_u *io_u)
 {
 	size_t offset;
-
-	if (!td->o.trim_zero)
-		return 0;
 
 	if (mem_is_zero(io_u->buf, io_u->buflen))
 		return 0;
 
 	mem_is_zero_slow(io_u->buf, io_u->buflen, &offset);
 
-	log_err("trim: verify failed at file %s offset %llu, length %llu"
+	log_err("verify failed for zeroed data at file %s offset %llu, length %llu"
 		", block offset %lu\n",
 			io_u->file->file_name, io_u->verify_offset, io_u->buflen,
 			(unsigned long) offset);
 	return EILSEQ;
+}
+
+static int verify_trimmed_io_u(struct thread_data *td, struct io_u *io_u)
+{
+	if (!td->o.trim_zero)
+		return 0;
+
+	return verify_zero(io_u);
 }
 
 static int verify_header(struct io_u *io_u, struct thread_data *td,
@@ -1011,6 +1016,9 @@ int verify_io_u(struct thread_data *td, struct io_u **io_u_ptr)
 
 	if (io_u->flags & IO_U_F_TRIMMED) {
 		ret = verify_trimmed_io_u(td, io_u);
+		goto done;
+	} else if (io_u->flags & IO_U_F_ZEROED) {
+		ret = verify_zero(io_u);
 		goto done;
 	}
 
@@ -2218,8 +2226,21 @@ out:
 		io_u->file = resolved_file;
 		io_u_set(td, io_u, IO_U_F_VER_LIST);
 
+		/*
+		 * Clear data pattern related flags since @io_u might have been initialized
+		 * in the ioengine for a specific usages, but with shared verify table, all
+		 * the @io_u instances should be initialized as per @ipo, not ioengine-specific
+		 * configurations.
+		 */
+		io_u_clear(td, io_u, IO_U_F_TRIMMED | IO_U_F_ZEROED |
+				IO_U_F_ERRORED);
+
 		if (ipo->flags & IP_F_TRIMMED)
 			io_u_set(td, io_u, IO_U_F_TRIMMED);
+		else if (ipo->flags & IP_F_ZEROED)
+			io_u_set(td, io_u, IO_U_F_ZEROED);
+		else if (ipo->flags & IP_F_ERRORED)
+			io_u_set(td, io_u, IO_U_F_ERRORED);
 
 		if (!fio_file_open(io_u->file)) {
 			int r = td_io_open_file(td, io_u->file);


### PR DESCRIPTION
See the first commit description for the background and details.

The following jobfile is an example for the multiple write job based data verification.
16 jobs are going to write[zeroes, uncor, trim] to the same area [0, 1M).

```
[global]
ioengine=io_uring_cmd
cmd_type=nvme
filename=/dev/ng0n1
size=1M
thread=1

norandommap

ignore_error=0x2281  # to mask uncorred (errored) offsets
iodepth=64

group_reporting=1

bs=4k
numjobs=4

verify=crc32
verify_header_seed=0
do_verify=1

verify_table_id=1

[trim]
rw=randtrim

[uncor]
rw=randwrite
write_mode=uncor

[write]
rw=randwrite

[zeroes]
rw=randwrite
write_mode=zeroes
nonvectored=0  ; to mask BAD ADDRESS error in kernel
                                       
```

After run this jobfile, we can see the READ(verify) phase were issued only just for 1MB(256 commands):

```
     issued rwts: total=256,3072,1024,0 short=0,0,0,0 dropped=0,0,0,0
```