### PR TITLE
backend: fix OOB access in usec_for_io() with DDIR_SYNC

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1194,7 +1194,7 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 				td->rate_io_issue_bytes[__ddir] += blen;
 			}
 
-			if (should_check_rate(td)) {
+			if (ddir_rw(__ddir) && should_check_rate(td)) {
 				td->rate_next_io_time[__ddir] = usec_for_io(td, __ddir);
 				fio_gettime(&comp_time, NULL);
 			}
@@ -1202,7 +1202,7 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 		} else {
 			ret = io_u_submit(td, io_u);
 
-			if (should_check_rate(td))
+			if (ddir_rw(ddir) && should_check_rate(td))
 				td->rate_next_io_time[ddir] = usec_for_io(td, ddir);
 
 			if (io_queue_event(td, io_u, &ret, ddir, &bytes_issued, 0, &comp_time))


### PR DESCRIPTION
When rate limiting is enabled, do_io() calls usec_for_io() to calculate
delays.

If the current operation is a sync (DDIR_SYNC), using it as an index into
arrays sized DDIR_RWDIR_CNT (such as td->rate_bps) results in an
out-of-bounds access.

Guard the rate limiting check in do_io() with ddir_rw() to ensure it only
applies to READ, WRITE, and TRIM operations.

This fixes a UBSAN out-of-bounds error reported in usec_for_io().

Signed-off-by: Florian Mayer <fmayer@google.com>