### PR TITLE
Fixes: #2142 inconsistent type of convert_agg_kbytes_percent()'s caller

### DIFF
--- a/stat.c
+++ b/stat.c
@@ -515,7 +515,7 @@ static struct thread_stat *gen_mixed_ddir_stats_from_ts(const struct thread_stat
 }
 
 static double convert_agg_kbytes_percent(const struct group_run_stats *rs,
-					 enum fio_ddir ddir, int mean)
+					 enum fio_ddir ddir, double mean)
 {
 	double p_of_agg = 100.0;
 	if (rs && rs->agg[ddir] > 1024) {


### PR DESCRIPTION
Fixes: #2142 inconsistent type of convert_agg_kbytes_percent()'s caller and definition.

In stat.c, show_ddir_status() and add_ddir_status_json() calls convert_agg_kbytes_percent() with 'double' parameter however convert_agg_kbytes_percent() defines the parameter as 'int'.

Signed-off-by: Dennis Chang chernhungc@google.com