### PR TITLE
fio: prevent OOM by not allocating buffer for TRIM range

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1467,7 +1467,10 @@ int init_io_u_buffers(struct thread_data *td)
 	char *p;
 
 	max_units = td->o.iodepth;
-	max_bs = td_max_bs(td);
+	if (td->trim_verify && td->o.trim_zero)
+		max_bs = td_max_bs(td);
+	else
+		max_bs = td_max_rw_bs(td);
 	min_write = td->o.min_bs[DDIR_WRITE];
 	td->orig_buffer_size = (unsigned long long) max_bs
 					* (unsigned long long) max_units;

--- a/fio.h
+++ b/fio.h
@@ -861,6 +861,14 @@ static inline bool should_check_rate(struct thread_data *td)
 	return (td->flags & TD_F_CHECK_RATE) != 0;
 }
 
+/*
+ * This function considers only read and write block sizes.
+ */
+static inline unsigned long long td_max_rw_bs(struct thread_data *td)
+{
+	return max(td->o.max_bs[DDIR_READ], td->o.max_bs[DDIR_WRITE]);
+}
+
 static inline unsigned long long td_max_bs(struct thread_data *td)
 {
 	unsigned long long max_bs;


### PR DESCRIPTION
Large TRIM ranges combined with high iodepth can cause memory usage to spike and trigger Out Of Memory (OOM) errors. Since TRIM is a metadata-only operation, it does not require a data payload buffer. This patch adds a function to calculate the buffer size without DDIR_TRIM, preventing unnecessary memory allocation.

Fixes: Issue #2056 https://github.com/axboe/fio/issues/2056
