### PR TITLE
doc: indicate that metadata options are supported with io_uring

### DIFF
--- a/HOWTO.rst
+++ b/HOWTO.rst
@@ -2737,13 +2737,13 @@ with the caveat that when used on the command line, they must come after the
 	this option is specified, the option :option:`plids` or :option:`fdp_pli` will be
 	ignored.)
 
-.. option:: md_per_io_size=int : [io_uring_cmd] [xnvme]
+.. option:: md_per_io_size=int : [io_uring] [io_uring_cmd] [xnvme]
 
         Size in bytes for separate metadata buffer per IO. For io_uring_cmd
         these buffers are allocated using malloc regardless of what is set for
         :option:`iomem`. Default: 0.
 
-.. option:: pi_act=int : [io_uring_cmd] [xnvme]
+.. option:: pi_act=int : [io_uring] [io_uring_cmd] [xnvme]
 
 	Action to take when nvme namespace is formatted with protection
 	information. If this is set to 1 and namespace is formatted with
@@ -2759,7 +2759,7 @@ with the caveat that when used on the command line, they must come after the
 	it will use the default slower generator.
 	(see: https://github.com/intel/isa-l)
 
-.. option:: pi_chk=str[,str][,str] : [io_uring_cmd] [xnvme]
+.. option:: pi_chk=str[,str][,str] : [io_uring] [io_uring_cmd] [xnvme]
 
 	Controls the protection information check. This can take one or more
 	of these values. Default: none.
@@ -2772,7 +2772,7 @@ with the caveat that when used on the command line, they must come after the
 	**APPTAG**
 		Enables protection information checking of application tag field.
 
-.. option:: apptag=int : [io_uring_cmd] [xnvme]
+.. option:: apptag=int : [io_uring] [io_uring_cmd] [xnvme]
 
 	Specifies logical block application tag value, if namespace is
 	formatted to use end to end protection information. Default: 0x1234.

--- a/fio.1
+++ b/fio.1
@@ -2485,12 +2485,12 @@ multiple devices in a job, all devices of the job will be affected by the scheme
 this option is specified, the option \fBplids\fP or \fBfdp_pli\fP will be ignored.)
 .RE
 .TP
-.BI (io_uring_cmd,xnvme)md_per_io_size \fR=\fPint
+.BI (io_uring,io_uring_cmd,xnvme)md_per_io_size \fR=\fPint
 Size in bytes for separate metadata buffer per IO. For io_uring_cmd these
 buffers are allocated using malloc regardless of what is set for \fBiomem\fR.
 Default: 0.
 .TP
-.BI (io_uring_cmd,xnvme)pi_act \fR=\fPint
+.BI (io_uring,io_uring_cmd,xnvme)pi_act \fR=\fPint
 Action to take when nvme namespace is formatted with protection information.
 If this is set to 1 and namespace is formatted with metadata size equal to
 protection information size, fio won't use separate metadata buffer or extended
@@ -2504,7 +2504,7 @@ For 16 bit CRC generation fio will use isa-l if available otherwise it will
 use the default slower generator.
 (see: https://github.com/intel/isa-l)
 .TP
-.BI (io_uring_cmd,xnvme)pi_chk \fR=\fPstr[,str][,str]
+.BI (io_uring,io_uring_cmd,xnvme)pi_chk \fR=\fPstr[,str][,str]
 Controls the protection information check. This can take one or more of these
 values. Default: none.
 .RS
@@ -2521,7 +2521,7 @@ Enables protection information checking of application tag field.
 .RE
 .RE
 .TP
-.BI (io_uring_cmd,xnvme)apptag \fR=\fPint
+.BI (io_uring,io_uring_cmd,xnvme)apptag \fR=\fPint
 Specifies logical block application tag value, if namespace is formatted to use
 end to end protection information. Default: 0x1234.
 .TP


### PR DESCRIPTION
Commit f97d9f38b27b ("engines/io_uring: support r/w with metadata") added support for io_uring I/O with metadata. The existing options `md_per_io_size`, `pi_act`, `pi_chk`, and `apptag` are now supported with the `io_uring` ioengine as well as `io_uring_cmd` and `xnvme`. The `apptag_mask` option isn't allowed to be set to anything other than the default of 0xFFFF. Update the documentation to indicate that the options can be used with the `io_uring` ioengine as well.
