### PR TITLE
verify: dump the received buffer when zero verify fails

### DIFF
--- a/verify.c
+++ b/verify.c
@@ -891,7 +891,7 @@ static int mem_is_zero_slow(const void *data, size_t length, size_t *offset)
 	return !length;
 }
 
-static int verify_zero(struct io_u *io_u)
+static int verify_zero(struct thread_data *td, struct io_u *io_u)
 {
 	size_t offset;
 
@@ -904,6 +904,15 @@ static int verify_zero(struct io_u *io_u)
 		", block offset %lu\n",
 			io_u->file->file_name, io_u->verify_offset, io_u->buflen,
 			(unsigned long) offset);
+
+	/*
+	 * Only the received data is worth dumping here, the expected
+	 * contents are all zeroes.
+	 */
+	if (td->o.verify_dump)
+		dump_buf(io_u->buf, io_u->buflen, io_u->verify_offset,
+				"received", io_u->file);
+
 	return EILSEQ;
 }
 
@@ -912,7 +921,7 @@ static int verify_trimmed_io_u(struct thread_data *td, struct io_u *io_u)
 	if (!td->o.trim_zero)
 		return 0;
 
-	return verify_zero(io_u);
+	return verify_zero(td, io_u);
 }
 
 static int verify_header(struct io_u *io_u, struct thread_data *td,
@@ -1018,7 +1027,7 @@ int verify_io_u(struct thread_data *td, struct io_u **io_u_ptr)
 		goto done;
 	} else if (io_u->flags & IO_U_F_ZEROED) {
 		dprint(FD_VERIFY, "verifying write zeroes command\n");
-		ret = verify_zero(io_u);
+		ret = verify_zero(td, io_u);
 		goto done;
 	}
 


### PR DESCRIPTION
verify_zero() logs the file, offset and length of a mismatch, but unlike the header and pattern verify paths it never writes out the data it read. That makes trim_verify_zero and write zeroes verify failures harder to analyze than a regular verify failure, where verify_dump=1 leaves the offending block on disk for inspection.

Dump the received block from verify_zero() when verify_dump is set, so that both callers benefit. There is no point in also dumping an expected buffer, as the expected contents are all zeroes.