### PR TITLE
io_uring: don't segfault if pi_chk isn't specified

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -1593,11 +1593,11 @@ static int fio_ioring_io_u_init(struct thread_data *td, struct io_u *io_u)
 		pi_attr->len = o->md_per_io_size;
 		pi_attr->app_tag = o->apptag;
 		pi_attr->flags = 0;
-		if (strstr(o->pi_chk, "GUARD") != NULL)
+		if (o->prchk & NVME_IO_PRINFO_PRCHK_GUARD)
 			pi_attr->flags |= IO_INTEGRITY_CHK_GUARD;
-		if (strstr(o->pi_chk, "REFTAG") != NULL)
+		if (o->prchk & NVME_IO_PRINFO_PRCHK_REF)
 			pi_attr->flags |= IO_INTEGRITY_CHK_REFTAG;
-		if (strstr(o->pi_chk, "APPTAG") != NULL)
+		if (o->prchk & NVME_IO_PRINFO_PRCHK_APP)
 			pi_attr->flags |= IO_INTEGRITY_CHK_APPTAG;
 	}
 


### PR DESCRIPTION
If `fio` is run with `md_per_io_size` but no `pi_chk` argument, `fio_ioring_io_u_init()` passes `NULL` to `strstr()`, which segfaults. Use the `struct ioring_options` `prchk` flags instead, which have already been parsed from `pi_chk` in `parse_prchk_flags()`.