### PR TITLE
Fix that the function libzbc_report_zones fails prematurely when encountering SOBR zone types if using libzbc engine

### DIFF
--- a/engines/libzbc.c
+++ b/engines/libzbc.c
@@ -240,6 +240,9 @@ static int libzbc_report_zones(struct thread_data *td, struct fio_file *f,
 		case ZBC_ZT_SEQUENTIAL_PREF:
 			zbdz->type = ZBD_ZONE_TYPE_SWP;
 			break;
+		case ZBC_ZT_SEQ_OR_BEF_REQ:
+			zbdz->type = ZBD_ZONE_TYPE_SOBR;
+			break;
 		default:
 			td_verror(td, errno, "invalid zone type");
 			log_err("%s: invalid type for zone at sector %llu.\n",

--- a/zbd.h
+++ b/zbd.h
@@ -44,7 +44,7 @@ struct fio_zone_info {
 	uint64_t		capacity;
 	uint32_t		writes_in_flight;
 	uint32_t		max_write_error_offset;
-	enum zbd_zone_type	type:2;
+	enum zbd_zone_type	type:4;
 	enum zbd_zone_cond	cond:4;
 	unsigned int		has_wp:1;
 	unsigned int		write:1;

--- a/zbd_types.h
+++ b/zbd_types.h
@@ -26,6 +26,7 @@ enum zbd_zone_type {
 	ZBD_ZONE_TYPE_CNV	= 0x1,	/* Conventional */
 	ZBD_ZONE_TYPE_SWR	= 0x2,	/* Sequential write required */
 	ZBD_ZONE_TYPE_SWP	= 0x3,	/* Sequential write preferred */
+	ZBD_ZONE_TYPE_SOBR	= 0x4,	/* Sequential Of Before Required */
 };
 
 /*


### PR DESCRIPTION
Support random write on SWR zones on Hybrid SMR drives with libzbc engine

Hybrid SMR has SWR zones. This change can support libzbc engine to run random write workload on SWR zones of Hybrid SMR drives. Require libzbc revision >= 6.0.

Signed-off-by: Rory Chen <rory.c.chen@seagate.com>
