### PR TITLE
fio: extend num_range to support multi-range I/O for general io_u

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2717,12 +2717,11 @@ with the caveat that when used on the command line, they must come after the
 
 .. option:: num_range=int : [io_uring_cmd]
 
-	For trim command this will be the number of ranges to trim per I/O
-	request. The number of logical blocks per range is determined by the
+	For some commands this will be the number of ranges per I/O request.
+	The number of logical blocks per range is determined by the
 	:option:`bs` option which should be a multiple of logical block size.
-	This cannot be used with read or write. Note that setting this
-	option > 1, :option:`log_offset` will not be able to log all the
-	offsets. Default: 1.
+	Note that setting this option > 1, :option:`log_offset` will not be
+	able to log all the offsets. Default: 1.
 
 .. option:: cpuload=int : [cpuio]
 

--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -1582,6 +1582,10 @@ static int fio_ioring_io_u_init(struct thread_data *td, struct io_u *io_u)
 	p += o->md_per_io_size * io_u->index;
 	io_u->mmap_data = p;
 
+	if ((ld->is_uring_cmd_eng && o->cmd_type == FIO_URING_CMD_NVME) &&
+			td_trim(td) && td->o.num_range > 1)
+		io_u_set(td, io_u, IO_U_F_MULTI_RANGE);
+
 	if (ld->pi_attr) {
 		struct io_uring_attr_pi *pi_attr;
 

--- a/fio.h
+++ b/fio.h
@@ -637,9 +637,9 @@ static inline void fio_ro_check(const struct thread_data *td, struct io_u *io_u)
 	 */
 }
 
-static inline bool multi_range_trim(struct thread_data *td, struct io_u *io_u)
+static inline bool multi_range_io_u(struct thread_data *td, struct io_u *io_u)
 {
-	if (io_u->ddir == DDIR_TRIM && td->o.num_range > 1)
+	if ((io_u->flags & IO_U_F_MULTI_RANGE) && td->o.num_range > 1)
 		return true;
 
 	return false;

--- a/io_u.c
+++ b/io_u.c
@@ -1062,7 +1062,7 @@ static int fill_io_u(struct thread_data *td, struct io_u *io_u)
 	else if (td->o.zone_mode == ZONE_MODE_ZBD)
 		setup_zbd_zone_mode(td, io_u);
 
-	if (multi_range_trim(td, io_u)) {
+	if (multi_range_io_u(td, io_u)) {
 		if (fill_multi_range_io_u(td, io_u))
 			return 1;
 	} else {
@@ -1105,11 +1105,11 @@ static int fill_io_u(struct thread_data *td, struct io_u *io_u)
 	/*
 	 * mark entry before potentially trimming io_u
 	 */
-	if (!multi_range_trim(td, io_u) && td_random(td) && file_randommap(td, io_u->file))
+	if (!multi_range_io_u(td, io_u) && td_random(td) && file_randommap(td, io_u->file))
 		io_u->buflen = mark_random_map(td, io_u, offset, io_u->buflen);
 
 out:
-	if (!multi_range_trim(td, io_u))
+	if (!multi_range_io_u(td, io_u))
 		dprint_io_u(io_u, "fill");
 	io_u->verify_offset = io_u->offset;
 	td->zone_bytes += io_u->buflen;
@@ -1926,7 +1926,7 @@ struct io_u *get_io_u(struct thread_data *td)
 
 	assert(fio_file_open(f));
 
-	if (ddir_rw(io_u->ddir) && !multi_range_trim(td, io_u)) {
+	if (ddir_rw(io_u->ddir) && !multi_range_io_u(td, io_u)) {
 		if (!io_u->buflen && !td_ioengine_flagged(td, FIO_NOIO)) {
 			dprint(FD_IO, "get_io_u: zero buflen on %p\n", io_u);
 			goto err_put;

--- a/io_u.h
+++ b/io_u.h
@@ -24,6 +24,7 @@ enum {
 	IO_U_F_PATTERN_DONE	= 1 << 8,
 	IO_U_F_DEVICE_ERROR	= 1 << 9,
 	IO_U_F_VER_IN_DEV	= 1 << 10, /* Verify data in device */
+	IO_U_F_MULTI_RANGE	= 1 << 11, /* Use multi range */
 };
 
 /*


### PR DESCRIPTION
Extend num_range to support multi-range I/O for general io_u

Previously, the `num_range` option was limited to trim commands only, restricting its use with read/write I/O patterns. This change generalizes the `num_range` functionality to support multi-range I/O across various I/O types, enabling more flexible and realistic I/O simulation.

The modification allows each io_u to issue multiple logical block ranges in a single submission, improving efficiency and enabling advanced workload modeling beyond trim operations.