### PR TITLE
parse: ignore leading minus sign when splitting options

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1041,8 +1041,15 @@ static int handle_option(const struct fio_option *o, const char *__ptr,
 			if (o->type != FIO_OPT_STR_MULTI && o->type != FIO_OPT_RANGE) {
 				if (!ptr2)
 					ptr2 = strchr(ptr, ':');
-				if (!ptr2)
+				if (!ptr2) {
 					ptr2 = strchr(ptr, '-');
+					/*
+					 * If the first character is a minus sign, it's
+					 * likely a negative number, not a delimiter.
+					 */
+					if (ptr2 == ptr)
+						ptr2 = strchr(ptr + 1, '-');
+				}
 			}
 		} else if (ptr && o->type == FIO_OPT_FLOAT_LIST) {
 			ptr2 = strchr(ptr, ':');


### PR DESCRIPTION
When parsing an option like --nice=-20, the hyphen is incorrectly identified as a delimiter, splitting the value into two parts: an empty string and '20'. This results in a bogus out-of-range warning: 'nice: max value out of range: 20 (19 max)'.

This commit fixes the issue by ignoring the hyphen if it appears as the very first character, correctly treating it as a negative sign rather than an option delimiter.

Fixes #1657
