### PR TITLE
sprandom: relax power of 2 block size requirement

### DIFF
--- a/sprandom.c
+++ b/sprandom.c
@@ -533,7 +533,7 @@ static uint64_t sprandom_physical_size(double over_provisioning, uint64_t logica
 	uint64_t size;
 
 	size = logical_sz + ceil((double)logical_sz * over_provisioning);
-	return (size + (align_bs - 1)) & ~(align_bs - 1);
+	return size - (size % align_bs);
 }
 
 /**
@@ -839,12 +839,6 @@ int sprandom_init(struct thread_data *td, struct fio_file *f)
 
 	if (!td->o.sprandom)
 		return 0;
-
-	if (!is_power_of_2(align_bs)) {
-		log_err("fio: sprandom: bs [%"PRIu64"] should be power of 2",
-			align_bs);
-		return -EINVAL;
-	}
 
 	info = calloc(1, sizeof(*info));
 	if (!info)


### PR DESCRIPTION
There is no a priori reason why the SPRandom approach cannot work with block sizes that are not a power of 2. Lift the constraint that allows only power of 2 block sizes when sprandom is enabled.

This allows sprandom to be used when devices are formatted in extended LBA (DIF) mode with 520- or 4160-byte sectors.

@steven-sprouse-sndk
@tomas-winkler-sndk 