### PR TITLE
stop experimental verify based on bytes issued, not completed

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -710,7 +710,7 @@ static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 				break;
 			}
 		} else {
-			if (td->bytes_verified + td->o.rw_min_bs > verify_bytes)
+			if (td->verify_bytes_prepped + td->o.rw_min_bs > verify_bytes)
 				break;
 
 			while ((io_u = get_io_u(td)) != NULL) {
@@ -735,6 +735,7 @@ static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 					continue;
 				} else if (io_u->ddir == DDIR_TRIM) {
 					io_u->ddir = DDIR_READ;
+					td->verify_bytes_prepped += io_u->buflen;
 					io_u_set(td, io_u, IO_U_F_TRIMMED);
 					if (td_io_prep(td, io_u)) {
 						put_io_u(td, io_u);
@@ -744,6 +745,7 @@ static void do_verify(struct thread_data *td, uint64_t verify_bytes)
 				} else if (io_u->ddir == DDIR_WRITE) {
 					io_u->ddir = DDIR_READ;
 					io_u->numberio = td->verify_read_issues;
+					td->verify_bytes_prepped += io_u->buflen;
 					td->verify_read_issues++;
 					populate_verify_io_u(td, io_u);
 					if (td_io_prep(td, io_u)) {

--- a/fio.h
+++ b/fio.h
@@ -378,6 +378,7 @@ struct thread_data {
 	uint64_t io_issues[DDIR_RWDIR_CNT];
 	uint64_t verify_read_issues;
 	uint64_t io_issue_bytes[DDIR_RWDIR_CNT];
+	uint64_t verify_bytes_prepped;
 	uint64_t loops;
 
 	/*

--- a/init.c
+++ b/init.c
@@ -933,6 +933,10 @@ static int fixup_options(struct thread_data *td)
 				o->verify_write_sequence = 0;
 		}
 
+		if (o->experimental_verify && fio_offset_overlap_risk(td) &&
+		    !fio_option_is_set(o, verify_write_sequence))
+			o->verify_write_sequence = 0;
+
 		/*
 		 * Verify header should not be offset beyond the verify
 		 * interval.

--- a/io_ddir.h
+++ b/io_ddir.h
@@ -33,7 +33,7 @@ static inline const char *io_ddir_name(enum fio_ddir ddir)
 		[DDIR_WAIT] = "wait",
 	};
 
-	if (ddir >= 0 && ddir < sizeof(name) / sizeof(name[0]) && name[ddir])
+	if (ddir >= 0 && ddir < (int)(sizeof(name) / sizeof(name[0])) && name[ddir])
 		return name[ddir];
 
 	return "invalid";

--- a/libfio.c
+++ b/libfio.c
@@ -97,6 +97,7 @@ static void reset_io_counters(struct thread_data *td, int all)
 			td->last_usec[ddir] = 0;
 		}
 		td->bytes_verified = 0;
+		td->verify_bytes_prepped = 0;
 	}
 
 	td->zone_bytes = 0;

--- a/t/verify.py
+++ b/t/verify.py
@@ -301,6 +301,19 @@ TEST_LIST_HEADER = [
         "test_class": VerifyTest,
         "success": SUCCESS_DEFAULT,
     },
+    {
+        # Basic test using experimental verify replay
+        "test_id": 2004,
+        "fio_opts": {
+            "ioengine": "libaio",
+            "filesize": "1M",
+            "bs": 4096,
+            "experimental_verify": 1,
+            "output-format": "json",
+            },
+        "test_class": VerifyTest,
+        "success": SUCCESS_DEFAULT,
+    },
 ]
 
 #
@@ -541,12 +554,7 @@ def verify_test_header(test_env, args, csum, mode, sequence):
         {sequential, random w/randommap, random w/norandommap, sequence modifiers}
     """
     for test in TEST_LIST_HEADER:
-        # experimental_verify does not work in verify_only=1 mode
-        if "_vo" in mode and 'experimental_verify' in test['fio_opts'] and \
-        test['fio_opts']['experimental_verify']:
-            test['force_skip'] = True
-        else:
-            test['force_skip'] = False
+        test['force_skip'] = False
 
         test['fio_opts']['verify'] = csum
         if csum in ('pattern', 'pattern_hdr'):


### PR DESCRIPTION
In experimental_verify mode, do_verify() decided whether to stop
issuing verify reads by comparing td->bytes_verified against
verify_bytes. bytes_verified is only updated on completion, so with a
queue depth > 1 it lags the issue side. As a result fio kept issuing
read/verify commands to fill the queue even after the last block that
was actually written had already been submitted.

Those extra reads target offsets that were never written (especially
with norandommap, where the write phase does not cover every block),
which the verify phase then reads back as zeroes, producing spurious
"bad magic header 0" verify failures.

Track a new counter, td->verify_bytes_issued, which is incremented at
issue time for both the write->read and trim->read verify conversions,
and use it for the stop condition. Reset it in reset_io_counters()
alongside bytes_verified.