### PR TITLE
fio: fix deadlock on job startup timeout / abort

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2003,6 +2003,14 @@ static void *thread_main(void *data)
 	fio_sem_up(startup_sem);
 	dprint(FD_MUTEX, "wait on td->sem\n");
 	fio_sem_down(td->sem);
+
+	/*
+	 * If we were woken up during an abort (e.g. job startup timeout),
+	 * bail out immediately instead of continuing with setup which may
+	 * block on a hung device/filesystem.
+	 */
+	if (td->terminate)
+		goto err;
 	dprint(FD_MUTEX, "done waiting on td->sem\n");
 
 	/*
@@ -2880,12 +2888,29 @@ reap:
 		if (left) {
 			log_err("fio: %d job%s failed to start\n", left,
 					left > 1 ? "s" : "");
+
+			/*
+			 * Kill threads that have not reached TD_INITIALIZED yet.
+			 */
 			for (i = 0; i < this_jobs; i++) {
 				td = map[i];
 				if (!td)
 					continue;
 				kill(td->pid, SIGTERM);
 			}
+
+			/*
+			 * Wake up threads that already reached TD_INITIALIZED and
+			 * are blocked in fio_sem_down(td->sem) (the startup barrier).
+			 * Without this they hang forever because the normal
+			 * fio_sem_up(td->sem) signal loop is skipped on abort.
+			 * They see td->terminate (set by fio_terminate_threads) and
+			 * exit cleanly via the err path.
+			 */
+			for_each_td(td) {
+				if (td->runstate == TD_INITIALIZED)
+					fio_sem_up(td->sem);
+			} end_for_each();
 			break;
 		}
 


### PR DESCRIPTION
When fio_sem_down_timeout(startup_sem, 10000) fails (e.g. FUSE daemon hangs during thread initialization), fio calls fio_terminate_threads() and sets fio_abort=true, then breaks out of the creation loop.

However, threads that already reached TD_INITIALIZED are blocked in fio_sem_down(td->sem) waiting for the main thread to signal them to start. The main thread skips the normal fio_sem_up(td->sem) loop due to the abort, and SIGTERM cannot interrupt pthread_cond_wait (glibc restarts it after signal handler). Result:

- 18+ job threads blocked forever in fio_sem_down(td->sem)
- helper thread blocks in fio_sem_down(td->rusage_sem) trying to collect rusage from those stuck threads
- main thread blocks in pthread_join(helper_thread)
- Classic A-B-C-A deadlock, process never exits

This patch fixes both sides:

1. In run_threads(): when jobs failed to start, after SIGTERM-ing uninitialized threads, also call fio_sem_up(td->sem) for all threads in TD_INITIALIZED state so they can wake from the startup barrier.

2. In thread_main(): after fio_sem_down(td->sem) returns, check td->terminate and jump to err cleanup path (which correctly signals rusage completion and sets TD_EXITED), rather than continuing setup that may block on a hung device.

Bug verified on fio 3.42; same code exists in upstream master.