### PR TITLE
backend: log trim @io_u to io_hist even `do_verify=0`

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -1273,9 +1273,14 @@ static void do_io(struct thread_data *td, uint64_t *bytes_done)
 		 * Always log IO before it's issued, so we know the specific
 		 * order of it. The logged unit will track when the IO has
 		 * completed.
+		 *
+		 * Trim command is determined by @io_u loggged in the @io_hist
+		 * based on the percentage of the given value to
+		 * --trim_percentage=<%>.  Log @io_u for trim command even in
+		 * --do_verify=0 case.
 		 */
 		if (td_write(td) && io_u->ddir == DDIR_WRITE &&
-		    td->o.do_verify &&
+		    (td->o.do_verify || td->trim_verify) &&
 		    td->o.verify != VERIFY_NONE &&
 		    !td->o.experimental_verify)
 			log_io_piece(td, io_u);
@@ -1826,8 +1831,14 @@ static uint64_t do_dry_run(struct thread_data *td)
 			td->ts.total_io_u[io_u->ddir]++;
 		}
 
+		/*
+		 * Trim command is determined by @io_u loggged in the @io_hist
+		 * based on the percentage of the given value to
+		 * --trim_percentage=<%>.  Log @io_u for trim command even in
+		 * --do_verify=0 case.
+		 */
 		if (td_write(td) && io_u->ddir == DDIR_WRITE &&
-		    td->o.do_verify &&
+		    (td->o.do_verify || td->trim_verify) &&
 		    td->o.verify != VERIFY_NONE &&
 		    !td->o.experimental_verify) {
 			if (!verify_state_should_skip(td, io_u->numberio))

--- a/t/verify-trim.py
+++ b/t/verify-trim.py
@@ -47,6 +47,7 @@ VERIFY_OPT_LIST = [
     'trim_backlog_batch',
     'trim_verify_zero',
     'number_ios',
+    'do_verify',
 ]
 
 class VerifyTrimTest(FioJobCmdTest):
@@ -208,7 +209,58 @@ TEST_LIST = [
             },
         "test_class": VerifyTrimTest,
     },
-
+    {
+        # do_verify=0: trim must still be issued when trim_percentage=100
+        "test_id": 200,
+        "fio_opts": {
+            "rw": "write",
+            "do_verify": 0,
+            "trim_percentage": 100,
+            "trim_backlog": 1,
+            "number_ios": 64,
+            "output-format": "json",
+            },
+        "test_class": VerifyTrimTest,
+    },
+    {
+        # do_verify=0: trim must still be issued when trim_percentage=100
+        "test_id": 201,
+        "fio_opts": {
+            "rw": "randwrite",
+            "do_verify": 0,
+            "trim_percentage": 100,
+            "trim_backlog": 1,
+            "number_ios": 64,
+            "output-format": "json",
+            },
+        "test_class": VerifyTrimTest,
+    },
+    {
+        # do_verify=0: trim must still be issued when trim_percentage=50
+        "test_id": 202,
+        "fio_opts": {
+            "rw": "write",
+            "do_verify": 0,
+            "trim_percentage": 50,
+            "trim_backlog": 1,
+            "number_ios": 64,
+            "output-format": "json",
+            },
+        "test_class": VerifyTrimTest,
+    },
+    {
+        # do_verify=0: trim must still be issued when trim_percentage=50
+        "test_id": 203,
+        "fio_opts": {
+            "rw": "randwrite",
+            "do_verify": 0,
+            "trim_percentage": 50,
+            "trim_backlog": 1,
+            "number_ios": 64,
+            "output-format": "json",
+            },
+        "test_class": VerifyTrimTest,
+    },
 ]
 
 


### PR DESCRIPTION
--do_verify=0 blocks TRIM command being issued even if --trim_percentage=<%> is given properly.  fio generates a TRIM command based on the logged @io_u in io_hist based on the percentage value.  If --do_verify=0, @io_u will never be logged into io_hist so that TRIM @io_u will never be generated.  TRIM itself is usually useful when verify operations come together, but it should have been able to be issued regardless to the verify.  This patch enabled WRITE @io_u logging to io_hist when --do_verify=0 case.