### PR TITLE
Consolidate all caller of io_ops_commit() to call td_io_commit()

### DIFF
--- a/ioengines.c
+++ b/ioengines.c
@@ -304,8 +304,7 @@ int td_io_getevents(struct thread_data *td, unsigned int min, unsigned int max,
 		return 0;
 
 	if (min > 0 && td->io_ops->commit) {
-		r = td->io_ops->commit(td);
-		if (r < 0)
+		if (!td_io_commit(td))
 			goto out;
 	}
 	if (max > td->cur_depth)
@@ -502,21 +501,24 @@ int td_io_init(struct thread_data *td)
 	return ret;
 }
 
-void td_io_commit(struct thread_data *td)
+bool td_io_commit(struct thread_data *td)
 {
 	int ret;
+	bool commit_success = true;
 
 	dprint(FD_IO, "calling ->commit(), depth %d\n", td->cur_depth);
 
 	if (!td->cur_depth || !td->io_u_queued)
-		return;
+		return true;
 
 	io_u_mark_depth(td, td->io_u_queued);
 
 	if (td->io_ops->commit) {
 		ret = td->io_ops->commit(td);
-		if (ret)
+		if (ret) {
 			td_verror(td, -ret, "io commit");
+			commit_success = false;
+		}
 	}
 
 	/*
@@ -524,6 +526,7 @@ void td_io_commit(struct thread_data *td)
 	 */
 	td->io_u_in_flight += td->io_u_queued;
 	td->io_u_queued = 0;
+	return commit_success;
 }
 
 int td_io_open_file(struct thread_data *td, struct fio_file *f)

--- a/ioengines.h
+++ b/ioengines.h
@@ -141,7 +141,7 @@ extern int __must_check td_io_init(struct thread_data *);
 extern int __must_check td_io_prep(struct thread_data *, struct io_u *);
 extern enum fio_q_status __must_check td_io_queue(struct thread_data *, struct io_u *);
 extern int __must_check td_io_getevents(struct thread_data *, unsigned int, unsigned int, const struct timespec *);
-extern void td_io_commit(struct thread_data *);
+extern bool td_io_commit(struct thread_data *);
 extern int __must_check td_io_open_file(struct thread_data *, struct fio_file *);
 extern int td_io_close_file(struct thread_data *, struct fio_file *);
 extern int td_io_unlink_file(struct thread_data *, struct fio_file *);


### PR DESCRIPTION
Calling io_ops->commit() will not update io_u_in_flight and io_u_queued accordingly. If iio_u_queued is not reset properly the fio may need to make unnecessary stop to drain the queue. Which may degrade the throughput.

Fix issue: https://github.com/axboe/fio/issues/2052

Please confirm that your commit message(s) follow these guidelines:

1. First line is a commit title, a descriptive one-liner for the change
2. Empty second line
3. Commit message body that explains why the change is useful. Break lines that
   aren't something like a URL at 72-74 chars.
4. Empty line
5. Signed-off-by: Real Name <real@email.com>

Reminders:

1. If you modify struct thread_options, also make corresponding changes in
   cconv.c and bump FIO_SERVER_VER in server.h
2. If you change the ioengine interface (hooks, flags, etc), remember to bump
   FIO_IOOPS_VERSION in ioengines.h.
