### PR TITLE
libnfs only requires gnutls on Linux

### DIFF
--- a/configure
+++ b/configure
@@ -2400,9 +2400,9 @@ if test "$libnfs" != "no" ; then
     libnfs_cflags=$(pkg-config --cflags libnfs)
     libnfs_libs=$(pkg-config --libs libnfs)
 
-    # libnfs >= 6.0.0 requires gnutls for TLS support
+    # libnfs >= 6.0.0 on Linux requires gnutls for TLS support
     libnfs_version=$(pkg-config --modversion libnfs 2>/dev/null)
-    if test -n "$libnfs_version" ; then
+    if test -n "$libnfs_version" -a "$targetos" = "Linux" ; then
       libnfs_major=$(echo $libnfs_version | cut -d. -f1)
       if test "$libnfs_major" -ge 6 ; then
         if $(pkg-config gnutls > /dev/null 2>&1); then


### PR DESCRIPTION
Modify configure to only require gnutls on Linux when libnfs is >= 6.

The requirement for gnutls when libnfs >=6 is Linux only. See libnfs [README](https://github.com/sahlberg/libnfs/blob/master/README#L210). gnutls is not
needed on other operating systems.