### PR TITLE
RBD Encryption Support

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2891,6 +2891,22 @@ with the caveat that when used on the command line, they must come after the
         Touching all objects affects ceph caches and likely impacts test results.
         Enabled by default.
 
+.. option:: rbd_encryption_format=str : [rbd]
+
+		Specifies the encryption format of the RBD image. Supported values are
+		``luks1`` and ``luks2``. If set, :option:`rbd_encryption_passphrase` must 
+		also be specified. Note that the image must have been previously formatted 
+		using :command:`rbd encryption format <image>`; the fio rbd engine will only 
+		attempt to load the encryption context, not format the image.
+		The RBD encryption feature is disabled by default.
+		Support for this feature requires librbd version 16.2 (Ceph Pacific) 
+		or later.
+
+.. option:: rbd_encryption_passphrase=str : [rbd]
+
+		The passphrase used to unlock the encrypted RBD image. Required if
+		:option:`rbd_encryption_format` is set.
+
 .. option:: pool=str :
 
    [rbd,rados]

--- a/configure
+++ b/configure
@@ -2012,6 +2012,28 @@ print_config "rbd_invalidate_cache" "$rbd_inval"
 fi
 
 ##########################################
+# check for rbd_encryption_load()
+if test "$rbd_encryption" != "yes" ; then
+  rbd_encryption="no"
+fi
+if test "$rbd" = "yes" ; then
+cat > $TMPC << EOF
+#include <rbd/librbd.h>
+
+int main(int argc, char **argv)
+{
+  rbd_image_t image;
+
+  return rbd_encryption_load(image, RBD_ENCRYPTION_FORMAT_LUKS1, 0, 0);
+}
+EOF
+if compile_prog "" "-lrbd -lrados" "rbd_encryption"; then
+    rbd_encryption="yes"
+fi
+  print_config "rbd_encryption_load" "$rbd_encryption"
+fi
+
+##########################################
 # Check whether we have setvbuf
 if test "$setvbuf" != "yes" ; then
   setvbuf="no"
@@ -3220,6 +3242,9 @@ if test "$rbd_poll" = "yes" ; then
 fi
 if test "$rbd_inval" = "yes" ; then
   output_sym "CONFIG_RBD_INVAL"
+fi
+if test "$rbd_encryption" = "yes" ; then
+  output_sym "CONFIG_RBD_ENCRYPTION"
 fi
 if test "$setvbuf" = "yes" ; then
   output_sym "CONFIG_SETVBUF"

--- a/fio.1
+++ b/fio.1
@@ -2637,6 +2637,20 @@ During initialization, touch (create if do not exist) all objects (files).
 Touching all objects affects ceph caches and likely impacts test results.
 Enabled by default.
 .TP
+.BI (rbd)rbd_encryption_format \fR=\fPstr
+Specifies the encryption format of the RBD image. Supported values are
+`luks1' and `luks2'. If set, \fBrbd_encryption_passphrase\fR must
+also be specified. Note that the image must have been previously formatted
+using `rbd encryption format <image>'; the fio rbd engine will only
+attempt to load the encryption context, not format the image.
+The RBD encryption feature is disabled by default.
+Support for this feature requires librbd version 16.2 (Ceph Pacific) 
+or later.
+.TP
+.BI (rbd)rbd_encryption_passphrase \fR=\fPstr
+The passphrase used to unlock the encrypted RBD image. Required if
+\fBrbd_encryption_format\fR is set.
+.TP
 .BI (http)http_host \fR=\fPstr
 Hostname to connect to.  HTTP port 80 is used automatically when the value 
 of the \fBhttps\fP parameter is \fBoff\fP, and HTTPS port 443 if it is \fBon\fP.


### PR DESCRIPTION
**Summary**
This PR adds support for testing Ceph `librbd` client-side encryption (AES-XTS) by allowing fio to load LUKS keys for an existing image with librbd. After the loading operation any IO to the rbd image will be encrypted/decrypted. 

See the Ceph documentation for this feature: https://docs.ceph.com/en/reef/rbd/rbd-encryption/

**Motivation**
`librbd` has supported encryption/decryption since Ceph Pacific (16.2.z). However, the fio rbd engine currently lacks the hooks to load encryption context. This prevents users from benchmarking the crypto overhead of this librbd feature. 

**Implementation Details**
* Adds `configure` configuration to detect if the linked `librbd` supports `rbd_encryption_load`.
* Adds two new job options:
    * `rbd_encryption_format`: (luks1, luks2)
    * `rbd_encryption_passphrase`: The key/passphrase to unlock the image.
* Uses `rbd_encryption_load()` during the connection phase to load encryption context. 

**Notes on Design**
* **No Auto-Formatting:** This patch does *not* use `rbd_encryption_format`. It is assumed the user has already provisioned and formatted the image using the Ceph CLI (`rbd encryption format ...`). This avoids accidental data destruction or re-formatting overhead during benchmark runtime.
    *  I could add Auto-Formatting by trying to load the encryption context and formatting if that fails, if you want me to. 
* **Backward Compatibility:** The feature is guarded by `CONFIG_RBD_ENCRYPTION`. If fio is built against an older Ceph version (pre-Pacific), the options are unavailable, and the engine behaves as before.

**Example Job File**
```ini
[encrypted-test]
ioengine=rbd
pool=bench_pool
rbdname=test_image
# New encryption options
rbd_encryption_format=luks2
rbd_encryption_passphrase=my_secret_passphrase
rw=randwrite
bs=4k
```

And please review the documentation I wrote. I am unsure if the phrasing and syntax I used is consistent with the rest of the documentation. 