### PR TITLE
stat: Avoid printing "issued rwts" when "verify_only" is supplied

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -3929,7 +3929,8 @@ Verification
 	for workloads that write data, and does not support workloads with the
 	:option:`time_based` option set. :option:`verify_write_sequence` and
 	:option:`verify_header_seed` will be disabled in this mode, unless they are
-	explicitly enabled.
+	explicitly enabled. The writes reported in the output when this option is
+	specified are phantom writes, since no writes are actually issued.
 
 .. option:: do_verify=bool
 

--- a/fio.1
+++ b/fio.1
@@ -3641,7 +3641,8 @@ times at a later date without overwriting it. This option makes sense only
 for workloads that write data, and does not support workloads with the
 \fBtime_based\fR option set. Options \fBverify_write_sequence\fR and
 \fBverify_header_seed\fR will be disabled in this mode, unless they are
-explicitly enabled.
+explicitly enabled. The writes reported in the output when this option is
+specified are phantom writes, since no writes are actually issued.
 .TP
 .BI do_verify \fR=\fPbool
 Run the verify phase after a write phase. Only valid if \fBverify\fR is


### PR DESCRIPTION
Avoid printing "issues rwts" when user has supplied "verify_only" option, since the IOs are not submitted.

Fixes: #1499