### PR TITLE
verify: fix bandwidth asymmetry and memory leak with norandommap

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -2167,11 +2167,23 @@ static void io_completed(struct thread_data *td, struct io_u **io_u_ptr,
 		/*
 		 * Remove errored entry from the verification list
 		 */
-		if (io_u->error)
+		if (io_u->error) {
 			unlog_io_piece(td, io_u);
-		else {
-			atomic_store_release(&io_u->ipo->flags,
-					io_u->ipo->flags & ~IP_F_IN_FLIGHT);
+		} else {
+			unsigned int flags = io_u->ipo->flags & ~IP_F_IN_FLIGHT;
+
+			/*
+			 * If the io_piece was evicted from the verification
+			 * tree due to an overlapping write while in-flight,
+			 * it is no longer reachable for verification. Free
+			 * it here to avoid a memory leak.
+			 */
+			if (!(flags & (IP_F_ONRB | IP_F_ONLIST))) {
+				free(io_u->ipo);
+				io_u->ipo = NULL;
+			} else {
+				atomic_store_release(&io_u->ipo->flags, flags);
+			}
 		}
 	}
 

--- a/iolog.c
+++ b/iolog.c
@@ -348,6 +348,7 @@ restart:
 				ipo->offset, ipo->len);
 			td->io_hist_len--;
 			rb_erase(parent, &td->io_hist_tree);
+			__ipo->flags &= ~IP_F_ONRB;
 			remove_trim_entry(td, __ipo);
 			if (!(__ipo->flags & IP_F_IN_FLIGHT))
 				free(__ipo);

--- a/verify.c
+++ b/verify.c
@@ -1416,15 +1416,23 @@ int get_next_verify(struct thread_data *td, struct io_u *io_u)
 	if (!RB_EMPTY_ROOT(&td->io_hist_tree)) {
 		struct fio_rb_node *n = rb_first(&td->io_hist_tree);
 
-		ipo = rb_entry(n, struct io_piece, rb_node);
-
 		/*
-		 * Ensure that the associated IO has completed
+		 * Walk the tree to find the first entry whose IO has
+		 * completed. The tree is sorted by offset, so the first
+		 * entry may still be in-flight while later entries are
+		 * already done.
 		 */
-		if (atomic_load_acquire(&ipo->flags) & IP_F_IN_FLIGHT)
+		while (n) {
+			ipo = rb_entry(n, struct io_piece, rb_node);
+			if (!(atomic_load_acquire(&ipo->flags) & IP_F_IN_FLIGHT))
+				break;
+			n = rb_next(n);
+		}
+
+		if (!n)
 			goto nothing;
 
-		rb_erase(n, &td->io_hist_tree);
+		rb_erase(&ipo->rb_node, &td->io_hist_tree);
 		assert(ipo->flags & IP_F_ONRB);
 		ipo->flags &= ~IP_F_ONRB;
 	} else if (!flist_empty(&td->io_hist_list)) {


### PR DESCRIPTION
When norandommap is set, io_pieces are stored in an RB tree sorted by offset to detect overlapping writes. This caused two problems with verify_backlog:

1) get_next_verify() only checked rb_first() for a completed entry. If
   the lowest-offset IO was still in-flight, it gave up entirely even
   though completed entries existed at higher offsets. This starved
   verification reads, causing severe read/write bandwidth asymmetry
   (e.g. 40 MiB/s read vs 700 MiB/s write).

2) When an in-flight io_piece was evicted from the RB tree due to an
   overlapping write, the IP_F_ONRB flag was not cleared. On IO
   completion the entry appeared to still belong to the tree, so it was
   never freed. This caused unbounded memory growth over long runs.

Fix (1) by walking the tree with rb_next() to find the first non in-flight entry instead of giving up at rb_first().

Fix (2) by clearing IP_F_ONRB when evicting an in-flight entry from the tree, and detecting the orphaned entry on IO completion to free it.

Neither issue affects the linked-list path used when norandommap is not set, since list ordering matches submission order and no overlap eviction occurs.