### PR TITLE
helper_thread: Handle EINTR errno from select()

### DIFF
--- a/helper_thread.c
+++ b/helper_thread.c
@@ -26,6 +26,7 @@ static int sleep_accuracy_ms;
 static int timerfd = -1;
 
 enum action {
+	A_NOOP		= 0,
 	A_EXIT		= 1,
 	A_RESET		= 2,
 	A_DO_STAT	= 3,
@@ -222,6 +223,8 @@ static uint8_t wait_for_action(int fd, unsigned int timeout_ms)
 #endif
 	res = select(max(fd, timerfd) + 1, &rfds, NULL, &efds,
 		     timerfd >= 0 ? NULL : &timeout);
+	if (res == -1 && errno == EINTR)
+		return A_NOOP;
 	if (res < 0) {
 		log_err("fio: select() call in helper thread failed: %s",
 			strerror(errno));


### PR DESCRIPTION
On our ARM platform, select() could return -1 with errno EINTR fairly often, while we have almost never observed this on x86 platforms. This breaks the helper_thread loop with A_EXIT, and stops status update at stdout as well as bandwidth logging (the one enabled by `write_bw_log` and `log_avg_msec`), causing `bw` logs to look like getting cutoff since a random time for prolonged runs (~1 hour). The issue can be easily reproduced on our ARM platform even with `ioengine=null` and `filename=/dev/null` by spwaning ~30 individual fio processes with each logging `bw`, and observe the lines of all produced logs with `wc -l` once all processes finish.

Added action enum A_NOOP and a check to handle the situation as no error.

Tested on both ARM and x86 platforms with and without CONFIG_HAVE_TIMERFD_CREATE marco defined. x86 platform never reproduces the issue in any situation, and result looks good. ARM platform no longer reproduces the bug and retains the full `bw` log after the fix.
