### PR TITLE
backend: guard prctl(PR_SET_NAME) against NULL thread name

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1823,7 +1823,8 @@ static void *thread_main(void *data)
 	fio_local_clock_init();
 
 #ifdef CONFIG_LINUX
-	prctl(PR_SET_NAME, o->comm);
+	if (o->comm)
+		prctl(PR_SET_NAME, o->comm);
 #endif
 
 	dprint(FD_PROCESS, "jobs pid=%d started\n", (int) td->pid);


### PR DESCRIPTION
o->comm may be NULL if job initialization fails or the job
structure is only partially initialized before thread creation.

Calling prctl(PR_SET_NAME, NULL) may lead to a NULL pointer
dereference inside strncpy().

Add a NULL check before calling prctl() to prevent the crash.

This issue was originally reported in #2072.