### PR TITLE
engines/io_uring: add copyright header to bsg files

### DIFF
--- a/engines/bsg.c
+++ b/engines/bsg.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * For conditions of distribution and use, see the accompanying COPYING file.
+ *
+ */
 #include "bsg.h"
 
 int fio_bsg_uring_cmd_read_capacity(struct thread_data *td, unsigned int *bs,

--- a/engines/bsg.h
+++ b/engines/bsg.h
@@ -1,6 +1,11 @@
 /*
  * bsg structure declarations and helper functions for the
  * io_uring_cmd engine.
+ *
+ * Copyright 2026 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * For conditions of distribution and use, see the accompanying COPYING file.
+ *
  */
 
 #ifndef FIO_BSG_H


### PR DESCRIPTION
Add the copyright header to bsg.c and bsg.h, which provide BSG (Block SCSI Generic) support for the io_uring_cmd engine. The files were previously committed without a license header.