### PR TITLE
server: fix out-of-bounds write zero-terminating received payloads

### DIFF
--- a/server.c
+++ b/server.c
@@ -443,20 +443,16 @@ struct fio_net_cmd *fio_net_recv_cmd(int sk, bool wait)
 		free(cmdret);
 		cmdret = NULL;
 	} else if (cmdret) {
-		/* zero-terminate text input */
+		/*
+		 * zero-terminate text input at the trailing byte reserved by
+		 * the allocation above, not at the length supplied by the peer
+		 */
 		if (cmdret->pdu_len) {
-			if (cmdret->opcode == FIO_NET_CMD_TEXT) {
-				struct cmd_text_pdu *__pdu = (struct cmd_text_pdu *) cmdret->payload;
-				char *buf = (char *) __pdu->buf;
-				int len = le32_to_cpu(__pdu->buf_len);
+			if (cmdret->opcode == FIO_NET_CMD_TEXT ||
+			    cmdret->opcode == FIO_NET_CMD_JOB) {
+				char *buf = (char *) cmdret->payload;
 
-				buf[len] = '\0';
-			} else if (cmdret->opcode == FIO_NET_CMD_JOB) {
-				struct cmd_job_pdu *__pdu = (struct cmd_job_pdu *) cmdret->payload;
-				char *buf = (char *) __pdu->buf;
-				int len = le32_to_cpu(__pdu->buf_len);
-
-				buf[len] = '\0';
+				buf[cmdret->pdu_len] = '\0';
 			}
 		}
 
@@ -1108,8 +1104,8 @@ static int handle_trigger_cmd(struct fio_net_cmd *cmd, struct flist_head *job_li
 	struct all_io_list *rep;
 	size_t sz;
 
-	pdu->len = le16_to_cpu(pdu->len);
-	buf[pdu->len] = '\0';
+	/* terminate at the trailing byte reserved by fio_net_recv_cmd() */
+	((char *) cmd->payload)[cmd->pdu_len] = '\0';
 
 	rep = get_all_io_list(IO_LIST_ALL, &sz);
 	if (!rep) {


### PR DESCRIPTION
out-of-bounds write, 1 byte, server side (peer-controlled TEXT, pdu_len 32):

    fio_net_recv_cmd: buf[buf_len] writes payload+16408, allocation is 33 bytes

The receive path reserves one byte for the terminator (cmd_size = sizeof(cmd) + pdu_len + 1) and then writes the nul at buf[buf_len]. buf_len comes straight off the wire and is never bounded against pdu_len, so a peer can point the write well past the payload and land a single nul anywhere on the heap.

Found reading the framing on the receive side. handle_trigger_cmd() repeats the same mistake with the 16-bit pdu->len from a VTRIGGER. The terminator belongs at the byte the allocation already set aside, so I write it there and drop the wire length entirely.

JOB and TEXT both go through fio_net_recv_cmd(), so --server and --client are both affected; VTRIGGER is server-side. Checked with a guard-page repro: the old buf[buf_len] faults, payload[pdu_len] runs clean, and a normal --client/--server job is unchanged.