### PR TITLE
backend: set td->eo to NULL after freeing eo

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2601,9 +2601,7 @@ reap:
 							strerror(ret));
 			} else {
 				pid_t pid;
-				void *eo;
 				dprint(FD_PROCESS, "will fork\n");
-				eo = td->eo;
 				read_barrier();
 				pid = fork();
 				if (!pid) {
@@ -2616,7 +2614,6 @@ reap:
 					_exit(ret);
 				} else if (__td_index == fio_debug_jobno)
 					*fio_debug_jobp = pid;
-				free(eo);
 				free(fd);
 				fd = NULL;
 			}


### PR DESCRIPTION
After freeing the engine options (eo), set td->eo to NULL to prevent double-free issues. This follows the same pattern used for fd which is set to NULL after being freed.
