### PR TITLE
backend: warn before write to block devices with recognizable content

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -2625,6 +2625,149 @@ mounted:
 	return true;
 }
 
+/*
+ * Devices the user declined to overwrite at an earlier job's prompt,
+ * so later jobs and numjobs clones writing them are skipped without
+ * asking again. Only devices that actually triggered a prompt are
+ * recorded; clean devices of a declined job are not blacklisted.
+ */
+#define MAX_DECLINED_DEVS 256
+static const char *declined_devs[MAX_DECLINED_DEVS];
+static unsigned int nr_declined_devs;
+static bool non_interactive_warned;
+
+static bool dev_was_declined(const char *dev)
+{
+	unsigned int i;
+
+	for (i = 0; i < nr_declined_devs; i++)
+		if (!strcmp(declined_devs[i], dev))
+			return true;
+
+	return false;
+}
+
+static void dev_decline(const char *dev)
+{
+	if (dev_was_declined(dev))
+		return;
+
+	if (nr_declined_devs < MAX_DECLINED_DEVS)
+		declined_devs[nr_declined_devs++] = dev;
+}
+
+/*
+ * Warn before writing to block devices that hold data fio is about to
+ * endanger: a partition table, an LVM physical volume, a file system,
+ * or other recognizable content. Each job is prompted separately when
+ * running interactively; a non-interactive run only warns and continues.
+ * Returns true if this job must be skipped: either the user declined
+ * its prompt, or it writes a device declined at an earlier prompt.
+ */
+static bool check_block_dev_safety(struct thread_data *td)
+{
+	struct fio_file *f;
+	unsigned int i;
+	char buf[16];
+	bool hit = false;
+
+	if (!td->o.pre_write_safety_check)
+		return false;
+
+	if (!td_write(td) || td->o.allow_mounted_write)
+		return false;
+
+	/*
+	 * A device declined at an earlier job's prompt must not be
+	 * written by this job either, so skip it without asking again.
+	 * This also covers the numjobs clones of a declined job.
+	 */
+	for_each_file(td, f, i) {
+		if (f->filetype != FIO_TYPE_BLOCK)
+			continue;
+		if (dev_was_declined(f->file_name)) {
+			log_err("fio: job %s skipped, %s was declined earlier\n",
+				td->o.name, f->file_name);
+			return true;
+		}
+	}
+
+	/*
+	 * numjobs clones duplicate the files of the first job, their
+	 * devices were covered by its prompt (or are caught above).
+	 */
+	if (td->subjob_number)
+		return false;
+
+	for_each_file(td, f, i) {
+		const char *content;
+
+		if (f->filetype != FIO_TYPE_BLOCK)
+			continue;
+
+		content = blkdev_probe_content(f->file_name);
+		if (content) {
+			log_err("fio: job %s: %s contains %s, writing may damage it\n",
+				td->o.name, f->file_name, content);
+			hit = true;
+		}
+	}
+
+	if (!hit)
+		return false;
+
+	if (!isatty(STDIN_FILENO)) {
+		if (!non_interactive_warned) {
+			log_err("fio: non-interactive run, continuing anyway\n");
+			non_interactive_warned = true;
+		}
+		return false;
+	}
+
+	/*
+	 * Suspend the periodic status line while waiting, so its redraw
+	 * does not clobber the prompt.
+	 */
+	eta_suspend();
+
+	log_err("fio: job %s: continue anyway? (y/N): ", td->o.name);
+	fflush(f_err);
+
+	if (!fgets(buf, sizeof(buf), stdin)) {
+		eta_resume();
+		return true;
+	}
+
+	/*
+	 * Drain the rest of the line, so leftovers cannot leak into
+	 * the next job's prompt.
+	 */
+	if (!strchr(buf, '\n')) {
+		int c;
+
+		while ((c = fgetc(stdin)) != '\n' && c != EOF)
+			;
+	}
+
+	/* newline so the status line resumes on a fresh line */
+	log_err("\n");
+	eta_resume();
+
+	if (buf[0] == '\n' || buf[0] == 'y' || buf[0] == 'Y')
+		return false;
+
+	/* remember the endangered devices, so no later job writes them */
+	for_each_file(td, f, i) {
+		if (f->filetype != FIO_TYPE_BLOCK)
+			continue;
+		if (blkdev_probe_content(f->file_name))
+			dev_decline(f->file_name);
+	}
+
+	log_err("fio: job %s skipped\n", td->o.name);
+	return true;
+}
+
 static bool waitee_running(struct thread_data *me)
 {
 	const char *waitee = me->o.wait_for;
@@ -2655,7 +2798,7 @@ static bool waitee_running(struct thread_data *me)
 static void run_threads(struct sk_out *sk_out)
 {
 	struct thread_data *td;
-	unsigned int i, todo, nr_running, nr_started;
+	unsigned int i, todo, nr_running, nr_started, nr_skipped;
 	uint64_t m_rate, t_rate;
 	uint64_t spent;
 
@@ -2674,6 +2817,23 @@ static void run_threads(struct sk_out *sk_out)
 			nr_thread++;
 		else
 			nr_process++;
+	} end_for_each();
+
+	/*
+	 * Interact with the user per job before anything starts: a job
+	 * whose prompt is declined is skipped, the remaining jobs run.
+	 */
+	nr_skipped = 0;
+	for_each_td(td) {
+		if (check_block_dev_safety(td)) {
+			exit_value++;
+			td_set_runstate(td, TD_REAPED);
+			nr_skipped++;
+			if (td->o.use_thread)
+				nr_thread--;
+			else
+				nr_process--;
+		}
 	} end_for_each();
 
 	if (output_format & FIO_OUTPUT_NORMAL) {
@@ -2695,13 +2855,17 @@ static void run_threads(struct sk_out *sk_out)
 		buf_output_free(&out);
 	}
 
-	todo = thread_number;
+	todo = thread_number - nr_skipped;
 	nr_running = 0;
 	nr_started = 0;
 	m_rate = t_rate = 0;
 
 	for_each_td(td) {
 		print_status_init(td->thread_number - 1);
+
+		/* declined at the block device safety prompt */
+		if (td->runstate == TD_REAPED)
+			continue;
 
 		if (!td->o.create_serialize)
 			continue;

--- a/cconv.c
+++ b/cconv.c
@@ -104,6 +104,7 @@ int convert_thread_options_to_cpu(struct thread_options *o,
 
 	o->allow_create = le32_to_cpu(top->allow_create);
 	o->allow_mounted_write = le32_to_cpu(top->allow_mounted_write);
+	o->pre_write_safety_check = le32_to_cpu(top->pre_write_safety_check);
 	o->td_ddir = le32_to_cpu(top->td_ddir);
 	o->rw_seq = le32_to_cpu(top->rw_seq);
 	o->kb_base = le32_to_cpu(top->kb_base);
@@ -431,6 +432,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 
 	top->allow_create = cpu_to_le32(o->allow_create);
 	top->allow_mounted_write = cpu_to_le32(o->allow_mounted_write);
+	top->pre_write_safety_check = cpu_to_le32(o->pre_write_safety_check);
 	top->td_ddir = cpu_to_le32(o->td_ddir);
 	top->rw_seq = cpu_to_le32(o->rw_seq);
 	top->kb_base = cpu_to_le32(o->kb_base);

--- a/configure
+++ b/configure
@@ -711,6 +711,28 @@ fi
 print_config "zlib" "$zlib"
 
 ##########################################
+# libblkid probe, for the block device write safety check
+if test "$libblkid" != "yes" ; then
+  libblkid="no"
+fi
+if test "$esx" != "yes" ; then
+  cat > $TMPC <<EOF
+#include <blkid/blkid.h>
+int main(void)
+{
+  blkid_probe pr = blkid_new_probe();
+  blkid_free_probe(pr);
+  return 0;
+}
+EOF
+  if compile_prog "" "-lblkid" "libblkid" ; then
+    libblkid=yes
+    LIBS="-lblkid $LIBS"
+  fi
+fi
+print_config "libblkid device probing" "$libblkid"
+
+##########################################
 # fcntl(F_FULLFSYNC) support
 if test "$fcntl_sync" != "yes" ; then
   fcntl_sync="no"
@@ -3388,6 +3410,9 @@ if test "$getmntinfo" = "yes" ; then
 fi
 if test "$getmntinfo_statvfs" = "yes" ; then
   output_sym "CONFIG_GETMNTINFO_STATVFS"
+fi
+if test "$libblkid" = "yes" ; then
+  output_sym "CONFIG_BLKID"
 fi
 if test "$static_assert" = "yes" ; then
   output_sym "CONFIG_STATIC_ASSERT"

--- a/eta.c
+++ b/eta.c
@@ -719,10 +719,29 @@ struct jobs_eta *get_jobs_eta(bool force, size_t *size)
 	return je;
 }
 
+/*
+ * Suspend/resume the periodic status line, used while fio waits for
+ * user input so the redrawn status line does not clobber the prompt.
+ */
+static int eta_suppress;
+
+void eta_suspend(void)
+{
+	eta_suppress++;
+}
+
+void eta_resume(void)
+{
+	eta_suppress--;
+}
+
 void print_thread_status(void)
 {
 	struct jobs_eta *je;
 	size_t size;
+
+	if (eta_suppress)
+		return;
 
 	je = get_jobs_eta(false, &size);
 	if (je) {

--- a/fio.h
+++ b/fio.h
@@ -709,6 +709,8 @@ extern void deinitialize_fio(void);
  * ETA/status stuff
  */
 extern void print_thread_status(void);
+extern void eta_suspend(void);
+extern void eta_resume(void);
 extern void print_status_init(int);
 extern char *fio_uint_to_kmg(unsigned int val);
 

--- a/lib/mountcheck.c
+++ b/lib/mountcheck.c
@@ -83,3 +83,136 @@ int device_is_mounted(const char *dev)
 }
 
 #endif
+
+#ifdef CONFIG_BLKID
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <blkid/blkid.h>
+
+/*
+ * Human-readable descriptions for the signatures libblkid reports on a
+ * block device fio is about to overwrite. Partition table types come
+ * from the PTTYPE value, the rest from TYPE.
+ */
+static const struct content_type_description {
+	const char *type;
+	const char *desc;
+} content_type_descriptions[] = {
+	{ "LVM2_member",	"an LVM physical volume" },
+	{ "LUKS",		"a LUKS encrypted volume" },
+	{ "LUKS2",		"a LUKS encrypted volume" },
+	{ "swap",		"a swap area" },
+	{ "linux_raid_member",	"a Linux RAID member device" },
+	{ "ext2",		"an ext2 file system" },
+	{ "ext3",		"an ext3 file system" },
+	{ "ext4",		"an ext4 file system" },
+	{ "xfs",		"an XFS file system" },
+	{ "btrfs",		"a btrfs file system" },
+	{ "vfat",		"a FAT file system" },
+	{ "exfat",		"an exFAT file system" },
+	{ "ntfs",		"an NTFS file system" },
+	{ "f2fs",		"an F2FS file system" },
+	{ "jfs",		"a JFS file system" },
+	{ "reiserfs",		"a ReiserFS file system" },
+	{ "iso9660",		"an ISO 9660 file system" },
+	{ "udf",		"a UDF file system" },
+	{ "zfs",		"a ZFS file system" },
+	{ "zfs_member",	"a ZFS member device" },
+	{ "dos",		"an MBR partition table" },
+	{ "gpt",		"a GPT partition table" },
+	{ "sun",		"a Sun partition table" },
+	{ "sgi",		"an SGI partition table" },
+	{ "mac",		"a Mac partition table" },
+	{ "amiga",		"an Amiga partition table" },
+	{ "bsd",		"a BSD partition table" },
+	{ "aix",		"an AIX partition table" },
+	{ NULL, NULL },
+};
+
+/*
+ * Return a description of what libblkid identified on the device, given
+ * the TYPE it reported (a libblkid TYPE or PTTYPE value). Unknown types
+ * still deserve a warning; report the raw type.
+ */
+static const char *describe_content_type(const char *type)
+{
+	const struct content_type_description *t;
+	static char desc[128];
+
+	for (t = content_type_descriptions; t->type; t++)
+		if (!strcmp(t->type, type))
+			return t->desc;
+
+	snprintf(desc, sizeof(desc), "data of type '%s'", type);
+	return desc;
+}
+
+/*
+ * Return what the block device 'dev' contains, judging from libblkid's
+ * superblock and partition-table signatures, or NULL if nothing is
+ * recognized. A partition table is reported in preference to a file
+ * system. Every probing failure counts as "nothing detected", so this
+ * check can never make fio fail on its own. Read-only probe, it cannot
+ * alter the device.
+ */
+const char *blkdev_probe_content(const char *dev)
+{
+	struct stat st;
+	const char *found = NULL;
+	blkid_probe pr;
+	int fd;
+
+	if (stat(dev, &st) || !S_ISBLK(st.st_mode))
+		return NULL;
+
+	/*
+	 * The device is opened read-only on a separate descriptor, so
+	 * probing does not disturb the descriptors fio writes to;
+	 * O_NONBLOCK guards against the file having changed type in
+	 * the race after the stat call above.
+	 */
+	fd = open(dev, O_RDONLY | O_NONBLOCK);
+	if (fd < 0)
+		return NULL;
+
+	if (fstat(fd, &st) == 0 && S_ISBLK(st.st_mode)) {
+		pr = blkid_new_probe();
+		if (pr) {
+			/*
+			 * Probing results are compared against plain
+			 * integers rather than the BLKID_PROBE_* macros,
+			 * as those macros are only available in
+			 * libblkid >= 2.39 while the return-value
+			 * semantics (0 = signature found) are stable
+			 * across versions.
+			 */
+			if (blkid_probe_set_device(pr, fd, 0, 0) == 0 &&
+			    blkid_probe_enable_superblocks(pr, 1) == 0 &&
+			    blkid_probe_enable_partitions(pr, 1) == 0 &&
+			    blkid_do_safeprobe(pr) == 0) {
+				const char *type = NULL;
+
+				if (blkid_probe_lookup_value(pr, "PTTYPE", &type, NULL) != 0)
+					blkid_probe_lookup_value(pr, "TYPE", &type, NULL);
+				found = type ? describe_content_type(type) : NULL;
+			}
+
+			/* the probe does not own fd, closing it is safe */
+			blkid_free_probe(pr);
+		}
+	}
+
+	close(fd);
+	return found;
+}
+
+#else /* no libblkid: fail open */
+
+const char *blkdev_probe_content(const char *dev)
+{
+	return NULL;
+}
+
+#endif

--- a/lib/mountcheck.h
+++ b/lib/mountcheck.h
@@ -2,5 +2,6 @@
 #define FIO_MOUNT_CHECK_H
 
 extern int device_is_mounted(const char *);
+extern const char *blkdev_probe_content(const char *dev);
 
 #endif

--- a/options.c
+++ b/options.c
@@ -4658,6 +4658,16 @@ struct fio_option fio_options[FIO_MAX_OPTS] = {
 		.group	= FIO_OPT_G_FILENAME,
 	},
 	{
+		.name	= "pre_write_safety_check",
+		.alias	= "pre-write-safety-check",
+		.lname	= "Pre-write safety check",
+		.type	= FIO_OPT_STR_SET,
+		.off1	= offsetof(struct thread_options, pre_write_safety_check),
+		.help	= "Check block devices for recognizable content before writing and prompt for confirmation per job",
+		.category = FIO_OPT_C_FILE,
+		.group	= FIO_OPT_G_FILENAME,
+	},
+	{
 		.name	= "pre_read",
 		.lname	= "Pre-read files",
 		.type	= FIO_OPT_BOOL,

--- a/thread_options.h
+++ b/thread_options.h
@@ -398,6 +398,7 @@ struct thread_options {
 
 	unsigned int allow_create;
 	unsigned int allow_mounted_write;
+	unsigned int pre_write_safety_check;
 
 	/* Parameters that affect zonemode=zbd */
 	unsigned int read_beyond_wp;
@@ -737,6 +738,7 @@ struct thread_options_pack {
 
 	uint32_t allow_create;
 	uint32_t allow_mounted_write;
+	uint32_t pre_write_safety_check;
 
 	uint32_t zone_mode;
 	int32_t max_open_zones;


### PR DESCRIPTION
backend: warn before write to block devices with recognizable content

fio currently protects against writing to mounted devices, but a job
file pointing at the wrong raw block device silently destroys whatever
lives there: partition tables, unmounted file systems, LVM physical
volumes, LUKS headers, swap areas and RAID members are all overwritten
without warning. A single filename typo can be catastrophic and there
is no way to get the data back.
This PR adds a write safety check for block devices, built on libblkid:
- Before any file is opened, every block device targeted by a write
  job is probed (read-only, separate fd) 
- If recognizable content is found, fio reports what the device
  contains in human-readable form, e.g.
  `fio: /dev/sda contains a GPT partition table, writing may damage it`.
- Interactive runs prompt `continue anyway? (y/N)` and abort before
  touching any file unless the user confirms.
- Non-interactive runs (stdin is not a tty, e.g. scripts, CI) only
  warn and continue, so existing automation is unaffected.

Signed-off-by: wengjianing <1528193783@qq.com>
