### PR TITLE
options: add support more POSIX errnos

### DIFF
--- a/options.c
+++ b/options.c
@@ -525,12 +525,40 @@ static int str2error(char *str)
 			    "EXDEV", "ENODEV", "ENOTDIR", "EISDIR",
 			    "EINVAL", "ENFILE", "EMFILE", "ENOTTY",
 			    "ETXTBSY","EFBIG", "ENOSPC", "ESPIPE",
-			    "EROFS","EMLINK", "EPIPE", "EDOM", "ERANGE" };
+			    "EROFS","EMLINK", "EPIPE", "EDOM", "ERANGE",
+			    "EDEADLK", "ENAMETOOLONG", "ENOLCK", "ENOSYS", "ENOTEMPTY",
+			    "ELOOP", "EWOULDBLOCK", "ENOMSG", "EIDRM", "ECHRNG",
+			    "EL2NSYNC", "EL3HLT", "EL3RST", "ELNRNG", "EUNATCH",
+			    "ENOCSI", "EL2HLT", "EBADE", "EBADR", "EXFULL",
+			    "ENOANO", "EBADRQC", "EBADSLT", "EDEADLOCK", "EBFONT",
+			    "ENOSTR", "ENODATA", "ETIME", "ENOSR", "ENONET",
+			    "ENOPKG", "EREMOTE", "ENOLINK", "EADV", "ESRMNT",
+			    "ECOMM", "EPROTO", "EMULTIHOP", "EDOTDOT", "EBADMSG",
+			    "EOVERFLOW", "ENOTUNIQ", "EBADFD", "EREMCHG", "ELIBACC",
+			    "ELIBBAD", "ELIBSCN", "ELIBMAX", "ELIBEXEC", "EILSEQ",
+			    "ERESTART", "ESTRPIPE", "EUSERS", "ENOTSOCK", "EDESTADDRREQ",
+			    "EMSGSIZE", "EPROTOTYPE", "ENOPROTOOPT", "EPROTONOSUPPORT", "ESOCKTNOSUPPORT",
+			    "EOPNOTSUPP", "EPFNOSUPPORT", "EAFNOSUPPORT", "EADDRINUSE", "EADDRNOTAVAIL",
+			    "ENETDOWN", "ENETUNREACH", "ENETRESET", "ECONNABORTED", "ECONNRESET",
+			    "ENOBUFS", "EISCONN", "ENOTCONN", "ESHUTDOWN", "ETOOMANYREFS",
+			    "ETIMEDOUT", "ECONNREFUSED", "EHOSTDOWN", "EHOSTUNREACH", "EALREADY",
+			    "EINPROGRESS", "ESTALE", "EUCLEAN", "ENOTNAM", "ENAVAIL",
+			    "EISNAM", "EREMOTEIO", "EDQUOT", "ENOMEDIUM", "EMEDIUMTYPE",
+			    "ECANCELED", "ENOKEY", "EKEYEXPIRED", "EKEYREVOKED", "EKEYREJECTED",
+			    "EOWNERDEAD", "ENOTRECOVERABLE", "ERFKILL", "EHWPOISON" };
 	int i = 0, num = sizeof(err) / sizeof(char *);
+	int retval;
 
 	while (i < num) {
-		if (!strcmp(err[i], str))
-			return i + 1;
+		if (!strcmp(err[i], str)) {
+			retval = i + 1;
+			/* Handle errno aliases that should map to actual errno values */
+			if (!strcmp(str, "EWOULDBLOCK"))
+				retval = EAGAIN;
+			else if (!strcmp(str, "EDEADLOCK"))
+				retval = EDEADLK;
+			return retval;
+		}
 		i++;
 	}
 	return 0;


### PR DESCRIPTION
Added more error numbers(errno) after ERANGE to support various errno string to options like `--ignore_error=ETIMEDOUT`.  unvme-cli libunvmed ioengine returns ETIMEDOUT if a command is timed out.  To mask this situation with `--ignore_error=` option, errno after ERANGE should be supported in `str2errr()`.

Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>

Reminders:

1. If you modify struct thread_options, also make corresponding changes in
   cconv.c and bump FIO_SERVER_VER in server.h
2. If you change the ioengine interface (hooks, flags, etc), remember to bump
   FIO_IOOPS_VERSION in ioengines.h.
