### PR TITLE
verify: fix segfault in timedout teardown

### DIFF
--- a/verify.c
+++ b/verify.c
@@ -1676,7 +1676,13 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 		if (save_mask != IO_LIST_ALL && (__td_index + 1) != save_mask)
 			continue;
 
-		for (int i = 0; i < td->o.iodepth; i++)
+		/*
+		 * This can be called even if --verify=none &&
+		 * --verify_state_save=0 case especially when
+		 *  --trigger-timeout= is given and it's expired.  In this
+		 *  case, td->inflight_numberio == NULL, so we should check it.
+		 */
+		for (int i = 0; td->inflight_numberio && i < td->o.iodepth; i++)
 			s->inflight[i].numberio = cpu_to_le64(atomic_load_acquire(&td->inflight_numberio[i]));
 
 		s->depth = cpu_to_le32((uint32_t) td->o.iodepth);


### PR DESCRIPTION
Fix segfault happening in the teardown caseud by `--trigger-timeout=` option regardless to the --verify= and --verify_state_save= options.

`td->inflight_numberio` array is allocated in `init_inflight_logging()` only if ``td->o.verify != VERIFY_NONE && td->o.verify_state_save``. But, in case where those two options are not given and --trigger-timeout= is given and the timer is expired, verify state is attempted to be saved.  In this case, `td->inflight_numberio` array is NULL causing the segfault.  This patch fixed the segfault by checking `td->inflight_numberio` before assigning them to the state.

This can be reproduced with --trigger-timeout= where the device ignores the incoming commands by not issuig the completion simply with QEMU; dm-flakey does not support to ignore the completion itself yet.