### PR TITLE
fix musl builds

### DIFF
--- a/oslib/linux-blkzoned.c
+++ b/oslib/linux-blkzoned.c
@@ -25,6 +25,7 @@
 #ifndef BLKFINISHZONE
 #define BLKFINISHZONE _IOW(0x12, 136, struct blk_zone_range)
 #endif
+#include <linux/falloc.h>
 
 /*
  * If the uapi headers installed on the system lacks zone capacity support,


### PR DESCRIPTION
This commit fixes the build on musl which fails with the following error:
```
oslib/linux-blkzoned.c: In function 'blkzoned_move_zone_wp':
oslib/linux-blkzoned.c:389:37: error: 'FALLOC_FL_ZERO_RANGE' undeclared (first use in this function)
  389 |                 ret = fallocate(fd, FALLOC_FL_ZERO_RANGE, z->wp, length);
      |                                     ^~~~~~~~~~~~~~~~~~~~
oslib/linux-blkzoned.c:389:37: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:501: oslib/linux-blkzoned.o] Error 1
make: *** Waiting for unfinished jobs....
```