### PR TITLE
record the eio offsets in verify state file, and do not verify them

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1222,6 +1222,9 @@ static void free_file_completion_logging(struct thread_data *td)
 		if (!f->last_write_comp)
 			break;
 		sfree(f->last_write_comp);
+		if (!f->last_write_fail_comp)
+			break;
+		sfree(f->last_write_fail_comp);
 	}
 }
 
@@ -1237,6 +1240,9 @@ static int init_file_completion_logging(struct thread_data *td,
 	for_each_file(td, f, i) {
 		f->last_write_comp = scalloc(depth, sizeof(uint64_t));
 		if (!f->last_write_comp)
+			goto cleanup;
+		f->last_write_fail_comp = scalloc(depth, sizeof(uint64_t));
+		if (!f->last_write_fail_comp)
 			goto cleanup;
 	}
 

--- a/file.h
+++ b/file.h
@@ -128,6 +128,8 @@ struct fio_file {
 	 */
 	uint64_t *last_write_comp;
 	unsigned int last_write_idx;
+	uint64_t *last_write_fail_comp;
+	unsigned int last_write_fail_idx;
 
 	/*
 	 * For use by the io engine to store offset

--- a/io_u.c
+++ b/io_u.c
@@ -2078,6 +2078,21 @@ static void file_log_write_comp(const struct thread_data *td, struct fio_file *f
 		f->last_write_idx = 0;
 }
 
+static void file_log_write_fail_comp(const struct thread_data *td, struct fio_file *f,
+				uint64_t offset)
+{
+	int idx;
+
+	if (!f)
+		return;
+
+	if (!f->last_write_fail_comp)
+		return;
+
+	idx = f->last_write_fail_idx++;
+	f->last_write_fail_comp[idx] = offset;
+}
+
 static bool should_account(struct thread_data *td)
 {
 	return ramp_time_over(td) && (td->runstate == TD_RUNNING ||
@@ -2169,6 +2184,8 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 	} else if (io_u->error) {
 error:
 		icd->error = io_u->error;
+		if (ddir == DDIR_WRITE)
+			file_log_write_fail_comp(td, f, io_u->offset);
 		io_u_log_error(td, io_u);
 	}
 	if (icd->error) {

--- a/t/verify-state.c
+++ b/t/verify-state.c
@@ -48,7 +48,7 @@ static void show(struct thread_io_list *s, size_t size)
 		s->depth = le32_to_cpu(s->depth);
 		s->nofiles = le32_to_cpu(s->nofiles);
 		s->numberio = le64_to_cpu(s->numberio);
-		s->index = le64_to_cpu(s->index);
+		s->index = le32_to_cpu(s->index);
 
 		for (i = 0; i < s->no_comps; i++) {
 			s->comps[i].fileno = le64_to_cpu(s->comps[i].fileno);

--- a/verify-state.h
+++ b/verify-state.h
@@ -35,7 +35,8 @@ struct thread_io_list {
 	uint32_t depth;
 	uint32_t nofiles;
 	uint64_t numberio;
-	uint64_t index;
+	uint32_t index;
+	uint32_t no_fails;
 	struct thread_rand_state rand;
 	uint8_t name[64];
 	struct file_comp comps[0];
@@ -66,14 +67,14 @@ extern int verify_state_should_stop(struct thread_data *, struct io_u *);
 extern void verify_assign_state(struct thread_data *, void *);
 extern int verify_state_hdr(struct verify_state_hdr *, struct thread_io_list *);
 
-static inline size_t __thread_io_list_sz(uint32_t depth, uint32_t nofiles)
+static inline size_t __thread_io_list_sz(uint64_t depth, uint32_t nofiles)
 {
 	return sizeof(struct thread_io_list) + depth * nofiles * sizeof(struct file_comp);
 }
 
 static inline size_t thread_io_list_sz(struct thread_io_list *s)
 {
-	return __thread_io_list_sz(le32_to_cpu(s->depth), le32_to_cpu(s->nofiles));
+	return __thread_io_list_sz((uint64_t)le32_to_cpu(s->depth) + le32_to_cpu(s->no_fails), le32_to_cpu(s->nofiles));
 }
 
 static inline struct thread_io_list *io_list_next(struct thread_io_list *s)

--- a/verify.c
+++ b/verify.c
@@ -1543,7 +1543,7 @@ int paste_blockoff(char *buf, unsigned int len, void *priv)
 
 static int __fill_file_completions(struct thread_data *td,
 				   struct thread_io_list *s,
-				   struct fio_file *f, unsigned int *index)
+				   struct fio_file *f, unsigned int *index, unsigned int *failindex)
 {
 	unsigned int comps;
 	int i, j;
@@ -1565,19 +1565,27 @@ static int __fill_file_completions(struct thread_data *td,
 		(*index)++;
 		j--;
 	}
-
+	if (f->last_write_fail_idx > 0) {
+		j = f->last_write_fail_idx - 1;
+		for (i = 0; i < f->last_write_fail_idx; i++) {
+			s->comps[comps + *failindex].fileno = __cpu_to_le64(f->fileno);
+			s->comps[comps + *failindex].offset = cpu_to_le64(f->last_write_fail_comp[j]);
+			(*failindex)++;
+			j--;
+		}
+	}
 	return comps;
 }
 
 static int fill_file_completions(struct thread_data *td,
-				 struct thread_io_list *s, unsigned int *index)
+				 struct thread_io_list *s, unsigned int *index, unsigned int *failindex)
 {
 	struct fio_file *f;
 	unsigned int i;
 	int comps = 0;
 
 	for_each_file(td, f, i)
-		comps += __fill_file_completions(td, s, f, index);
+		comps += __fill_file_completions(td, s, f, index, failindex);
 
 	return comps;
 }
@@ -1602,7 +1610,7 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 			continue;
 		td->stop_io = 1;
 		td->flags |= TD_F_VSTATE_SAVED;
-		depth += (td->o.iodepth * td->o.nr_files);
+		depth += (2 * td->o.iodepth * td->o.nr_files);
 		nr++;
 	} end_for_each();
 
@@ -1619,18 +1627,19 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 	next = &rep->state[0];
 	for_each_td(td) {
 		struct thread_io_list *s = next;
-		unsigned int comps, index = 0;
+		unsigned int comps, index = 0, failindex = 0;
 
 		if (save_mask != IO_LIST_ALL && (__td_index + 1) != save_mask)
 			continue;
 
-		comps = fill_file_completions(td, s, &index);
+		comps = fill_file_completions(td, s, &index, &failindex);
 
 		s->no_comps = cpu_to_le64((uint64_t) comps);
 		s->depth = cpu_to_le32((uint32_t) td->o.iodepth);
 		s->nofiles = cpu_to_le32((uint32_t) td->o.nr_files);
 		s->numberio = cpu_to_le64((uint64_t) td->io_issues[DDIR_WRITE]);
-		s->index = cpu_to_le64((uint64_t) __td_index);
+		s->index = cpu_to_le32((uint32_t) __td_index);
+		s->no_fails = cpu_to_le32((uint32_t) failindex);
 		if (td->random_state.use64) {
 			s->rand.state64.s[0] = cpu_to_le64(td->random_state.state64.s1);
 			s->rand.state64.s[1] = cpu_to_le64(td->random_state.state64.s2);
@@ -1762,6 +1771,7 @@ void verify_assign_state(struct thread_data *td, void *p)
 	s->nofiles = le32_to_cpu(s->nofiles);
 	s->numberio = le64_to_cpu(s->numberio);
 	s->rand.use64 = le64_to_cpu(s->rand.use64);
+	s->no_fails = le32_to_cpu(s->no_fails);
 
 	if (s->rand.use64) {
 		for (i = 0; i < 6; i++)
@@ -1771,7 +1781,7 @@ void verify_assign_state(struct thread_data *td, void *p)
 			s->rand.state32.s[i] = le32_to_cpu(s->rand.state32.s[i]);
 	}
 
-	for (i = 0; i < s->no_comps; i++) {
+	for (i = 0; i < s->no_comps + s->no_fails; i++) {
 		s->comps[i].fileno = le64_to_cpu(s->comps[i].fileno);
 		s->comps[i].offset = le64_to_cpu(s->comps[i].offset);
 	}
@@ -1872,10 +1882,19 @@ int verify_state_should_stop(struct thread_data *td, struct io_u *io_u)
 	 * If we're not into the window of issues - depth yet, continue. If
 	 * issue is shorter than depth, do check.
 	 */
-	if ((td->io_blocks[DDIR_READ] < s->depth ||
-	    s->numberio - td->io_blocks[DDIR_READ] > s->depth) &&
-	    s->numberio > s->depth)
-		return 0;
+	if ((td->io_blocks[DDIR_READ] < (s->depth + s->no_fails) ||
+	    s->numberio - td->io_blocks[DDIR_READ] > (s->depth + s->no_fails)) &&
+	    s->numberio > (s->depth + s->no_fails)) {
+		if ((s->numberio - td->io_blocks[DDIR_READ] < (s->depth + s->no_fails)) || (td->io_blocks[DDIR_READ] < (s->depth + s->no_fails))) {
+			for (i = 0; i < s->no_fails; i++) {
+				if (s->comps[i + s->no_comps].fileno != f->fileno)
+					continue;
+				if (io_u->verify_offset == s->comps[i + s->no_comps].offset)
+					return 1;
+			}
+		}
+		return 0;		
+	}
 
 	/*
 	 * We're in the window of having to check if this io was
@@ -1889,6 +1908,13 @@ int verify_state_should_stop(struct thread_data *td, struct io_u *io_u)
 			return 0;
 	}
 
+	for (i = 0; i < s->no_fails; i++) {
+		if (s->comps[i + s->no_comps].fileno != f->fileno)
+			continue;
+		if (io_u->verify_offset == s->comps[i + s->no_comps].offset)
+			return 1;
+	}
+	
 	/*
 	 * Not found, we have to stop
 	 */


### PR DESCRIPTION
**record the eio offsets in verify state file, and do not verify them**

there is a case always meet when run fio with verify_state_load=1,  when fio writes the first round, the disks disappear or have something wrong caused eio happend, when verify with verify_state_load=1, there is verify error that is not correct.  that is because the verify state file record every io even the io returns eio and verify them.

Signed-off-by: QianTu <qiantu98@email.com>
