### PR TITLE
Fix stat_sem/rusage_sem deadlock during stats collection

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2095,11 +2095,10 @@ static void *thread_main(void *data)
 		clear_state = true;
 
 		/*
-		 * Make sure we've successfully updated the rusage stats
-		 * before waiting on the stat mutex. Otherwise we could have
-		 * the stat thread holding stat mutex and waiting for
-		 * the rusage_sem, which would never get upped because
-		 * this thread is waiting for the stat mutex.
+		 * Service any pending rusage request, then acquire stat_sem to update
+		 * runtime counters. This trylock loop will primarily guard against
+		 * contention from concurrent stat calls or other slow operations under
+		 * stat_sem.
 		 */
 		deadlock_loop_cnt = 0;
 		do {

--- a/stat.c
+++ b/stat.c
@@ -2821,16 +2821,35 @@ int __show_running_run_stats(void)
 	unsigned long long *rt;
 	struct timespec ts;
 
-	fio_sem_down(stat_sem);
-
 	rt = malloc(thread_number * sizeof(unsigned long long));
 	fio_gettime(&ts, NULL);
 
+	/*
+	 * Collect rusage from workers outside stat_sem to prevent deadlock caused
+	 * by semaphore contention between the stat thread and the worker threads.
+	 */
 	for_each_td(td) {
 		if (td->runstate >= TD_EXITED)
 			continue;
 
-		td->update_rusage = 1;
+		if (td->rusage_sem) {
+			td->update_rusage = 1;
+			/* Prevent deadlock if worker exits between first check and sem_down */
+			if (td->runstate >= TD_EXITED) {
+				td->update_rusage = 0;
+				continue;
+			}
+			fio_sem_down(td->rusage_sem);
+		}
+		td->update_rusage = 0;
+	} end_for_each();
+
+	fio_sem_down(stat_sem);
+
+	for_each_td(td) {
+		if (td->runstate >= TD_EXITED)
+			continue;
+	
 		for_each_rw_ddir(ddir) {
 			td->ts.io_bytes[ddir] = td->io_bytes[ddir];
 		}
@@ -2843,16 +2862,6 @@ int __show_running_run_stats(void)
 			td->ts.runtime[DDIR_WRITE] += rt[__td_index];
 		if (td_trim(td) && td->ts.io_bytes[DDIR_TRIM])
 			td->ts.runtime[DDIR_TRIM] += rt[__td_index];
-	} end_for_each();
-
-	for_each_td(td) {
-		if (td->runstate >= TD_EXITED)
-			continue;
-		if (td->rusage_sem) {
-			td->update_rusage = 1;
-			fio_sem_down(td->rusage_sem);
-		}
-		td->update_rusage = 0;
 	} end_for_each();
 
 	__show_run_stats();


### PR DESCRIPTION
## Summary

- Fixes a family of ABBA deadlocks between `stat_sem` and `rusage_sem` in `stat.c`/`backend.c`
- Adds targeted regression tests (`t/stat_sem_race.py`) that will reliably reproduce the deadlocks on the current release

Since race conditions are generally non-obvious, I’m going to go into a bit too much detail regarding what is happening and how it has been fixed.

## The Deadlocks
fio uses two semaphores during statistics collection:

- `stat_sem` (global): ensures mutual exclusion over `td->ts.runtime[]` updates. Both the stat thread and worker threads perform non-atomic read-modify-write sequences on these counters and the semaphore prevents reading intermediate state. `td->ts.io_bytes[]` is also copied under the lock to maintain a consistent snapshot alongside runtime for display.

- `rusage_sem` (per-thread): coordinates resource-usage collection between the stat thread and workers. The stat thread sets `td->update_rusage` and blocks on the semaphore to wait for the result; the worker calls `update_rusage_stat()` (since `getrusage()` must be sampled from within the owning thread) and posts the semaphore to signal that the data is ready.

In the original code, `__show_running_run_stats()` acquires `stat_sem` _before_ iteratively getting resource usage updates from the workers. For each worker it uses `rusage_sem` as a mechanism for the worker to signal that it has finished its update. The deadlock can then manifest on two different paths.

### Verify Path
This only happens when the job is configured to verify IO operations. If the stat thread reaches a worker that has just finished or is in its verify phase, but before it has updated runtime counters, we have the following sequence of events:

1. Stat thread holds `stat_sem`, sets `update_rusage = 1` for worker N, blocks on `fio_sem_down(rusage_sem)`.

2. Worker N then finishes `do_verify() `and calls `fio_sem_down(stat_sem)`. The threads are now deadlocked; the worker will never raise `rusage_sem` to unblock the stat thread.

### IO Path
As noted in the comment in `backend.c`, the IO path uses a trylock loop that calls `check_update_rusage()` on each iteration, which generally allows workers to service the pending resource usage request while contending for `stat_sem`. It’s sort of a quick semaphore swap between the stats thread and the worker thread. However, if there are multiple workers, the stats thread will service them sequentially and thus may not be waiting on this worker. This servicing happens while the stats thread is still holding `stat_sem`. If the other worker takes a long time or there is a large queue of workers it becomes possible for this worker to exceed the 5 second timeout and exit with `EDEADLK`.

### Bonus Deadlock
I didn’t actually try to write a test to force this one because it may be more theoretical than practical. The stats thread checks if the worker has exited, signals that it wants resource usage data, then waits for the usage data. But if the worker reached `TD_EXITED` after the stats thread checked `td->runstate` and exited before the stats thread set `td->update_rusage`, the stats thread could end up waiting for an update from a worker that isn’t running anymore.

## Why These Rarely Manifest
Several factors make these deadlocks difficult to hit during a typical run:

1. Stats requests are infrequent, generally requested on the order of seconds.
2. Workers only acquire `stat_sem` between IO/verify phases or between loop iterations. In a typical long-running job with typical working set sizes, the worker is only vulnerable for a tiny portion of time.
3. Even if we do run into resource contention, the trylock loop can typically handle it.
4. Low thread counts reduce collision probability. 

So during a given run there’s typically only a small number of chances for a very improbable alignment. And when it does happen the current mitigation can typically handle it.

## The Fix
`__show_running_run_stats()` now collects all thread resource usage data before acquiring `stat_sem`, eliminating any contention on the worker threads. I left the trylock loop and `check_update_rusage()` calls as an additional layer of safety but they are no longer the primary deadlock-avoidance mechanism.

## Test Design
`t/stat_sem_race.py` runs two tests, designed to greatly increase the probability of hitting each of the two primary deadlocks. Note that it's still a matter of probability, not a deterministic outcome. The tests work well on my machine but they're really sensitive to the test host's performance.

- `StatSemRaceTestVerifyPath`: Maximizes phase-transition frequency. Uses verify=sha512, numjobs=8, loops=100, size=4M, bs=8k so workers transition between writing and verifying hundreds of times per second. A helper thread sends `SIGUSR1` every 1ms, making the likelihood of the stat thread and a worker thread aligning much more likely. If there is no deadlock the test will complete the job fairly quickly. If there is a deadlock it hits a 30-second timeout, we kill the process and the test fails.

- `StatSemRaceTestIOPath`: Creates conditions where the trylock loop cannot service rusage requests fast enough. The primary way this is done is by setting thinktime=8000000 (8s) and numjobs=8, along with startdelay=0:6 to stagger workers. Again, a helper thread periodically sends `SIGUSR1` to create stats thread pressure, though at a much lower rate than the first test since the window is not as small here. Here we check for failure primarily based on the exit code.

Both tests check for the "stuck grabbing stat_sem" message on stderr. For the verify path test this is emitted as a secondary failure, the thread experiencing the primary ABBA deadlock fails silently. Before and after the run a `cleanup_stale_shm()` can be run to clean up orphaned SysV shared memory segments left by deadlocked/killed fio processes.
