### PR TITLE
write_hist_log: do not require ZLIB for non-server instances

### DIFF
--- a/init.c
+++ b/init.c
@@ -1769,7 +1769,7 @@ static int add_job(struct thread_data *td, const char *jobname, int job_add_num,
 		const char *suf;
 
 #ifndef CONFIG_ZLIB
-		if (td->client_type) {
+		if (is_backend) {
 			log_err("fio: --write_hist_log requires zlib in client/server mode\n");
 			goto err;
 		}


### PR DESCRIPTION
write_hist_log: do not require ZLIB for non-server instances

Since `td->client_type` is always non-zero (CLI is 1, GUI is 2), the check
`if (td->client_type)` in `init.c` always triggers, causing --write_hist_log
to be unusable when ZLIB is not configured for standalone runs.
By checking if the fio instance `is_backend`, ZLIB availability will be
checked for fio running as server in server/client mode, and the check
will be passed for fio running in standalone mode.

Fixes #1996

Signed-off-by: Alex Qiu <xqiu@google.com>