### PR TITLE
json: add NULL checks after strdup and malloc calls

### DIFF
--- a/json.c
+++ b/json.c
@@ -20,6 +20,10 @@ static struct json_pair *json_create_pair(const char *name, struct json_value *v
 	struct json_pair *pair = malloc(sizeof(struct json_pair));
 	if (pair) {
 		pair->name = strdup(name);
+		if (!pair->name) {
+			free(pair);
+			return NULL;
+		}
 		pair->value = value;
 
 		value->parent_type = JSON_PARENT_TYPE_PAIR;
@@ -63,6 +67,8 @@ static char *strdup_escape(const char *str)
 	}
 
 	p = ret = malloc(strlen(str) + escapes + 1);
+	if (!ret)
+		return NULL;
 	while (*str) {
 		if (*str == '\\' || *str == '\"')
 			*p++ = '\\';


### PR DESCRIPTION
Add NULL checks for allocation failures in json.c to prevent NULL
pointer dereferences under OOM conditions.

strdup_escape() did not check the return value of malloc(), leading
to a NULL dereference in the subsequent while loop that copies and
escapes characters.

json_create_pair() did not check the return value of strdup(). When
strdup failed, the function returned a non-NULL pair with pair->name
set to NULL, which was later dereferenced in json_print_pair() via
log_buf(out, "\"%s\" : ", pair->name).

These bugs were identified while investigating #2092.
