### PR TITLE
fio: sprandom: append newline to error message

### DIFF
--- a/init.c
+++ b/init.c
@@ -715,7 +715,7 @@ static int fixup_options(struct thread_data *td)
 				o->norandommap = 1;
 			}
 		} else {
-			log_err("fio: sprandom requires random write, random_generator=lfsr, norandommap=1");
+			log_err("fio: sprandom requires random write, random_generator=lfsr, norandommap=1\n");
 			ret |= 1;
 		}
 	}


### PR DESCRIPTION
Terminate the error message with a newline.

Fixes: #2047
Signed-off-by: Tomas Winkler <tomas.winkler@sandisk.com>

