### PR TITLE
Add ZBD support for SMR drives to io_uring engine

### DIFF
--- a/engines/io_uring.c
+++ b/engines/io_uring.c
@@ -1883,6 +1883,47 @@ static int fio_ioring_cmd_get_file_size(struct thread_data *td,
 	return generic_get_file_size(td, f);
 }
 
+static int fio_ioring_get_zoned_model(struct thread_data *td,
+				      struct fio_file *f,
+				      enum zbd_zoned_model *model)
+{
+	return blkzoned_get_zoned_model(td, f, model);
+}
+
+static int fio_ioring_report_zones(struct thread_data *td,
+				   struct fio_file *f, uint64_t offset,
+				   struct zbd_zone *zbdz,
+				   unsigned int nr_zones)
+{
+	return blkzoned_report_zones(td, f, offset, zbdz, nr_zones);
+}
+
+static int fio_ioring_reset_wp(struct thread_data *td, struct fio_file *f,
+			       uint64_t offset, uint64_t length)
+{
+	return blkzoned_reset_wp(td, f, offset, length);
+}
+
+static int fio_ioring_get_max_open_zones(struct thread_data *td,
+					 struct fio_file *f,
+					 unsigned int *max_open_zones)
+{
+	return blkzoned_get_max_open_zones(td, f, max_open_zones);
+}
+
+static int fio_ioring_finish_zone(struct thread_data *td, struct fio_file *f,
+				  uint64_t offset, uint64_t length)
+{
+	return blkzoned_finish_zone(td, f, offset, length);
+}
+
+static int fio_ioring_move_zone_wp(struct thread_data *td, struct fio_file *f,
+				   struct zbd_zone *z, uint64_t length,
+				   const char *buf)
+{
+	return blkzoned_move_zone_wp(td, f, z, length, buf);
+}
+
 static int fio_ioring_cmd_get_zoned_model(struct thread_data *td,
 					  struct fio_file *f,
 					  enum zbd_zoned_model *model)
@@ -1954,6 +1995,12 @@ static struct ioengine_ops ioengine_uring = {
 	.open_file		= fio_ioring_open_file,
 	.close_file		= fio_ioring_close_file,
 	.get_file_size		= generic_get_file_size,
+	.get_zoned_model	= fio_ioring_get_zoned_model,
+	.report_zones		= fio_ioring_report_zones,
+	.reset_wp		= fio_ioring_reset_wp,
+	.get_max_open_zones	= fio_ioring_get_max_open_zones,
+	.finish_zone		= fio_ioring_finish_zone,
+	.move_zone_wp		= fio_ioring_move_zone_wp,
 	.options		= options,
 	.option_struct_size	= sizeof(struct ioring_options),
 };


### PR DESCRIPTION
Hi,

We've been working with zoned block devices (ZBD) and noticed that the io_uring engines don't support zonemode=zbd, which prevents leveraging io_uring's performance benefits for zone testing workloads in SMR (Shingled Magnetic Recording) drives. This finding came from our analysis, while testing the integration of io_uring into Dropbox storage stack. An [io_uring patch enabling ZBD support](https://github.com/axboe/liburing/pull/1524) is also submitted.

The attached patch adds ZBD hooks to io_uring engines. The implementation is straightforward, where it delegates to the existing blkzoned, maintaining consistency with other engines.

What this enables:
    - ZBD function implementations for zone management operations
    - Integration with existing blkzoned interfaces
    - Support for zone reporting, reset, finish, and write pointer operations in SMR/ZBD devices

I've tested this on SMR drives with the io_uring engine and it works well. 

Sample fio job:
```
[zbd-test]
ioengine=io_uring
direct=1
bs=128k
zonemode=zbd
filename=/dev/sdg
```

Thanks,
Vishal Jose Mannanal