### PR TITLE
backend: remove linux/prctl.h include to fix musl conflict

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -32,7 +32,6 @@
 #include <pthread.h>
 
 #ifdef CONFIG_LINUX
-#include <linux/prctl.h>
 #include <sys/prctl.h>
 #endif
 


### PR DESCRIPTION
Building with musl fails the error `redefinition of 'struct prctl_mm_map'`. This is because musl completely redefines linux/prctl.h in sys/prctl.h. 

This commit removes the linux/prctl.h include and only keeps sys/prctl.h.

Fixes: #2096 
