### PR TITLE
init: fix memory leaks reported by LeakSanitizer

### DIFF
--- a/init.c
+++ b/init.c
@@ -339,6 +339,14 @@ static void free_shm(void)
 		flow_exit();
 		fio_debug_jobp = NULL;
 		fio_warned = NULL;
+
+		for_each_td(td) {
+			if (td->io_ops)
+				free_ioengine(td);
+			free(td->files);
+			td->files = NULL;
+		} end_for_each();
+
 		free_threads_shm();
 	}
 


### PR DESCRIPTION
Free per-thread ioengine options (td->eo), duplicated option strings, and the files array in free_shm() before deallocating thread shared memory.

Fixes 3 leak sources detected by ASAN across all worker threads:
- td->eo allocated in ioengine_load()
- strdup'd strings from options_mem_dupe()
- td->files array from dup_files()