### PR TITLE
verify: skip errored WRITE offset in verify

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -621,6 +621,7 @@ static enum fio_q_status io_u_submit(struct thread_data *td, struct io_u *io_u)
  */
 static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 {
+	uint64_t expected_numberio;
 	struct fio_file *f;
 	struct io_u *io_u;
 	unsigned int i;
@@ -649,6 +650,7 @@ static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 	td_set_runstate(td, TD_VERIFYING);
 
 	io_u = NULL;
+	expected_numberio = UINT64_MAX;
 	while (!td->terminate) {
 		enum fio_ddir ddir;
 		int full;
@@ -675,6 +677,33 @@ static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 			if (get_next_verify(td, io_u)) {
 				put_io_u(td, io_u);
 				break;
+			}
+
+			/*
+			 * Advance verify_state to the seed that was used when
+			 * this block was written.  Any numberio gap between
+			 * @expected_numberio and @io_u->numberio represents
+			 * skipped writes due to errors (e.g., suppressed by
+			 * --ignore_error= in online verification, or skipped
+			 *  offsets from do_dry_run in offline verification).
+			 */
+			if (td->o.verify_header_seed && !td->o.verify_pattern_bytes) {
+				uint64_t seed = 0;
+				uint64_t from;
+
+				if (io_u->numberio < expected_numberio)
+					from = io_u->numberio;
+				else
+					from = expected_numberio;
+
+				for (uint64_t n = from; n <= io_u->numberio; n++) {
+					seed = __rand(&td->verify_state);
+					if (sizeof(int) != sizeof(long *))
+						seed *= __rand(&td->verify_state);
+				}
+
+				io_u->rand_seed = seed;
+				expected_numberio = io_u->numberio + 1;
 			}
 
 			if (td_io_prep(td, io_u)) {
@@ -1207,7 +1236,26 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 					io_u->rand_seed *= __rand(&td->verify_state);
 			}
 
-			if (verify_state_should_stop(td, td->io_issues[io_u->ddir])) {
+			/*
+			 * Assign numberio for read-only verify workloads. This
+			 * handles two cases: (1) rw=[rand]write with verify_only=1
+			 * and verify_state_load=1, where we replay a prior write
+			 * run; (2) a prior job ran with rw=[rand]write and
+			 * verify_state_save=1, and the current job runs with
+			 * rw=[rand]read and verify_state_load=1 to verify those
+			 * writes.
+			 */
+			if (!td_rw(td) && !(io_u->flags & IO_U_F_VER_LIST))
+				io_u->numberio = td->io_issues[io_u->ddir];
+
+			if (verify_state_should_skip(td, io_u->numberio)) {
+				/* Account for this I/O so we move to the next sequence */
+				td->io_issues[io_u->ddir]++;
+				put_io_u(td, io_u);
+				continue;
+			}
+
+			if (verify_state_should_stop(td, io_u->numberio)) {
 				put_io_u(td, io_u);
 				break;
 			}
@@ -1380,6 +1428,8 @@ static void free_inflight_logging(struct thread_data *td)
 {
 	if (td->inflight_numberio)
 		sfree(td->inflight_numberio);
+	if (td->failed_numberio)
+		free(td->failed_numberio);
 }
 
 static void cleanup_io_u(struct thread_data *td)
@@ -1780,8 +1830,10 @@ static uint64_t do_dry_run(struct thread_data *td)
 		if (td_write(td) && io_u->ddir == DDIR_WRITE &&
 		    td->o.do_verify &&
 		    td->o.verify != VERIFY_NONE &&
-		    !td->o.experimental_verify)
-			log_io_piece(td, io_u);
+		    !td->o.experimental_verify) {
+			if (!verify_state_should_skip(td, io_u->numberio))
+				log_io_piece(td, io_u);
+		}
 
 		ret = io_u_sync_complete(td, io_u);
 		(void) ret;

--- a/fio.h
+++ b/fio.h
@@ -387,6 +387,13 @@ struct thread_data {
 	uint64_t inflight_issued;
 
 	/*
+	 * Track failed write I/Os for offline verification (to exclude from verify state)
+	 */
+	uint64_t *failed_numberio;
+	unsigned int failed_numberio_count;
+	unsigned int failed_numberio_alloc;
+
+	/*
 	 * Completions
 	 */
 	uint64_t io_blocks[DDIR_RWDIR_CNT];

--- a/io_u.c
+++ b/io_u.c
@@ -2138,6 +2138,29 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 		zbd_recover_write_error(td, io_u);
 
 	/*
+	 * Track failed write I/Os for offline verification (independent of io_u->ipo).
+	 * This works even when do_verify=0 is set.  In case of online
+	 * verification, `unlog_io_piece()` will be called so that the ipo will
+	 * be removed from the `io_hist`.
+	 */
+	if (io_u->error && ddir == DDIR_WRITE && io_u->numberio != INVALID_NUMBERIO) {
+		if (td->failed_numberio_count >= td->failed_numberio_alloc) {
+			unsigned int new_alloc;
+
+			if (td->failed_numberio_alloc)
+				new_alloc = td->failed_numberio_alloc * 2;
+			else
+				new_alloc = 16;
+			td->failed_numberio = realloc(td->failed_numberio,
+						new_alloc * sizeof(uint64_t));
+			td->failed_numberio_alloc = new_alloc;
+		}
+		td->failed_numberio[td->failed_numberio_count++] = io_u->numberio;
+		dprint(FD_VERIFY, "Recorded failed write numberio=%"PRIu64"\n",
+			io_u->numberio);
+	}
+
+	/*
 	 * Mark IO ok to verify
 	 */
 	if (io_u->ipo) {

--- a/verify-state.h
+++ b/verify-state.h
@@ -41,7 +41,7 @@ struct all_io_list {
 	struct thread_io_list state[0];
 };
 
-#define VSTATE_HDR_VERSION	0x05
+#define VSTATE_HDR_VERSION	0x06
 
 struct verify_state_hdr {
 	uint64_t version;
@@ -57,6 +57,7 @@ extern void __verify_save_state(struct all_io_list *, const char *);
 extern void verify_save_state(int mask);
 extern int verify_load_state(struct thread_data *, const char *);
 extern void verify_free_state(struct thread_data *);
+extern int verify_state_should_skip(struct thread_data *, uint64_t);
 extern int verify_state_should_stop(struct thread_data *, uint64_t);
 extern void verify_assign_state(struct thread_data *, void *);
 extern int verify_state_hdr(struct verify_state_hdr *, struct thread_io_list *);

--- a/verify.c
+++ b/verify.c
@@ -1474,11 +1474,6 @@ int get_next_verify(struct thread_data *td, struct io_u *io_u)
 		free(ipo);
 		dprint(FD_VERIFY, "get_next_verify: ret io_u %p\n", io_u);
 
-		if (!td->o.verify_pattern_bytes) {
-			io_u->rand_seed = __rand(&td->verify_state);
-			if (sizeof(int) != sizeof(long *))
-				io_u->rand_seed *= __rand(&td->verify_state);
-		}
 		return 0;
 	}
 
@@ -1655,7 +1650,8 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 			continue;
 		td->stop_io = 1;
 		td->flags |= TD_F_VSTATE_SAVED;
-		depth += (td->o.iodepth * td->o.nr_files);
+		/* Include both inflight and failed I/Os in the state */
+		depth += ((td->o.iodepth + td->failed_numberio_count) * td->o.nr_files);
 		nr++;
 	} end_for_each();
 
@@ -1672,6 +1668,7 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 	next = &rep->state[0];
 	for_each_td(td) {
 		struct thread_io_list *s = next;
+		unsigned int total_depth;
 
 		if (save_mask != IO_LIST_ALL && (__td_index + 1) != save_mask)
 			continue;
@@ -1685,7 +1682,15 @@ struct all_io_list *get_all_io_list(int save_mask, size_t *sz)
 		for (int i = 0; td->inflight_numberio && i < td->o.iodepth; i++)
 			s->inflight[i].numberio = cpu_to_le64(atomic_load_acquire(&td->inflight_numberio[i]));
 
-		s->depth = cpu_to_le32((uint32_t) td->o.iodepth);
+		/* Then, append failed I/Os to exclude them from verification */
+		for (unsigned int i = 0; i < td->failed_numberio_count; i++) {
+			s->inflight[td->o.iodepth + i].numberio = cpu_to_le64(td->failed_numberio[i]);
+			dprint(FD_VERIFY, "Added failed numberio=%"PRIu64" to inflight list\n",
+				td->failed_numberio[i]);
+		}
+
+		total_depth = td->o.iodepth + td->failed_numberio_count;
+		s->depth = cpu_to_le32((uint32_t) total_depth);
 		s->numberio = cpu_to_le64((uint64_t) atomic_load_acquire(&td->inflight_issued));
 		s->index = cpu_to_le64((uint64_t) __td_index);
 		if (td->offset_state.use64) {
@@ -1809,6 +1814,18 @@ void verify_free_state(struct thread_data *td)
 		free(td->vstate);
 }
 
+static int verify_u64_cmp(const void *a, const void *b)
+{
+	uint64_t x = *(const uint64_t *) a;
+	uint64_t y = *(const uint64_t *) b;
+
+	if (x < y)
+		return -1;
+	if (x > y)
+		return 1;
+	return 0;
+}
+
 void verify_assign_state(struct thread_data *td, void *p)
 {
 	struct thread_io_list *s = p;
@@ -1829,6 +1846,30 @@ void verify_assign_state(struct thread_data *td, void *p)
 	for (i = 0; i < s->depth; i++) {
 		s->inflight[i].numberio = le64_to_cpu(s->inflight[i].numberio);
 		dprint(FD_VERIFY, "verify_assign_state numberio=%"PRIu64", inflight[%d]=%"PRIu64"\n", s->numberio, i, s->inflight[i].numberio);
+	}
+
+	/*
+	 * Restore failed I/Os from state. Failed I/Os are appended after
+	 * the regular inflight array (starting at index td->o.iodepth).
+	 */
+	if (s->depth > td->o.iodepth) {
+		unsigned int failed_count = s->depth - td->o.iodepth;
+
+		td->failed_numberio = malloc(failed_count * sizeof(uint64_t));
+		td->failed_numberio_alloc = failed_count;
+		td->failed_numberio_count = 0;
+
+		for (i = td->o.iodepth; i < s->depth; i++) {
+			uint64_t nio = s->inflight[i].numberio;
+			if (nio != INVALID_NUMBERIO) {
+				td->failed_numberio[td->failed_numberio_count++] = nio;
+				dprint(FD_VERIFY, "Restored failed numberio=%"PRIu64"\n", nio);
+			}
+		}
+
+		/* Sort for O(log n) binary search in verify_state_should_skip() */
+		qsort(td->failed_numberio, td->failed_numberio_count,
+		      sizeof(uint64_t), verify_u64_cmp);
 	}
 
 	td->vstate = p;
@@ -1912,6 +1953,35 @@ err:
 }
 
 /*
+ * Check if this I/O should be skipped during verification (because it failed during write).
+ * failed_numberio[] is sorted in verify_assign_state(), so we use binary search: O(log n).
+ */
+int verify_state_should_skip(struct thread_data *td, uint64_t numberio)
+{
+	unsigned int lo, hi;
+
+	if (!td->failed_numberio || td->failed_numberio_count == 0)
+		return 0;
+
+	lo = 0;
+	hi = td->failed_numberio_count;
+	while (lo < hi) {
+		unsigned int mid = lo + (hi - lo) / 2;
+
+		if (td->failed_numberio[mid] == numberio) {
+			dprint(FD_VERIFY, "Skipping failed numberio=%"PRIu64"\n", numberio);
+			return 1;
+		} else if (td->failed_numberio[mid] < numberio) {
+			lo = mid + 1;
+		} else {
+			hi = mid;
+		}
+	}
+
+	return 0;
+}
+
+/*
  * Use the loaded verify state to know when to stop doing verification
  */
 int verify_state_should_stop(struct thread_data *td, uint64_t numberio)
@@ -1924,10 +1994,17 @@ int verify_state_should_stop(struct thread_data *td, uint64_t numberio)
 		return 0;
 
 	/* If the current seq is lower than the max issued seq, check to make sure
-	 * the write was not inflight.
+	 * the write was not inflight (but exclude failed writes, they should be skipped not stopped).
 	 */
 	if (numberio < s->numberio) {
-		for (i = 0; i < s->depth; i++) {
+		/* Check only the actual inflight array (first td->o.iodepth entries) */
+		int actual_depth;
+
+		if (s->depth > td->o.iodepth)
+			actual_depth = td->o.iodepth;
+		else
+			actual_depth = s->depth;
+		for (i = 0; i < actual_depth; i++) {
 			if (s->inflight[i].numberio == numberio) {
 				log_info("Stop verify because seq %"PRIu64" was an inflight write\n",
 					numberio);


### PR DESCRIPTION
``get_next_verify()`` has filled up `io_u->rand_seed` in the sequence of
the same of write phase @io_u's.  Let's say that fio faces errored @io_u
with --ignore_error= to suppress the error(expected), the @io_u will be
unlogged in ``io_completed()`` by ``unlog_io_piece()``.  This leads
``get_next_verify()`` skips to advance the random seed for the @io_u
next to the errored @io_u which is excluded.  This caused verification
error.  To fix this issue, @io_u->rand_seed should be filled up in
``do_verify()`` rather than ``get_next_verify()``.

If any WRITE command fails with error (io_u->error != 0), and it's due
to some of expected situation such as resets, those offsets should be
excluded from the verification list since we can't simply guarantee the
written data.

**Online verification**

Online verification can be done by running a single fio session with
`--do_verify=1`.  It can keep the errored numberio information with the
verify list by unlogging the errored io letting `get_next_verify()`
never retrieves the errored @io_u.

**Offline verification**

Offline verification is to keep the verify state as a file and restore
it in the verify phase, and it can be run by:
  - Run two fio sessions (one for write, one for verify) with
    (--verify_state_save=1 and --verify_state_load=1)

After saving a verify state file in WRITE phase, VERIFY phase will read
it and do `do_dry_run()` where the actual skipping the errored @io_u is
done.  Errored @io_u will not be logged into the verify history and will
not be poped by `get_next_verify()` at all in `do_verify()`.

This patch bumped up the verify header version since @inflight[] of the
verify state file has been expanded to keep the errored numberios along
with the existing inflight numberios.  No header attributes changed, but
meaning has been updated.