### PR TITLE
backend: exit non-zero when a job process is killed by a signal

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2449,9 +2449,12 @@ static void reap_threads(unsigned int *nr_running, uint64_t *t_rate,
 			if (WIFSIGNALED(status)) {
 				int sig = WTERMSIG(status);
 
-				if (sig != SIGTERM && sig != SIGUSR2)
+				if (sig != SIGTERM && sig != SIGUSR2) {
 					log_err("fio: pid=%d, got signal=%d\n",
 							(int) td->pid, sig);
+					if (!td->error)
+						td->error = EINTR;
+				}
 				td->sig = sig;
 				td_set_runstate(td, TD_REAPED);
 				goto reaped;


### PR DESCRIPTION
When a forked job process dies from a fatal signal (SIGABRT from a
failed assert(), SIGSEGV, OOM kill), reap_threads() logs
"fio: pid=..., got signal=..." and records td->sig, but never sets
td->error. The reaped: label only counts td->error into exit_value, so
the main fio process exits 0 and the job summary prints err= 0 for the
crashed job. The WIFEXITED branch right below does propagate a
non-zero exit status, so a worker that exits(1) fails the run while a
worker that crashes reports success, defeating any automation that
checks fio's exit code.

Mark an unexpectedly signaled worker as failed by setting td->error
(EINTR) next to the existing log_err. SIGTERM and SIGUSR2 stay
excluded, matching the log message: fio uses them for orderly
termination. Setting td->error rather than bumping exit_value directly
keeps the accounting in one place and makes the job summary show a
non-zero err for the crashed job.

Tested by sending SIGABRT to one worker of a two-job process-based
run: the crashed job now reports err= 4 and fio exits 1 (both were 0
before); a crash-free run still reports err= 0 for all jobs and
exits 0.

Fixes: https://github.com/axboe/fio/issues/2127

Signed-off-by: Vlad Tudose <tudosevt@amazon.com>
