### PR TITLE
blktrace: fix three bugs in merge_blktrace_iologs path

### DIFF
--- a/blktrace.c
+++ b/blktrace.c
@@ -664,7 +664,7 @@ static int read_trace(struct thread_data *td, struct blktrace_cursor *bc)
 
 read_skip:
 	/* read an io trace */
-	ret = fread(&t, 1, sizeof(t), bc->f);
+	ret = fread(t, 1, sizeof(*t), bc->f);
 	if (ferror(bc->f)) {
 		td_verror(td, errno, "read blktrace file");
 		return ret;
@@ -790,7 +790,9 @@ int merge_blktrace_iologs(struct thread_data *td)
 	}
 
 	/* set iolog file to read from the newly merged file */
+	free(td->o.read_iolog_file);
 	td->o.read_iolog_file = td->o.merge_blktrace_file;
+	td->o.merge_blktrace_file = NULL;
 	ret = 0;
 
 err_file:
@@ -799,10 +801,10 @@ err_file:
 		fclose(bcs[i].f);
 	}
 err_merge_buf:
-	free(merge_buf);
-err_out_file:
 	fflush(merge_fp);
 	fclose(merge_fp);
+err_out_file:
+	free(merge_buf);
 err_param:
 	free(bcs);
 


### PR DESCRIPTION
1. fread pointer: pass the trace buffer pointer (t) instead of pointer to the pointer (&t), and use sizeof(*t) for the struct size instead of the pointer size. This caused "iolog short read" and made the merge path dead code.
2. stdio buffer use-after-free: fclose the merged file before freeing the custom stdio buffer set up via setvbuf. Previously free(merge_buf) was called while merge_fp still referenced it.
3. double free on merge success: read_iolog_file and merge_blktrace_file are both FIO_OPT_STR_STORE char pointers. Assigning one to the other made them point to the same memory, causing a double free when options_free frees both. Fix by transferring ownership and NULLing merge_blktrace_file.

Reproduction:
  ./fio       --name=merge       --merge-blktrace-only       --merge_blktrace_file=/tmp/result.log       --merge_blktrace_scalars=100       --merge_blktrace_iters=1       --read_iolog=/data_disk6/randy/tmp/bt1.blktrace.220

  Before fix: "iolog short read" error (Bug 1 makes merge dead code).
  After Bug 1 only: "double free or corruption (fasttop)" crash during
  put_job -> options_free, caused by Bugs 2 and 3 unmasked by Bug 1 fix.

Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>

Reminders:

1. If you modify struct thread_options, also make corresponding changes in
   cconv.c and bump FIO_SERVER_VER in server.h
2. If you change the ioengine interface (hooks, flags, etc), remember to bump
   FIO_IOOPS_VERSION in ioengines.h.
