### PR TITLE
Add option to specify job process comm

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -3744,6 +3744,11 @@ Threads, processes and job synchronization
 	(meaning no forward references). Second, if a job is being referenced as a
 	waitee, it must have a unique name (no duplicate waitees).
 
+.. option:: comm=str
+
+	Set the job process comm to the specified string. See man :manpage:`prctrl(2)`.
+	Note: This option is currently supported only on Linux.
+
 .. option:: nice=int
 
 	Run the job with the given nice value. See man :manpage:`nice(2)`.

--- a/backend.c
+++ b/backend.c
@@ -31,6 +31,11 @@
 #include <math.h>
 #include <pthread.h>
 
+#ifdef CONFIG_LINUX
+#include <linux/prctl.h>
+#include <sys/prctl.h>
+#endif
+
 #include "fio.h"
 #include "smalloc.h"
 #include "verify.h"
@@ -1757,6 +1762,10 @@ static void *thread_main(void *data)
 		td->pid = gettid();
 
 	fio_local_clock_init();
+
+#ifdef CONFIG_LINUX
+	prctl(PR_SET_NAME, o->comm);
+#endif
 
 	dprint(FD_PROCESS, "jobs pid=%d started\n", (int) td->pid);
 

--- a/cconv.c
+++ b/cconv.c
@@ -34,6 +34,7 @@ static void free_thread_options_to_cpu(struct thread_options *o)
 	free(o->opendir);
 	free(o->ioengine);
 	free(o->mmapfile);
+	free(o->comm);
 	free(o->read_iolog_file);
 	free(o->write_iolog_file);
 	free(o->merge_blktrace_file);
@@ -81,6 +82,7 @@ int convert_thread_options_to_cpu(struct thread_options *o,
 	string_to_cpu(&o->opendir, top->opendir);
 	string_to_cpu(&o->ioengine, top->ioengine);
 	string_to_cpu(&o->mmapfile, top->mmapfile);
+	string_to_cpu(&o->comm, top->comm);
 	string_to_cpu(&o->read_iolog_file, top->read_iolog_file);
 	string_to_cpu(&o->write_iolog_file, top->write_iolog_file);
 	string_to_cpu(&o->merge_blktrace_file, top->merge_blktrace_file);
@@ -396,6 +398,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 	string_to_net(top->opendir, o->opendir);
 	string_to_net(top->ioengine, o->ioengine);
 	string_to_net(top->mmapfile, o->mmapfile);
+	string_to_net(top->comm, o->comm);
 	string_to_net(top->read_iolog_file, o->read_iolog_file);
 	string_to_net(top->write_iolog_file, o->write_iolog_file);
 	string_to_net(top->merge_blktrace_file, o->merge_blktrace_file);

--- a/configure
+++ b/configure
@@ -3075,6 +3075,9 @@ if test "$bigendian" = "yes" ; then
 else
   output_sym "CONFIG_LITTLE_ENDIAN"
 fi
+if test "$targetos" = "Linux" ; then
+  output_sym "CONFIG_LINUX"
+fi
 if test "$zlib" = "yes" ; then
   output_sym "CONFIG_ZLIB"
 fi

--- a/fio.1
+++ b/fio.1
@@ -3454,6 +3454,10 @@ limitations. First, the waitee must be defined prior to the waiter job
 (meaning no forward references). Second, if a job is being referenced as a
 waitee, it must have a unique name (no duplicate waitees).
 .TP
+.BI comm \fR=\fPstr
+Set the job process comm to the specified string. See man \fBprctrl\fR\|(2).
+Note: This option is currently supported only on Linux.
+.TP
 .BI nice \fR=\fPint
 Run the job with the given nice value. See man \fBnice\fR\|(2).
 .\" ignore blank line here from HOWTO as it looks normal without it

--- a/options.c
+++ b/options.c
@@ -4034,6 +4034,17 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		.category = FIO_OPT_C_IO,
 		.group	= FIO_OPT_G_RWMIX,
 	},
+#ifdef CONFIG_LINUX
+	{
+		.name	= "comm",
+		.lname	= "Job process comm",
+		.type	= FIO_OPT_STR_STORE,
+		.off1	= offsetof(struct thread_options, comm),
+		.help	= "Process comm of this job",
+		.category = FIO_OPT_C_GENERAL,
+		.group	= FIO_OPT_G_DESC,
+	},
+#endif
 	{
 		.name	= "nice",
 		.lname	= "Nice",

--- a/server.h
+++ b/server.h
@@ -51,7 +51,7 @@ struct fio_net_cmd_reply {
 };
 
 enum {
-	FIO_SERVER_VER			= 116,
+	FIO_SERVER_VER			= 117,
 
 	FIO_SERVER_MAX_FRAGMENT_PDU	= 1024,
 	FIO_SERVER_MAX_CMD_MB		= 2048,

--- a/thread_options.h
+++ b/thread_options.h
@@ -252,6 +252,7 @@ struct thread_options {
 	unsigned int iolog;
 	unsigned int rwmixcycle;
 	unsigned int rwmix[DDIR_RWDIR_CNT];
+	char *comm;
 	unsigned int nice;
 	unsigned int ioprio;
 	unsigned int ioprio_class;
@@ -585,6 +586,7 @@ struct thread_options_pack {
 	uint32_t iolog;
 	uint32_t rwmixcycle;
 	uint32_t rwmix[DDIR_RWDIR_CNT];
+	uint8_t comm[FIO_TOP_STR_MAX];
 	uint32_t nice;
 	uint32_t ioprio;
 	uint32_t ioprio_class;


### PR DESCRIPTION
Some storage systems may exhibit different behaviors depending on the application running on top, identified by its process comm string. It can be useful for fio jobs to present themselves with a specified comm string to trigger those behaviors in a testing setup.