### PR TITLE
windows: fix a Y2038 bug by replacing `Int32x32To64` with multiplication

### DIFF
--- a/os/windows/posix.c
+++ b/os/windows/posix.c
@@ -297,7 +297,7 @@ void Time_tToSystemTime(time_t dosTime, SYSTEMTIME *systemTime)
 	LONGLONG jan1970;
 	SYSTEMTIME tempSystemTime;
 
-	jan1970 = Int32x32To64(dosTime, 10000000) + 116444736000000000;
+	jan1970 = (dosTime * 10000000LL) + 116444736000000000LL;
 	utcFT.dwLowDateTime = (DWORD)jan1970;
 	utcFT.dwHighDateTime = jan1970 >> 32;
 


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>