### PR TITLE
iolog: free io_piece log on thread cleanup

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2209,6 +2209,7 @@ err:
 		verify_async_exit(td);
 
 	close_and_free_files(td);
+	prune_io_piece_log(td);
 	cleanup_io_u(td);
 	close_ioengine(td);
 	cgroup_shutdown(td, cgroup_mnt);


### PR DESCRIPTION
prune_io_piece_log() is called only at the start of each loop iteration, so io_piece entries accumulated during the final do_io() run are never explicitly freed.

When fio runs as a process this goes unnoticed because the OS reclaims the heap on exit. When fio is embedded as a pthread, which is a use-case of unvme-cli, the parent process keeps running, so those allocations become a genuine memory leak proportional to the number of write IOs logged for verify.